### PR TITLE
Pin production heavy model and Vulkan backend (#2)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -6,13 +6,16 @@ SUPABASE_SERVICE_KEY=<your-service-role-key>
 # Lemonade Server (local LLM inference)
 # Default port: 13305 (Ubuntu snap install). Native installs use 8000.
 LEMONADE_BASE_URL=http://localhost:13305/api/v1
-# Recommended for Strix Halo with Lemonade >=10.2.0:
+# Backend: vulkan is ~20% faster than rocm on Strix Halo Radeon 8060S (tested 2026-05-06)
+LEMONADE_LLAMACPP=vulkan
+# Recommended for Strix Halo with Lemonade >=10.3.0:
 #   light  — fast smoke tests, hello-world, single-tool calls
-#   heavy  — digest generation; MoE keeps generation fast at higher quality
+#   heavy  — digest generation; ~90s per 500-800 word digest on Vulkan
 # Use the short Lemonade model id (not the upstream HF checkpoint).
-# Pull each with `lemonade-server pull <id>` before first run.
+# Pull each with `lemonade pull <id>` before first run.
 LEMONADE_LIGHT_MODEL=Gemma-4-E4B-it-GGUF
-LEMONADE_HEAVY_MODEL=Gemma-4-26B-A4B-it-GGUF
+# Heavy tier — Gemma 4 31B dense · Q4_K_M · 18.3 GB · 10.7 tok/s on Vulkan
+LEMONADE_HEAVY_MODEL=Gemma-4-31B-it-GGUF
 
 # Local storage paths (relative to project root)
 SQLITE_PATH=data/news_digest.db

--- a/src/news_digest/config.py
+++ b/src/news_digest/config.py
@@ -20,6 +20,7 @@ class Settings(BaseSettings):
 
     # Lemonade Server
     lemonade_base_url: str = "http://localhost:8000/api/v1"
+    lemonade_llamacpp: Literal["vulkan", "rocm", "cpu"] = "vulkan"
     lemonade_light_model: str = ""
     lemonade_heavy_model: str = ""
 


### PR DESCRIPTION
## Summary

Pin `Gemma-4-31B-it-GGUF` on `llamacpp:vulkan` as the production heavy model, validated by live inference testing on Strix Halo (2026-05-06).

## Sample output (T2)

> OpenAI has officially released GPT-5, and it is looking like a major leap forward. The company claims the new model offers a forty percent boost in reasoning benchmarks over GPT-4o. It also features a massive one-million-token context window and a new deep research mode that can autonomously scour the web and synthesize sources before providing an answer. Pricing starts at thirty dollars per million input tokens for the standard tier.

Quality: OK — no markdown artifacts, length within target, claims match input, audio-ready prose.

## Residency check (T3)

- Call 1: ~45 s (includes model load from disk)
- Call 2: ~43 s (model resident in VRAM)
- Resident: yes, ratio ~0.96 (second call faster — model warm)

## Backend comparison (Vulkan vs ROCm)

| Backend | Build | Steady tok/s (tiny model) |
|---------|-------|--------------------------|
| llamacpp:vulkan | b8940 | ~430 |
| llamacpp:rocm | b8935 | ~333 |

Vulkan wins by ~20%. ROCm was installed for comparison; Vulkan is the snap default and faster on Radeon 8060S.

## Model spec

- ID: `Gemma-4-31B-it-GGUF` (unsloth/gemma-4-31B-it-GGUF:Q4_K_M)
- Params: 31B dense
- Quantization: Q4_K_M
- File size: 18.3 GB (17.5 GB model + 1.1 GB mmproj)
- Context: 32k tokens
- Generation speed: 10.7 tok/s on Vulkan
- Digest latency: ~90s per 500-800 word output

Note: Gemma 4 31B is a thinking/reasoning model — it emits chain-of-thought in `reasoning_content` and final answer in `content`. Callers must read `content`, not `message.content` directly.

## Test plan

- [x] Sample output reviewed — audio-friendly prose, no markdown
- [x] Back-to-back latency check — model stays resident
- [x] Vulkan vs ROCm comparison done
- [x] `.env.example` updated with backend + model + spec comment
- [x] `config.py` lemonade_llamacpp field typed as Literal["vulkan","rocm","cpu"]
- [x] CI green

Closes #2