### PR TITLE
Implement fetch_rss scraping tool

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,12 +17,13 @@ dependencies = [
     # amd-gaia 0.17.2 (commit 2026-04-17); migration to PyPI ==0.17.5 + hashes deferred (see docs/gaia-audit.md §2.2.c).
     "amd-gaia @ git+https://github.com/amd/gaia.git@da5ba458dc1b147927e4c1e8b7c40c473e0da41e",
     "httpx>=0.27.0",
-    "feedparser>=6.0.0",
+    "feedparser>=6.0.10,<7.0.0",
     "beautifulsoup4>=4.12.0",
     "lxml>=5.0.0",
     "pydantic-settings>=2.0",
     "apscheduler>=3.10.0,<4.0.0",
     "supabase>=2.0,<3.0",
+    "tenacity>=8.2.3",
 ]
 
 [project.optional-dependencies]

--- a/src/news_digest/tools/scraping.py
+++ b/src/news_digest/tools/scraping.py
@@ -5,60 +5,405 @@ The LLM decides which tools to call and in what order.
 
 Tools:
     fetch_rss: Parse an RSS/Atom feed and return recent entries.
-    fetch_html: Scrape an HTML page with an optional CSS selector.
-    parse_article: Extract full article content from a URL.
+    fetch_html: (issue #6) Scrape an HTML page with an optional CSS selector.
+    parse_article: (issue #6) Extract full article content from a URL.
+
+Note on architecture deviation: docs/architecture.md §5.3 shows @retry directly
+on the public tool function. We deviate intentionally: @retry lives on the
+private _fetch_feed_bytes helper, and fetch_rss owns error translation. This
+preserves the @tool contract that the LLM always receives a list[dict] and the
+function never raises.
 """
 
-# TODO: Phase 1 implementation
-#
-# import time
-# from datetime import datetime, timezone
-#
-# import feedparser
-# import httpx
-# from bs4 import BeautifulSoup
-# from gaia.agents.base.tools import tool
-#
-# # Polite delay between requests to the same domain
-# _RATE_LIMIT_SECONDS = 1.5
-#
-#
-# @tool
-# def fetch_rss(url: str, max_entries: int = 20) -> dict:
-#     """Fetch and parse an RSS or Atom feed.
-#
-#     Args:
-#         url: The feed URL.
-#         max_entries: Maximum number of entries to return.
-#
-#     Returns:
-#         Dict with 'entries' list of {title, url, published, summary}.
-#     """
-#     ...
-#
-#
-# @tool
-# def fetch_html(url: str, selector: str | None = None) -> dict:
-#     """Fetch an HTML page and extract text content.
-#
-#     Args:
-#         url: The page URL.
-#         selector: Optional CSS selector to narrow extraction.
-#
-#     Returns:
-#         Dict with 'content' (extracted text) and 'title'.
-#     """
-#     ...
-#
-#
-# @tool
-# def parse_article(url: str) -> dict:
-#     """Extract full article content from a URL.
-#
-#     Args:
-#         url: The article URL.
-#
-#     Returns:
-#         Dict with 'title', 'body', 'published_date', 'url'.
-#     """
-#     ...
+import hashlib
+import ipaddress
+import socket
+import sys
+import threading
+import time
+from calendar import timegm
+from collections import Counter
+from datetime import UTC, datetime, timedelta
+from urllib.parse import urljoin, urlparse
+
+import feedparser
+import httpx
+from gaia.agents.base.tools import tool
+from tenacity import (
+    retry,
+    retry_if_not_exception_type,
+    stop_after_attempt,
+    wait_exponential,
+)
+
+from news_digest.logging import log
+
+
+class _NonRetryableHttp(Exception):
+    """Raised by _fetch_feed_bytes on non-retryable HTTP outcomes (4xx except 429,
+    or response-too-large 413). Tenacity is configured to skip retry on this.
+    fetch_rss catches it, logs once, and returns []."""
+
+    def __init__(self, status_code: int, url: str) -> None:
+        self.status_code = status_code
+        self.url = url
+        super().__init__(f"HTTP {status_code} for {url}")
+
+
+class _UnsafeUrl(Exception):
+    """Raised by _validate_url when a URL fails SSRF defenses."""
+
+    def __init__(self, reason: str, url: str) -> None:
+        self.reason = reason
+        self.url = url
+        super().__init__(f"unsafe url: {reason} ({url})")
+
+
+_RATE_LIMIT_SECONDS: float = 1.5
+_CONNECT_TIMEOUT: float = 3.0
+_TOTAL_TIMEOUT: float = 15.0
+_MAX_RESPONSE_BYTES: int = 10 * 1024 * 1024  # 10 MB
+_USER_AGENT: str = (
+    "news-digest-agent/0.1 (+https://github.com/itomek/itomek-news-digest-agent)"
+)
+
+# Per-domain last-fetch timestamp (monotonic clock). See _throttle.
+_last_fetch: dict[str, float] = {}
+_rate_lock: threading.Lock = threading.Lock()
+
+# Captures the last exception from a retried fetch so fetch_rss can log it
+# with class+message after retry exhaustion. Keyed by id(callable) to avoid
+# any future collision if multiple retried helpers exist.
+_last_retry_error: dict[int, BaseException] = {}
+
+
+def _now_utc() -> datetime:
+    """Indirection seam so tests can monkeypatch time without touching `datetime`."""
+    return datetime.now(UTC)
+
+
+def _make_client(transport: httpx.BaseTransport | None = None) -> httpx.Client:
+    return httpx.Client(
+        transport=transport,
+        timeout=httpx.Timeout(_TOTAL_TIMEOUT, connect=_CONNECT_TIMEOUT),
+        follow_redirects=True,
+        headers={"User-Agent": _USER_AGENT},
+    )
+
+
+def _domain_of(url: str) -> str:
+    return urlparse(url).netloc.lower()
+
+
+def _validate_url(url: str) -> None:
+    """SSRF defense. Raises _UnsafeUrl on dangerous targets.
+
+    Rejects: non-http(s) schemes; hosts that resolve to loopback / RFC1918 /
+    link-local / multicast / reserved IPs.
+    """
+    parsed = urlparse(url)
+    if parsed.scheme not in ("http", "https"):
+        raise _UnsafeUrl(f"scheme {parsed.scheme!r} not in (http, https)", url)
+    host = parsed.hostname
+    if not host:
+        raise _UnsafeUrl("no hostname", url)
+    try:
+        infos = socket.getaddrinfo(host, None)
+    except socket.gaierror as exc:
+        raise _UnsafeUrl(f"DNS error: {exc}", url) from exc
+    for info in infos:
+        ip = ipaddress.ip_address(info[4][0])
+        if (
+            ip.is_loopback
+            or ip.is_private
+            or ip.is_link_local
+            or ip.is_multicast
+            or ip.is_reserved
+        ):
+            raise _UnsafeUrl(f"host resolves to {ip} (blocked)", url)
+
+
+def _throttle(domain: str) -> None:
+    # Reserve slot inside lock, then sleep outside — holding the lock during
+    # sleep would serialize all domains. Slot is reserved pessimistically.
+    now = time.monotonic()
+    with _rate_lock:
+        last = _last_fetch.get(domain, 0.0)
+        elapsed = now - last
+        wait = _RATE_LIMIT_SECONDS - elapsed
+        if wait > 0:
+            _last_fetch[domain] = now + wait  # reserve slot
+        else:
+            _last_fetch[domain] = now
+            wait = 0.0
+    if wait > 0:
+        time.sleep(wait)
+
+
+def _content_hash(title: str, url: str) -> str:
+    # Null byte separator: title and url cannot contain it, so no
+    # ("foo|", "bar") vs ("foo", "|bar") collision risk.
+    # NOTE: no URL canonicalization. analysis.deduplicate_articles must
+    # regenerate hashes if it adds canonicalization later.
+    return hashlib.sha256(f"{title}\x00{url}".encode()).hexdigest()
+
+
+def _to_utc_dt(parsed) -> datetime | None:
+    """Convert feedparser's struct_time (UTC) to aware datetime.
+    Returns None on failure."""
+    if parsed is None:
+        return None
+    try:
+        return datetime.fromtimestamp(timegm(parsed), tz=UTC)
+    except (OverflowError, OSError, ValueError, TypeError):
+        return None
+
+
+def _resolve_url(feed_link: str, entry_link: str) -> str | None:
+    if not entry_link:
+        return None
+    resolved = urljoin(feed_link or "", entry_link)
+    if not resolved.startswith(("http://", "https://")):
+        return None
+    return resolved
+
+
+def _parse_entry(entry, feed_link: str, cutoff: datetime) -> dict | str:
+    """Parse one feedparser entry.
+
+    Returns the entry dict on success, or a short reason string on drop
+    ('no_url', 'no_date', 'too_old', 'parse_error'). fetch_rss aggregates the
+    reasons into the success log's metadata for diagnosability.
+    """
+    try:
+        title = (getattr(entry, "title", "") or "").strip()
+        raw_link = getattr(entry, "link", "") or ""
+        url = _resolve_url(feed_link, raw_link)
+        if not url:
+            return "no_url"
+        # Atom: prefer <published>, fall back to <updated>. Real-world Atom feeds
+        # often emit only <updated>; without the fallback they silently drop.
+        parsed_time = getattr(entry, "published_parsed", None) or getattr(
+            entry, "updated_parsed", None
+        )
+        published_dt = _to_utc_dt(parsed_time)
+        if published_dt is None:
+            return "no_date"
+        if published_dt < cutoff:
+            return "too_old"
+        summary = getattr(entry, "summary", "") or ""
+        return {
+            "title": title,
+            "url": url,
+            "published": published_dt.isoformat(),
+            "summary": summary,
+            "content_hash": _content_hash(title, url),
+        }
+    except Exception:
+        return "parse_error"
+
+
+def _retry_returns_none(retry_state) -> None:
+    """Tenacity callback after retries are exhausted. Captures the final
+    exception (so fetch_rss can log it with class+message) and returns None
+    as a sentinel."""
+    exc = retry_state.outcome.exception() if retry_state.outcome else None
+    if exc is not None:
+        _last_retry_error[id(_fetch_feed_bytes)] = exc
+    return None
+
+
+@retry(
+    stop=stop_after_attempt(3),
+    wait=wait_exponential(multiplier=1, max=30),
+    reraise=False,
+    retry=retry_if_not_exception_type(_NonRetryableHttp),
+    retry_error_callback=_retry_returns_none,
+)
+def _fetch_feed_bytes(
+    url: str, transport: httpx.BaseTransport | None = None
+) -> bytes | None:
+    """Fetch raw feed bytes with a hard 10 MB body cap.
+
+    NEVER calls log() — all logging happens in fetch_rss to preserve the
+    one-failure-one-log invariant.
+
+    Raises:
+        _NonRetryableHttp(status_code, url): on 4xx EXCEPT 429, or 413 when
+            the body exceeds the size cap. Tenacity skips retry; fetch_rss
+            catches and logs once.
+        httpx.HTTPStatusError / httpx.RequestError: on 5xx / network / 429 —
+            tenacity retries.
+
+    Returns:
+        bytes on success.
+        None when retries are exhausted (via retry_error_callback).
+    """
+    with _make_client(transport=transport) as client:
+        with client.stream("GET", url) as resp:
+            # 4xx EXCEPT 429: deterministic, no retry.
+            if 400 <= resp.status_code < 500 and resp.status_code != 429:
+                # Close the stream BEFORE raising so __exit__ doesn't try to
+                # drain a (potentially large) body on the way out.
+                resp.close()
+                raise _NonRetryableHttp(resp.status_code, url)
+            # 429 and 5xx fall through to raise_for_status → tenacity retries.
+            resp.raise_for_status()
+            buf = bytearray()
+            for chunk in resp.iter_bytes(8192):
+                buf.extend(chunk)
+                if len(buf) > _MAX_RESPONSE_BYTES:
+                    # Same: close before raising so we don't waste bandwidth
+                    # draining the rest of an oversized payload.
+                    resp.close()
+                    raise _NonRetryableHttp(413, url)
+            return bytes(buf)
+
+
+@tool
+def fetch_rss(url: str, since_hours: int = 24) -> list[dict]:
+    """Fetch and parse an RSS or Atom feed, returning recent entries.
+
+    Args:
+        url: The feed URL.
+        since_hours: Only return entries published within this window.
+            Use 24 for daily topics, 168 for weekly.
+
+    Returns:
+        List of dicts, each with keys: title, url, published (ISO-8601 UTC),
+        summary, content_hash. Entries without parseable dates are dropped.
+        Returns [] on fetch failure (the call never raises).
+    """
+    t_start = time.monotonic()
+
+    # Input validation — short-circuit before any network or sleep.
+    if since_hours <= 0:
+        log(
+            "warn",
+            "scrape",
+            f"fetch_rss: since_hours={since_hours} <= 0",
+            metadata={"url": url, "since_hours": since_hours},
+        )
+        return []
+
+    try:
+        _validate_url(url)
+    except _UnsafeUrl as exc:
+        log(
+            "warn",
+            "scrape",
+            f"fetch_rss: blocked unsafe url: {exc.reason}",
+            metadata={"url": url, "reason": exc.reason},
+        )
+        return []
+
+    domain = _domain_of(url)
+    _throttle(domain)
+
+    raw: bytes | None
+    try:
+        raw = _fetch_feed_bytes(url)
+    except _NonRetryableHttp as exc:
+        log(
+            "warn",
+            "scrape",
+            f"fetch_rss: HTTP {exc.status_code} (non-retryable) for {url}",
+            metadata={"url": url, "status_code": exc.status_code},
+        )
+        return []
+    except Exception as exc:
+        log(
+            "warn",
+            "scrape",
+            f"fetch_rss: unexpected error for {url}: {exc.__class__.__name__}: {exc}",
+            metadata={
+                "url": url,
+                "error_class": exc.__class__.__name__,
+                "error": str(exc),
+            },
+        )
+        return []
+
+    if raw is None:
+        # Retries exhausted on 5xx / transport / timeout / 429.
+        last = _last_retry_error.pop(id(_fetch_feed_bytes), None)
+        log(
+            "warn",
+            "scrape",
+            f"fetch_rss: all retries exhausted for {url}: "
+            f"{last.__class__.__name__ if last else 'unknown'}",
+            metadata={
+                "url": url,
+                "since_hours": since_hours,
+                "last_error_class": last.__class__.__name__ if last else None,
+                "last_error": str(last) if last else None,
+            },
+        )
+        return []
+
+    feed = feedparser.parse(raw)
+    bozo = bool(getattr(feed, "bozo", 0))
+    if bozo:
+        log(
+            "warn",
+            "scrape",
+            f"fetch_rss: bozo feed at {url}",
+            metadata={
+                "url": url,
+                "bozo_exception": str(getattr(feed, "bozo_exception", "")),
+                "entries_parsed": len(getattr(feed, "entries", []) or []),
+            },
+        )
+
+    cutoff = _now_utc() - timedelta(hours=since_hours)
+    feed_obj = getattr(feed, "feed", None)
+    feed_link = (
+        feed_obj.get("link", "") if feed_obj and hasattr(feed_obj, "get") else ""
+    ) or url
+
+    entries: list[dict] = []
+    drops: Counter[str] = Counter()
+    for raw_entry in getattr(feed, "entries", []) or []:
+        result = _parse_entry(raw_entry, feed_link, cutoff)
+        if isinstance(result, dict):
+            entries.append(result)
+        else:
+            drops[result] += 1
+
+    log(
+        "info",
+        "scrape",
+        f"fetch_rss: returned {len(entries)} entries from {url}",
+        metadata={
+            "url": url,
+            "since_hours": since_hours,
+            "entries_seen": len(getattr(feed, "entries", []) or []),
+            "entries_returned": len(entries),
+            "dropped_no_url": drops.get("no_url", 0),
+            "dropped_no_date": drops.get("no_date", 0),
+            "dropped_too_old": drops.get("too_old", 0),
+            "dropped_parse_error": drops.get("parse_error", 0),
+            "bozo": bozo,
+            "duration_ms": round((time.monotonic() - t_start) * 1000),
+        },
+    )
+    return entries
+
+
+# Debug entry point: `python -m news_digest.tools.scraping <url> [since_hours]`.
+# Bypasses scheduler / agent so a developer can validate one feed in seconds.
+if __name__ == "__main__":  # pragma: no cover
+    import json
+
+    if len(sys.argv) < 2:
+        print(
+            "usage: python -m news_digest.tools.scraping <url> [since_hours]",
+            file=sys.stderr,
+        )
+        sys.exit(2)
+    _url = sys.argv[1]
+    _since = int(sys.argv[2]) if len(sys.argv) > 2 else 24
+    _result = fetch_rss(_url, since_hours=_since)
+    print(
+        json.dumps({"count": len(_result), "entries": _result}, indent=2, default=str)
+    )

--- a/tests/test_scraping_tools.py
+++ b/tests/test_scraping_tools.py
@@ -1,0 +1,650 @@
+"""Tests for src/news_digest/tools/scraping.py — issue #5."""
+
+import hashlib
+from collections import Counter
+from datetime import UTC, datetime, timedelta
+from email.utils import format_datetime
+from unittest.mock import MagicMock
+
+import httpx
+import pytest
+
+from news_digest.tools import scraping
+from news_digest.tools.scraping import _validate_url as _REAL_VALIDATE_URL
+from news_digest.tools.scraping import fetch_rss
+
+# ---------------------------------------------------------------------------
+# Synthetic feed XML helpers
+# ---------------------------------------------------------------------------
+
+
+def _rss(items_xml: str, channel_link: str = "https://example.com") -> str:
+    return f"""<?xml version="1.0"?>
+<rss version="2.0"><channel>
+  <title>Test Feed</title>
+  <link>{channel_link}</link>
+  {items_xml}
+</channel></rss>"""
+
+
+def _item(
+    title: str = "Article",
+    link: str = "https://example.com/1",
+    pub_date: str = "Wed, 06 May 2026 11:00:00 +0000",
+    description: str = "Summary",
+    include_pubdate: bool = True,
+) -> str:
+    pubdate_xml = f"<pubDate>{pub_date}</pubDate>" if include_pubdate else ""
+    return f"""<item>
+        <title>{title}</title>
+        <link>{link}</link>
+        {pubdate_xml}
+        <description>{description}</description>
+    </item>"""
+
+
+# An RSS feed with a single fresh entry (just past the fixed_now clock).
+RSS_2_0_WELL_FORMED = _rss(
+    _item(
+        title="Article One",
+        link="https://example.com/1",
+        pub_date="Wed, 06 May 2026 11:00:00 +0000",
+        description="Summary one",
+    )
+    + _item(
+        title="Article Two",
+        link="https://example.com/2",
+        pub_date="Wed, 06 May 2026 10:00:00 +0000",
+        description="Summary two",
+    )
+)
+
+
+ATOM_FEED = """<?xml version="1.0" encoding="utf-8"?>
+<feed xmlns="http://www.w3.org/2005/Atom">
+  <title>Test Atom</title>
+  <link href="https://example.com"/>
+  <entry>
+    <title>Atom Article</title>
+    <link href="https://example.com/atom-1"/>
+    <published>2026-05-06T11:00:00Z</published>
+    <summary>Atom summary</summary>
+  </entry>
+</feed>"""
+
+
+# Atom entry with only <updated>, no <published>.
+ATOM_UPDATED_ONLY = """<?xml version="1.0" encoding="utf-8"?>
+<feed xmlns="http://www.w3.org/2005/Atom">
+  <title>Updated Only</title>
+  <link href="https://example.com"/>
+  <entry>
+    <title>Updated Article</title>
+    <link href="https://example.com/u-1"/>
+    <updated>2026-05-06T11:00:00Z</updated>
+    <summary>Updated summary</summary>
+  </entry>
+</feed>"""
+
+
+# Bozo: unclosed tag in second item.
+RSS_BOZO_MALFORMED = """<?xml version="1.0"?>
+<rss version="2.0"><channel>
+  <title>Bozo Feed</title>
+  <link>https://example.com</link>
+  <item>
+    <title>Valid</title>
+    <link>https://example.com/valid</link>
+    <pubDate>Wed, 06 May 2026 11:00:00 +0000</pubDate>
+    <description>ok</description>
+  </item>
+  <item>
+    <title>Broken
+    <link>https://example.com/broken
+    <pubDate>not-a-date</pubDate>
+    <description>oops</description>
+  </item>
+</channel></rss>"""
+
+
+# ---------------------------------------------------------------------------
+# Autouse fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(autouse=True)
+def mock_log(valid_env, monkeypatch):
+    """Patch scraping.log on every test so no test ever exercises the real log()
+    (which would attempt Supabase + create a real SQLite fallback file)."""
+    log_mock = MagicMock()
+    monkeypatch.setattr(scraping, "log", log_mock)
+    return log_mock
+
+
+@pytest.fixture(autouse=True)
+def _reset_rate_limit_state():
+    scraping._last_fetch.clear()
+    scraping._last_retry_error.clear()
+    yield
+    scraping._last_fetch.clear()
+    scraping._last_retry_error.clear()
+
+
+@pytest.fixture(autouse=True)
+def no_real_sleep(monkeypatch):
+    """No test ever blocks on real sleep. Tests that care assert via .call_args."""
+    sleep_mock = MagicMock()
+    monkeypatch.setattr(scraping.time, "sleep", sleep_mock)
+    return sleep_mock
+
+
+@pytest.fixture(autouse=True)
+def _allow_loopback_in_tests(monkeypatch):
+    """SSRF defense rejects loopback / private IPs. Tests use https://example.com
+    which IANA reserves; on most networks DNS resolution may map to a public IP,
+    but on isolated CI the resolver may fail. Bypass by no-op'ing _validate_url
+    EXCEPT in tests that explicitly test it. Those tests will re-monkeypatch
+    back to the real implementation."""
+    monkeypatch.setattr(scraping, "_validate_url", lambda url: None)
+
+
+@pytest.fixture
+def fixed_now(monkeypatch):
+    """Freeze _now_utc() at 2026-05-06 12:00 UTC."""
+    fixed = datetime(2026, 5, 6, 12, 0, tzinfo=UTC)
+    monkeypatch.setattr(scraping, "_now_utc", lambda: fixed)
+    return fixed
+
+
+# ---------------------------------------------------------------------------
+# Helper: inject MockTransport via _make_client
+# ---------------------------------------------------------------------------
+
+
+def _patch_make_client(monkeypatch, handler):
+    """Replace scraping._make_client with one wired to a MockTransport built from
+    handler. The lambda accepts **_kwargs so any production-side `transport=` kwarg
+    is ignored — we always inject the mock. Production code never passes a
+    transport at runtime; if a future refactor does, the lambda will TypeError
+    loudly (a safety property, not a bug)."""
+    mock_transport = httpx.MockTransport(handler)
+    real_make = (
+        scraping._make_client.__wrapped__
+        if hasattr(scraping._make_client, "__wrapped__")
+        else scraping._make_client
+    )
+
+    def _patched(**_kwargs):
+        return real_make(transport=mock_transport)
+
+    monkeypatch.setattr(scraping, "_make_client", _patched)
+    return mock_transport
+
+
+def _ok_response(content: bytes) -> httpx.Response:
+    return httpx.Response(200, content=content)
+
+
+def _rss_response(xml_str: str) -> httpx.Response:
+    return _ok_response(xml_str.encode("utf-8"))
+
+
+# ===========================================================================
+# T2 — Happy path + tool decorator
+# ===========================================================================
+
+
+def test_fetch_rss_returns_normalized_entries_for_well_formed_feed(
+    monkeypatch, fixed_now
+):
+    _patch_make_client(monkeypatch, lambda req: _rss_response(RSS_2_0_WELL_FORMED))
+
+    result = fetch_rss("https://example.com/feed.xml", since_hours=24)
+
+    assert isinstance(result, list)
+    assert len(result) == 2
+    for entry in result:
+        assert set(entry.keys()) == {
+            "title",
+            "url",
+            "published",
+            "summary",
+            "content_hash",
+        }
+        # published must round-trip through fromisoformat
+        assert isinstance(datetime.fromisoformat(entry["published"]), datetime)
+        # content_hash is sha256 hex of (title + \x00 + url)
+        expected = hashlib.sha256(
+            f"{entry['title']}\x00{entry['url']}".encode()
+        ).hexdigest()
+        assert entry["content_hash"] == expected
+        assert len(entry["content_hash"]) == 64
+        assert all(c in "0123456789abcdef" for c in entry["content_hash"])
+
+
+def test_fetch_rss_logs_scrape_info_with_count_and_duration(
+    monkeypatch, fixed_now, mock_log
+):
+    _patch_make_client(monkeypatch, lambda req: _rss_response(RSS_2_0_WELL_FORMED))
+
+    fetch_rss("https://example.com/feed.xml", since_hours=24)
+
+    info_calls = [c for c in mock_log.call_args_list if c.args[0] == "info"]
+    assert len(info_calls) == 1
+    args = info_calls[0].args
+    assert args[1] == "scrape"
+    md = info_calls[0].kwargs["metadata"]
+    assert md["url"] == "https://example.com/feed.xml"
+    assert md["since_hours"] == 24
+    assert md["entries_returned"] == 2
+    assert md["entries_seen"] == 2
+    assert md["dropped_no_url"] == 0
+    assert md["dropped_no_date"] == 0
+    assert md["dropped_too_old"] == 0
+    assert md["dropped_parse_error"] == 0
+    assert md["bozo"] is False
+    assert isinstance(md["duration_ms"], int)
+
+
+def test_fetch_rss_is_callable_and_doc_preserved():
+    assert callable(fetch_rss)
+    assert fetch_rss.__doc__ is not None
+    # GAIA's @tool must preserve the docstring contents the schema generator parses
+    assert "since_hours" in fetch_rss.__doc__
+    assert "Args:" in fetch_rss.__doc__
+    assert "Returns:" in fetch_rss.__doc__
+
+
+# ===========================================================================
+# T3 — Date filtering, drop unparseable dates, Atom-updated fallback, URLs
+# ===========================================================================
+
+
+def _aged_feed(fixed_dt: datetime) -> str:
+    """Build a feed with three pubDates: 5h, 30h, 200h before fixed_dt."""
+    return _rss(
+        _item(
+            title="Five Hours",
+            link="https://example.com/5h",
+            pub_date=format_datetime(fixed_dt - timedelta(hours=5)),
+        )
+        + _item(
+            title="Thirty Hours",
+            link="https://example.com/30h",
+            pub_date=format_datetime(fixed_dt - timedelta(hours=30)),
+        )
+        + _item(
+            title="Two Hundred Hours",
+            link="https://example.com/200h",
+            pub_date=format_datetime(fixed_dt - timedelta(hours=200)),
+        )
+    )
+
+
+@pytest.mark.parametrize(
+    "since_hours,expected_count,expected_too_old",
+    [(24, 1, 2), (168, 2, 1)],
+)
+def test_fetch_rss_filters_by_since_hours(
+    monkeypatch, fixed_now, mock_log, since_hours, expected_count, expected_too_old
+):
+    feed_xml = _aged_feed(fixed_now)
+    _patch_make_client(monkeypatch, lambda req: _rss_response(feed_xml))
+
+    result = fetch_rss("https://example.com/feed.xml", since_hours=since_hours)
+
+    assert len(result) == expected_count
+    info_call = [c for c in mock_log.call_args_list if c.args[0] == "info"][0]
+    assert info_call.kwargs["metadata"]["dropped_too_old"] == expected_too_old
+
+
+def test_fetch_rss_drops_entries_without_pubdate(monkeypatch, fixed_now, mock_log):
+    feed_xml = _rss(
+        _item(title="Has Date", link="https://example.com/1")
+        + _item(title="No Date", link="https://example.com/2", include_pubdate=False)
+        + _item(title="Bad Date", link="https://example.com/3", pub_date="not-a-date")
+    )
+    _patch_make_client(monkeypatch, lambda req: _rss_response(feed_xml))
+
+    result = fetch_rss("https://example.com/feed.xml", since_hours=24)
+
+    assert len(result) == 1
+    assert result[0]["title"] == "Has Date"
+    info_call = [c for c in mock_log.call_args_list if c.args[0] == "info"][0]
+    assert info_call.kwargs["metadata"]["dropped_no_date"] == 2
+
+
+def test_fetch_rss_uses_updated_when_published_absent(monkeypatch, fixed_now):
+    """Atom 1.0 entries with only <updated> (no <published>) MUST be retained.
+    Without the updated_parsed fallback, every such entry is silently dropped —
+    regression-guarded for simonwillison.net etc."""
+    _patch_make_client(monkeypatch, lambda req: _rss_response(ATOM_UPDATED_ONLY))
+
+    result = fetch_rss("https://example.com/atom.xml", since_hours=24)
+
+    assert len(result) == 1
+    assert result[0]["title"] == "Updated Article"
+    assert result[0]["url"] == "https://example.com/u-1"
+    assert datetime.fromisoformat(result[0]["published"]) == datetime(
+        2026, 5, 6, 11, 0, tzinfo=UTC
+    )
+
+
+@pytest.mark.parametrize("bad_link", ["javascript:void(0)", "mailto:x@y.z"])
+def test_fetch_rss_drops_entries_with_unresolvable_url(
+    monkeypatch, fixed_now, mock_log, bad_link
+):
+    feed_xml = _rss(
+        _item(title="Good", link="https://example.com/ok")
+        + _item(title="Bad", link=bad_link)
+    )
+    _patch_make_client(monkeypatch, lambda req: _rss_response(feed_xml))
+
+    result = fetch_rss("https://example.com/feed.xml", since_hours=24)
+
+    assert len(result) == 1
+    assert result[0]["title"] == "Good"
+    info_call = [c for c in mock_log.call_args_list if c.args[0] == "info"][0]
+    assert info_call.kwargs["metadata"]["dropped_no_url"] == 1
+
+
+def test_fetch_rss_resolves_relative_entry_urls_against_channel_link(
+    monkeypatch, fixed_now
+):
+    feed_xml = _rss(
+        _item(title="Rel", link="/posts/foo"),
+        channel_link="https://blog.example.com",
+    )
+    _patch_make_client(monkeypatch, lambda req: _rss_response(feed_xml))
+
+    result = fetch_rss("https://blog.example.com/feed.xml", since_hours=24)
+
+    assert len(result) == 1
+    assert result[0]["url"] == "https://blog.example.com/posts/foo"
+
+
+def test_fetch_rss_parses_atom_1_0_feed(monkeypatch, fixed_now):
+    _patch_make_client(monkeypatch, lambda req: _rss_response(ATOM_FEED))
+
+    result = fetch_rss("https://example.com/atom.xml", since_hours=24)
+
+    assert len(result) == 1
+    assert set(result[0].keys()) == {
+        "title",
+        "url",
+        "published",
+        "summary",
+        "content_hash",
+    }
+    assert result[0]["url"] == "https://example.com/atom-1"
+
+
+# ===========================================================================
+# T4 — Rate limit
+# ===========================================================================
+
+
+def test_fetch_rss_throttles_repeat_calls_to_same_domain(
+    monkeypatch, fixed_now, no_real_sleep
+):
+    _patch_make_client(monkeypatch, lambda req: _rss_response(RSS_2_0_WELL_FORMED))
+
+    fetch_rss("https://example.com/feed-a.xml", since_hours=24)
+    fetch_rss("https://example.com/feed-b.xml", since_hours=24)
+
+    # The second call should have triggered at least one positive-duration sleep.
+    assert no_real_sleep.call_count >= 1
+    first_arg = no_real_sleep.call_args_list[0].args[0]
+    assert first_arg > 0  # NOT pytest.approx(1.5) — would be flaky on loaded CI
+
+
+def test_fetch_rss_does_not_throttle_across_domains(
+    monkeypatch, fixed_now, no_real_sleep
+):
+    _patch_make_client(monkeypatch, lambda req: _rss_response(RSS_2_0_WELL_FORMED))
+
+    fetch_rss("https://a.example.com/feed.xml", since_hours=24)
+    fetch_rss("https://b.example.com/feed.xml", since_hours=24)
+
+    # Distinct domains must not throttle. _throttle skips time.sleep when
+    # wait <= 0, so call_count MUST be 0 — sharper than a tolerant `or`
+    # branch that would vacuously pass.
+    assert no_real_sleep.call_count == 0
+
+
+# ===========================================================================
+# T5 — Retry / 4xx / SSRF / size-cap / never-raises
+# ===========================================================================
+
+
+def _counting_handler(responses):
+    """Build an httpx handler that returns the i-th item in `responses` per call.
+    `responses[i]` may be a callable raising httpx exceptions, or a Response."""
+    state = {"i": 0}
+
+    def handler(request):
+        i = state["i"]
+        state["i"] += 1
+        item = responses[min(i, len(responses) - 1)]
+        if callable(item):
+            return item(request)
+        return item
+
+    handler.calls = state
+    return handler
+
+
+def test_fetch_rss_retries_on_connect_error_then_succeeds(monkeypatch, fixed_now):
+    def raise_connect(req):
+        raise httpx.ConnectError("boom")
+
+    handler = _counting_handler(
+        [raise_connect, raise_connect, _rss_response(RSS_2_0_WELL_FORMED)]
+    )
+    _patch_make_client(monkeypatch, handler)
+
+    result = fetch_rss("https://example.com/feed.xml", since_hours=24)
+
+    assert handler.calls["i"] == 3
+    assert len(result) == 2
+
+
+def test_fetch_rss_returns_empty_after_retry_exhaustion(
+    monkeypatch, fixed_now, mock_log
+):
+    def raise_connect(req):
+        raise httpx.ConnectError("dns failed")
+
+    handler = _counting_handler([raise_connect])
+    _patch_make_client(monkeypatch, handler)
+
+    result = fetch_rss("https://example.com/feed.xml", since_hours=24)
+
+    assert result == []
+    # exactly one warn record for the failure (no preceding info)
+    warn_calls = [c for c in mock_log.call_args_list if c.args[0] == "warn"]
+    assert len(warn_calls) == 1
+    md = warn_calls[0].kwargs["metadata"]
+    assert (
+        "all retries exhausted" in warn_calls[0].args[2]
+        or "exhausted" in warn_calls[0].args[2]
+    )
+    assert md["last_error_class"] == "ConnectError"
+    # info log should NOT fire when we returned early
+    info_calls = [c for c in mock_log.call_args_list if c.args[0] == "info"]
+    assert info_calls == []
+
+
+@pytest.mark.parametrize("status_code", [400, 401, 403, 404, 410, 451])
+def test_fetch_rss_does_not_retry_on_4xx(monkeypatch, fixed_now, mock_log, status_code):
+    handler = _counting_handler([httpx.Response(status_code)])
+    _patch_make_client(monkeypatch, handler)
+
+    result = fetch_rss("https://example.com/feed.xml", since_hours=24)
+
+    assert result == []
+    assert handler.calls["i"] == 1  # no retry
+    # exactly one log call (regression test for the original double-log bug)
+    assert mock_log.call_count == 1
+    args = mock_log.call_args.args
+    md = mock_log.call_args.kwargs["metadata"]
+    assert args[0] == "warn"
+    assert args[1] == "scrape"
+    assert md["status_code"] == status_code
+
+
+def test_fetch_rss_RETRIES_on_429(monkeypatch, fixed_now):
+    """429 means 'back off and retry'. Must NOT be in the non-retryable set."""
+    handler = _counting_handler(
+        [httpx.Response(429), httpx.Response(429), _rss_response(RSS_2_0_WELL_FORMED)]
+    )
+    _patch_make_client(monkeypatch, handler)
+
+    result = fetch_rss("https://example.com/feed.xml", since_hours=24)
+
+    assert handler.calls["i"] == 3
+    assert len(result) == 2
+
+
+@pytest.mark.parametrize(
+    "url",
+    [
+        "http://127.0.0.1/feed",
+        "http://localhost/feed",
+        "http://169.254.169.254/",
+        "http://10.0.0.1/feed",
+        "http://192.168.1.1/feed",
+    ],
+)
+def test_fetch_rss_rejects_loopback_url(monkeypatch, mock_log, url):
+    """SSRF defense: blocked IPs must not reach the network."""
+    # Restore the real validator (autouse fixture replaces it with a no-op).
+    monkeypatch.setattr(scraping, "_validate_url", _REAL_VALIDATE_URL)
+    handler = _counting_handler([_rss_response(RSS_2_0_WELL_FORMED)])
+    _patch_make_client(monkeypatch, handler)
+
+    result = fetch_rss(url, since_hours=24)
+
+    assert result == []
+    assert handler.calls["i"] == 0  # never reached the network
+    warn_calls = [c for c in mock_log.call_args_list if c.args[0] == "warn"]
+    assert len(warn_calls) == 1
+    msg = warn_calls[0].args[2]
+    assert "blocked" in msg.lower() or "unsafe" in msg.lower()
+
+
+@pytest.mark.parametrize(
+    "url",
+    ["ftp://example.com/feed", "file:///etc/passwd", "gopher://example.com/"],
+)
+def test_fetch_rss_rejects_non_http_scheme(monkeypatch, mock_log, url):
+    monkeypatch.setattr(scraping, "_validate_url", _REAL_VALIDATE_URL)
+
+    result = fetch_rss(url, since_hours=24)
+
+    assert result == []
+    warn_calls = [c for c in mock_log.call_args_list if c.args[0] == "warn"]
+    assert len(warn_calls) == 1
+
+
+def test_fetch_rss_rejects_oversized_response(monkeypatch, fixed_now, mock_log):
+    """Response body > 10 MB raises _NonRetryableHttp(413), no retry."""
+    big = b"x" * (11 * 1024 * 1024)
+    handler = _counting_handler([httpx.Response(200, content=big)])
+    _patch_make_client(monkeypatch, handler)
+
+    result = fetch_rss("https://example.com/feed.xml", since_hours=24)
+
+    assert result == []
+    assert handler.calls["i"] == 1  # 413 is non-retryable
+    md = mock_log.call_args.kwargs["metadata"]
+    assert md["status_code"] == 413
+
+
+def test_fetch_rss_processes_valid_entries_when_bozo(monkeypatch, fixed_now, mock_log):
+    _patch_make_client(monkeypatch, lambda req: _rss_response(RSS_BOZO_MALFORMED))
+
+    result = fetch_rss("https://example.com/feed.xml", since_hours=24)
+
+    assert len(result) == 1
+    # Pin call counts by level — guards against a future refactor that turns
+    # the bozo log into a per-entry warn (volume bug).
+    levels = Counter(call.args[0] for call in mock_log.call_args_list)
+    assert levels == Counter({"warn": 1, "info": 1})
+    info_call = [c for c in mock_log.call_args_list if c.args[0] == "info"][0]
+    assert info_call.kwargs["metadata"]["bozo"] is True
+
+
+def test_fetch_rss_never_raises_when_helper_throws_unexpected(
+    monkeypatch, fixed_now, mock_log
+):
+    def boom(*_a, **_kw):
+        raise RuntimeError("boom")
+
+    monkeypatch.setattr(scraping, "_fetch_feed_bytes", boom)
+
+    result = fetch_rss("https://example.com/feed.xml", since_hours=24)
+
+    assert result == []
+    warn_calls = [c for c in mock_log.call_args_list if c.args[0] == "warn"]
+    assert len(warn_calls) == 1
+    md = warn_calls[0].kwargs["metadata"]
+    assert md["error_class"] == "RuntimeError"
+
+
+@pytest.mark.parametrize("since_hours", [0, -1, -24])
+def test_fetch_rss_returns_empty_for_non_positive_since_hours(
+    monkeypatch, fixed_now, mock_log, since_hours
+):
+    """No HTTP call should happen for invalid since_hours."""
+    handler = _counting_handler([_rss_response(RSS_2_0_WELL_FORMED)])
+    _patch_make_client(monkeypatch, handler)
+
+    result = fetch_rss("https://example.com/feed.xml", since_hours=since_hours)
+
+    assert result == []
+    assert handler.calls["i"] == 0  # never reached the network
+    warn_calls = [c for c in mock_log.call_args_list if c.args[0] == "warn"]
+    assert len(warn_calls) == 1
+
+
+# ===========================================================================
+# T9 — Integration tests (excluded from CI)
+# ===========================================================================
+
+
+def _assert_real_feed_contract(result):
+    """Contract-only assertions — no URL-specific values, so feed schema drift
+    between writing and merging doesn't break the test for unrelated reasons."""
+    assert isinstance(result, list)
+    assert len(result) >= 1
+    for entry in result:
+        assert set(entry.keys()) == {
+            "title",
+            "url",
+            "published",
+            "summary",
+            "content_hash",
+        }
+        assert entry["url"].startswith("https://")
+        # published parses
+        datetime.fromisoformat(entry["published"])
+        assert len(entry["content_hash"]) == 64
+
+
+@pytest.mark.integration
+def test_fetch_rss_against_huggingface():
+    result = fetch_rss("https://huggingface.co/blog/feed.xml", since_hours=720)
+    _assert_real_feed_contract(result)
+
+
+@pytest.mark.integration
+def test_fetch_rss_against_arxiv():
+    result = fetch_rss("https://export.arxiv.org/rss/cs.AI", since_hours=720)
+    _assert_real_feed_contract(result)
+
+
+@pytest.mark.integration
+def test_fetch_rss_against_simon_willison():
+    result = fetch_rss("https://simonwillison.net/atom/everything/", since_hours=720)
+    _assert_real_feed_contract(result)


### PR DESCRIPTION
Closes #5

## Summary

- Adds `fetch_rss(url, since_hours=24) -> list[dict]` as a GAIA `@tool` in `src/news_digest/tools/scraping.py`
- Streams feed bytes via `httpx` (with 10 MB cap) and parses with `feedparser`; `tenacity` provides 3-attempt exponential-backoff retry
- SSRF defense: `_validate_url` rejects non-http(s) schemes and RFC1918/loopback/link-local/multicast IPs via `socket.getaddrinfo` + `ipaddress`
- Per-domain rate limiter (1.5 s polite delay) using `threading.Lock` held only during dict r/w, sleeping outside the lock
- 429 is retried; 4xx (except 429) and 413 oversized responses are non-retryable and logged exactly once (single-log invariant)
- Atom `<updated>` fallback when `<published>` is absent; drop-reason counters (`no_url`, `no_date`, `too_old`, `parse_error`) in success log metadata

## Test plan

- [x] 36 unit tests (`pytest -m "not integration"`) — all pass, ruff clean
- [x] 3 integration tests run locally: HuggingFace blog feed, arxiv cs.AI, simonwillison.net Atom feed — all pass (verifies Atom `<updated>` fallback against a real feed)
- [ ] CI (`pytest -m "not integration"`) must stay green on merge

> **Note:** Registration of `fetch_rss` in `agent.py`'s `_register_tools()` is deferred to #9 (E2E manual run).