### PR TITLE
Implement fetch_html and parse_article scraping tools (#6)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,6 +20,7 @@ dependencies = [
     "feedparser>=6.0.10,<7.0.0",
     "beautifulsoup4>=4.12.0",
     "lxml>=5.0.0",
+    "trafilatura>=1.12.0",
     "pydantic-settings>=2.0",
     "apscheduler>=3.10.0,<4.0.0",
     "supabase>=2.0,<3.0",

--- a/src/news_digest/tools/scraping.py
+++ b/src/news_digest/tools/scraping.py
@@ -5,18 +5,19 @@ The LLM decides which tools to call and in what order.
 
 Tools:
     fetch_rss: Parse an RSS/Atom feed and return recent entries.
-    fetch_html: (issue #6) Scrape an HTML page with an optional CSS selector.
-    parse_article: (issue #6) Extract full article content from a URL.
+    fetch_html: Scrape an HTML page, optionally scoped to a CSS selector.
+    parse_article: Extract the main article body + metadata from a URL.
 
 Note on architecture deviation: docs/architecture.md §5.3 shows @retry directly
 on the public tool function. We deviate intentionally: @retry lives on the
-private _fetch_feed_bytes helper, and fetch_rss owns error translation. This
+private _fetch_bytes helper, and fetch_rss owns error translation. This
 preserves the @tool contract that the LLM always receives a list[dict] and the
 function never raises.
 """
 
 import hashlib
 import ipaddress
+import json
 import socket
 import sys
 import threading
@@ -28,6 +29,8 @@ from urllib.parse import urljoin, urlparse
 
 import feedparser
 import httpx
+import trafilatura
+from bs4 import BeautifulSoup
 from gaia.agents.base.tools import tool
 from tenacity import (
     retry,
@@ -40,7 +43,7 @@ from news_digest.logging import log
 
 
 class _NonRetryableHttp(Exception):
-    """Raised by _fetch_feed_bytes on non-retryable HTTP outcomes (4xx except 429,
+    """Raised by _fetch_bytes on non-retryable HTTP outcomes (4xx except 429,
     or response-too-large 413). Tenacity is configured to skip retry on this.
     fetch_rss catches it, logs once, and returns []."""
 
@@ -71,8 +74,8 @@ _USER_AGENT: str = (
 _last_fetch: dict[str, float] = {}
 _rate_lock: threading.Lock = threading.Lock()
 
-# Captures the last exception from a retried fetch so fetch_rss can log it
-# with class+message after retry exhaustion. Keyed by id(callable) to avoid
+# Captures the last exception from a retried fetch so the calling tool can log
+# it with class+message after retry exhaustion. Keyed by id(callable) to avoid
 # any future collision if multiple retried helpers exist.
 _last_retry_error: dict[int, BaseException] = {}
 
@@ -209,7 +212,7 @@ def _retry_returns_none(retry_state) -> None:
     as a sentinel."""
     exc = retry_state.outcome.exception() if retry_state.outcome else None
     if exc is not None:
-        _last_retry_error[id(_fetch_feed_bytes)] = exc
+        _last_retry_error[id(_fetch_bytes)] = exc
     return None
 
 
@@ -220,12 +223,13 @@ def _retry_returns_none(retry_state) -> None:
     retry=retry_if_not_exception_type(_NonRetryableHttp),
     retry_error_callback=_retry_returns_none,
 )
-def _fetch_feed_bytes(
+def _fetch_bytes(
     url: str, transport: httpx.BaseTransport | None = None
 ) -> bytes | None:
-    """Fetch raw feed bytes with a hard 10 MB body cap.
+    """Fetch raw response bytes with a hard 10 MB body cap.
 
-    NEVER calls log() — all logging happens in fetch_rss to preserve the
+    Source-agnostic: shared by fetch_rss (feeds) and the HTML tools (pages).
+    NEVER calls log() — all logging happens in the calling tool to preserve the
     one-failure-one-log invariant.
 
     Raises:
@@ -302,7 +306,7 @@ def fetch_rss(url: str, since_hours: int = 24) -> list[dict]:
 
     raw: bytes | None
     try:
-        raw = _fetch_feed_bytes(url)
+        raw = _fetch_bytes(url)
     except _NonRetryableHttp as exc:
         log(
             "warn",
@@ -326,7 +330,7 @@ def fetch_rss(url: str, since_hours: int = 24) -> list[dict]:
 
     if raw is None:
         # Retries exhausted on 5xx / transport / timeout / 429.
-        last = _last_retry_error.pop(id(_fetch_feed_bytes), None)
+        last = _last_retry_error.pop(id(_fetch_bytes), None)
         log(
             "warn",
             "scrape",
@@ -390,20 +394,268 @@ def fetch_rss(url: str, since_hours: int = 24) -> list[dict]:
     return entries
 
 
-# Debug entry point: `python -m news_digest.tools.scraping <url> [since_hours]`.
-# Bypasses scheduler / agent so a developer can validate one feed in seconds.
-if __name__ == "__main__":  # pragma: no cover
-    import json
+def _fetch_document(url: str, tool: str) -> tuple[bytes | None, str | None]:
+    """Validate, throttle, and fetch raw bytes for an HTML tool.
 
-    if len(sys.argv) < 2:
+    Shared by fetch_html and parse_article. Returns (raw_bytes, None) on success,
+    or (None, reason) on failure — logging exactly one warn per failure, mirroring
+    fetch_rss's error translation but yielding a reason string instead of [].
+    """
+    try:
+        _validate_url(url)
+    except _UnsafeUrl as exc:
+        log(
+            "warn",
+            "scrape",
+            f"{tool}: blocked unsafe url: {exc.reason}",
+            metadata={"url": url, "reason": exc.reason},
+        )
+        return None, f"unsafe_url: {exc.reason}"
+
+    _throttle(_domain_of(url))
+
+    try:
+        raw = _fetch_bytes(url)
+    except _NonRetryableHttp as exc:
+        log(
+            "warn",
+            "scrape",
+            f"{tool}: HTTP {exc.status_code} (non-retryable) for {url}",
+            metadata={"url": url, "status_code": exc.status_code},
+        )
+        return None, f"http_{exc.status_code}"
+    except Exception as exc:
+        log(
+            "warn",
+            "scrape",
+            f"{tool}: unexpected error for {url}: {exc.__class__.__name__}: {exc}",
+            metadata={
+                "url": url,
+                "error_class": exc.__class__.__name__,
+                "error": str(exc),
+            },
+        )
+        return None, f"error: {exc.__class__.__name__}"
+
+    if raw is None:
+        last = _last_retry_error.pop(id(_fetch_bytes), None)
+        log(
+            "warn",
+            "scrape",
+            f"{tool}: all retries exhausted for {url}: "
+            f"{last.__class__.__name__ if last else 'unknown'}",
+            metadata={
+                "url": url,
+                "last_error_class": last.__class__.__name__ if last else None,
+                "last_error": str(last) if last else None,
+            },
+        )
+        return None, "retries_exhausted"
+
+    return raw, None
+
+
+@tool
+def fetch_html(url: str, selector: str | None = None) -> dict:
+    """Fetch an HTML page and extract its text and links.
+
+    Args:
+        url: The page URL (http or https).
+        selector: Optional CSS selector. When given, only matching elements are
+            used for text and link extraction; when omitted, the whole <body> is.
+
+    Returns:
+        A dict with keys: title, content (visible text), links (absolute http(s)
+        URLs), url, fetched_at (ISO-8601 UTC). On any failure the same shape is
+        returned with empty title/content/links plus an "error" key. The call
+        never raises. JavaScript is not executed, so client-rendered pages may
+        return little or no content.
+    """
+    t_start = time.monotonic()
+    fetched_at = _now_utc().isoformat()
+    base: dict = {
+        "title": "",
+        "content": "",
+        "links": [],
+        "url": url,
+        "fetched_at": fetched_at,
+    }
+
+    raw, err = _fetch_document(url, "fetch_html")
+    if err is not None:
+        return {**base, "error": err}
+
+    try:
+        soup = BeautifulSoup(raw, "lxml")
+    except Exception as exc:
+        log(
+            "warn",
+            "scrape",
+            f"fetch_html: parse error for {url}: {exc.__class__.__name__}",
+            metadata={"url": url, "error_class": exc.__class__.__name__},
+        )
+        return {**base, "error": f"parse_error: {exc.__class__.__name__}"}
+
+    title = soup.title.get_text(strip=True) if soup.title else ""
+
+    # Intentionally simple extraction: selector scope if given, else the whole
+    # <body>, with no boilerplate stripping. Refinement is tracked in issue #41.
+    if selector:
+        scope = soup.select(selector)
+    else:
+        scope = [soup.body] if soup.body else [soup]
+
+    content = "\n".join(
+        node.get_text(separator=" ", strip=True) for node in scope
+    ).strip()
+
+    links: list[str] = []
+    seen: set[str] = set()
+    for node in scope:
+        for anchor in node.find_all("a", href=True):
+            absolute = urljoin(url, anchor["href"])
+            if absolute.startswith(("http://", "https://")) and absolute not in seen:
+                seen.add(absolute)
+                links.append(absolute)
+
+    log(
+        "info",
+        "scrape",
+        f"fetch_html: {len(content)} chars, {len(links)} links from {url}",
+        metadata={
+            "url": url,
+            "selector": selector,
+            "nodes_matched": len(scope) if selector else None,
+            "content_chars": len(content),
+            "links": len(links),
+            "duration_ms": round((time.monotonic() - t_start) * 1000),
+        },
+    )
+    return {
+        "title": title,
+        "content": content,
+        "links": links,
+        "url": url,
+        "fetched_at": fetched_at,
+    }
+
+
+@tool
+def parse_article(url: str) -> dict:
+    """Extract the main article body and metadata from a URL via trafilatura.
+
+    Args:
+        url: The article URL (http or https).
+
+    Returns:
+        A dict with keys: title, content (clean body text), author, date
+        (publication date, "" if unknown), url, fetched_at (ISO-8601 UTC). On any
+        failure the same shape is returned with empty fields plus an "error" key.
+        The call never raises. JavaScript is not executed, so client-rendered
+        pages may yield no content (error="no_content").
+    """
+    t_start = time.monotonic()
+    fetched_at = _now_utc().isoformat()
+    base: dict = {
+        "title": "",
+        "content": "",
+        "author": "",
+        "date": "",
+        "url": url,
+        "fetched_at": fetched_at,
+    }
+
+    raw, err = _fetch_document(url, "parse_article")
+    if err is not None:
+        return {**base, "error": err}
+
+    try:
+        html = raw.decode("utf-8", errors="replace")
+        extracted = trafilatura.extract(
+            html,
+            url=url,
+            output_format="json",
+            with_metadata=True,
+            include_comments=False,
+        )
+    except Exception as exc:
+        log(
+            "warn",
+            "scrape",
+            f"parse_article: extraction error for {url}: {exc.__class__.__name__}",
+            metadata={"url": url, "error_class": exc.__class__.__name__},
+        )
+        return {**base, "error": f"extract_error: {exc.__class__.__name__}"}
+
+    if not extracted:
+        log(
+            "info",
+            "scrape",
+            f"parse_article: no main content extracted for {url}",
+            metadata={"url": url},
+        )
+        return {**base, "error": "no_content"}
+
+    try:
+        data = json.loads(extracted)
+    except (json.JSONDecodeError, TypeError) as exc:
+        log(
+            "warn",
+            "scrape",
+            f"parse_article: json decode error for {url}: {exc.__class__.__name__}",
+            metadata={"url": url, "error_class": exc.__class__.__name__},
+        )
+        return {**base, "error": "json_decode_error"}
+
+    result = {
+        "title": (data.get("title") or "").strip(),
+        "content": (data.get("text") or "").strip(),
+        "author": (data.get("author") or "").strip(),
+        "date": (data.get("date") or "").strip(),
+        "url": url,
+        "fetched_at": fetched_at,
+    }
+    log(
+        "info",
+        "scrape",
+        f"parse_article: {len(result['content'])} chars from {url}",
+        metadata={
+            "url": url,
+            "content_chars": len(result["content"]),
+            "has_date": bool(result["date"]),
+            "has_author": bool(result["author"]),
+            "duration_ms": round((time.monotonic() - t_start) * 1000),
+        },
+    )
+    return result
+
+
+# Debug entry point — bypasses scheduler / agent so a developer can validate a
+# single tool against a real URL in seconds:
+#   python -m news_digest.tools.scraping <feed_url> [since_hours]
+#   python -m news_digest.tools.scraping --html <url> [css_selector]
+#   python -m news_digest.tools.scraping --article <url>
+if __name__ == "__main__":  # pragma: no cover
+
+    def _emit(obj: object) -> None:
+        print(json.dumps(obj, indent=2, default=str))
+
+    _args = sys.argv[1:]
+    if not _args:
         print(
-            "usage: python -m news_digest.tools.scraping <url> [since_hours]",
+            "usage:\n"
+            "  python -m news_digest.tools.scraping <feed_url> [since_hours]\n"
+            "  python -m news_digest.tools.scraping --html <url> [css_selector]\n"
+            "  python -m news_digest.tools.scraping --article <url>",
             file=sys.stderr,
         )
         sys.exit(2)
-    _url = sys.argv[1]
-    _since = int(sys.argv[2]) if len(sys.argv) > 2 else 24
-    _result = fetch_rss(_url, since_hours=_since)
-    print(
-        json.dumps({"count": len(_result), "entries": _result}, indent=2, default=str)
-    )
+
+    if _args[0] == "--html":
+        _emit(fetch_html(_args[1], selector=_args[2] if len(_args) > 2 else None))
+    elif _args[0] == "--article":
+        _emit(parse_article(_args[1]))
+    else:
+        _since = int(_args[1]) if len(_args) > 1 else 24
+        _result = fetch_rss(_args[0], since_hours=_since)
+        _emit({"count": len(_result), "entries": _result})

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,19 +2,20 @@
 
 import pytest
 
+from news_digest.config import Settings, get_settings
+
+# Tests must never read a developer's real .env file. On a host where one exists
+# (e.g. the Strix Halo box), pydantic-settings would load it and clobber the
+# values tests set via monkeypatch — silently breaking the defaults/required
+# assertions in test_config.py. Neutralize env_file once, process-wide, so the
+# suite is hermetic regardless of working directory. Doing this per-test via
+# monkeypatch is unreliable: it races with other fixtures' monkeypatch usage.
+Settings.model_config["env_file"] = None
+
 
 @pytest.fixture(autouse=True)
-def clear_settings_cache(monkeypatch):
-    """Force get_settings() to re-read env on every test, and isolate tests
-    from any real .env file on disk.
-
-    Settings hard-codes env_file=".env"; on a host where that file exists (e.g.
-    the Strix Halo box), pydantic-settings would load it and clobber the values
-    these tests set via monkeypatch. Neutralizing env_file keeps tests hermetic.
-    """
-    from news_digest.config import Settings, get_settings
-
-    monkeypatch.setitem(Settings.model_config, "env_file", None)
+def clear_settings_cache():
+    """Force get_settings() to re-read env on every test."""
     get_settings.cache_clear()
     yield
     get_settings.cache_clear()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -4,26 +4,36 @@ import pytest
 
 from news_digest.config import Settings, get_settings
 
-# Tests must never read a developer's real .env file. On a host where one exists
-# (e.g. the Strix Halo box), pydantic-settings would load it and clobber the
-# values tests set via monkeypatch — silently breaking the defaults/required
-# assertions in test_config.py. Neutralize env_file once, process-wide, so the
-# suite is hermetic regardless of working directory. Doing this per-test via
-# monkeypatch is unreliable: it races with other fixtures' monkeypatch usage.
+# Belt: stop pydantic-settings from reading a real .env file directly.
 Settings.model_config["env_file"] = None
 
 
 @pytest.fixture(autouse=True)
-def clear_settings_cache():
-    """Force get_settings() to re-read env on every test."""
+def isolate_settings_env(monkeypatch):
+    """Make every test hermetic with respect to the process environment.
+
+    Importing gaia (transitively, via the tools) calls load_dotenv() at import
+    time, which copies a developer's real .env into os.environ. pydantic-settings
+    then reads those values regardless of env_file, clobbering what these tests
+    set and breaking the defaults/required assertions in test_config.py — but
+    only on a host that has a .env (so CI and clean dev machines pass while the
+    Strix Halo box fails). Strip every Settings field's env var before each test
+    so behaviour is identical everywhere; tests opt back in via monkeypatch.
+    """
+    for field in Settings.model_fields:
+        monkeypatch.delenv(field.upper(), raising=False)
     get_settings.cache_clear()
     yield
     get_settings.cache_clear()
 
 
 @pytest.fixture
-def valid_env(monkeypatch):
-    """Minimal valid environment for Settings."""
+def valid_env(isolate_settings_env, monkeypatch):
+    """Minimal valid environment for Settings.
+
+    Depends on isolate_settings_env so the ambient env is cleared *before* these
+    values are set — otherwise the autouse delenv could wipe them.
+    """
     monkeypatch.setenv("SUPABASE_URL", "https://test.supabase.co")
     monkeypatch.setenv("SUPABASE_ANON_KEY", "anon-key")
     monkeypatch.setenv("SUPABASE_SERVICE_KEY", "service-key")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -4,10 +4,17 @@ import pytest
 
 
 @pytest.fixture(autouse=True)
-def clear_settings_cache():
-    """Force get_settings() to re-read env on every test."""
-    from news_digest.config import get_settings
+def clear_settings_cache(monkeypatch):
+    """Force get_settings() to re-read env on every test, and isolate tests
+    from any real .env file on disk.
 
+    Settings hard-codes env_file=".env"; on a host where that file exists (e.g.
+    the Strix Halo box), pydantic-settings would load it and clobber the values
+    these tests set via monkeypatch. Neutralizing env_file keeps tests hermetic.
+    """
+    from news_digest.config import Settings, get_settings
+
+    monkeypatch.setitem(Settings.model_config, "env_file", None)
     get_settings.cache_clear()
     yield
     get_settings.cache_clear()

--- a/tests/test_scraping_tools.py
+++ b/tests/test_scraping_tools.py
@@ -1,4 +1,5 @@
-"""Tests for src/news_digest/tools/scraping.py — issue #5."""
+"""Tests for src/news_digest/tools/scraping.py — issues #5 (fetch_rss) and #6
+(fetch_html, parse_article)."""
 
 import hashlib
 from collections import Counter
@@ -11,7 +12,7 @@ import pytest
 
 from news_digest.tools import scraping
 from news_digest.tools.scraping import _validate_url as _REAL_VALIDATE_URL
-from news_digest.tools.scraping import fetch_rss
+from news_digest.tools.scraping import fetch_html, fetch_rss, parse_article
 
 # ---------------------------------------------------------------------------
 # Synthetic feed XML helpers
@@ -581,7 +582,7 @@ def test_fetch_rss_never_raises_when_helper_throws_unexpected(
     def boom(*_a, **_kw):
         raise RuntimeError("boom")
 
-    monkeypatch.setattr(scraping, "_fetch_feed_bytes", boom)
+    monkeypatch.setattr(scraping, "_fetch_bytes", boom)
 
     result = fetch_rss("https://example.com/feed.xml", since_hours=24)
 
@@ -606,6 +607,203 @@ def test_fetch_rss_returns_empty_for_non_positive_since_hours(
     assert handler.calls["i"] == 0  # never reached the network
     warn_calls = [c for c in mock_log.call_args_list if c.args[0] == "warn"]
     assert len(warn_calls) == 1
+
+
+# ===========================================================================
+# T6 — fetch_html (issue #6)
+# ===========================================================================
+
+
+HTML_PAGE = """<!DOCTYPE html>
+<html>
+<head><title>Listing Page</title></head>
+<body>
+  <nav><a href="/home">Home</a></nav>
+  <main id="content">
+    <p>Featured stories this week.</p>
+    <a href="/posts/alpha">Alpha</a>
+    <a href="https://other.example.com/beta">Beta</a>
+    <a href="mailto:editor@example.com">Email</a>
+  </main>
+  <footer><a href="/about">About</a></footer>
+</body>
+</html>"""
+
+
+def _html_response(html_str: str) -> httpx.Response:
+    return _ok_response(html_str.encode("utf-8"))
+
+
+def test_fetch_html_returns_title_content_links_without_selector(monkeypatch):
+    _patch_make_client(monkeypatch, lambda req: _html_response(HTML_PAGE))
+
+    result = fetch_html("https://example.com/list")
+
+    assert set(result.keys()) == {"title", "content", "links", "url", "fetched_at"}
+    assert result["title"] == "Listing Page"
+    # Whole-body text (no selector): nav + main + footer text all present.
+    assert "Featured stories this week." in result["content"]
+    assert "Home" in result["content"]
+    assert "About" in result["content"]
+    # Relative links resolved against the page URL; mailto dropped; order kept.
+    assert result["links"] == [
+        "https://example.com/home",
+        "https://example.com/posts/alpha",
+        "https://other.example.com/beta",
+        "https://example.com/about",
+    ]
+
+
+def test_fetch_html_scopes_extraction_to_selector(monkeypatch):
+    _patch_make_client(monkeypatch, lambda req: _html_response(HTML_PAGE))
+
+    result = fetch_html("https://example.com/list", selector="#content")
+
+    # Only the #content subtree contributes — nav/footer excluded.
+    assert "Featured stories this week." in result["content"]
+    assert "Home" not in result["content"]
+    assert "About" not in result["content"]
+    assert result["links"] == [
+        "https://example.com/posts/alpha",
+        "https://other.example.com/beta",
+    ]
+
+
+def test_fetch_html_selector_no_match_returns_empty_not_error(monkeypatch):
+    _patch_make_client(monkeypatch, lambda req: _html_response(HTML_PAGE))
+
+    result = fetch_html("https://example.com/list", selector=".does-not-exist")
+
+    assert result["content"] == ""
+    assert result["links"] == []
+    assert "error" not in result  # a clean fetch with 0 matches is not an error
+
+
+def test_fetch_html_returns_error_dict_on_4xx_without_raising(monkeypatch):
+    handler = _counting_handler([httpx.Response(404)])
+    _patch_make_client(monkeypatch, handler)
+
+    result = fetch_html("https://example.com/missing")
+
+    assert result["error"] == "http_404"
+    assert result["content"] == "" and result["links"] == []
+    assert handler.calls["i"] == 1  # 4xx is non-retryable
+
+
+def test_fetch_html_rejects_unsafe_url(monkeypatch, mock_log):
+    monkeypatch.setattr(scraping, "_validate_url", _REAL_VALIDATE_URL)
+    handler = _counting_handler([_html_response(HTML_PAGE)])
+    _patch_make_client(monkeypatch, handler)
+
+    result = fetch_html("http://127.0.0.1/admin")
+
+    assert result["error"].startswith("unsafe_url")
+    assert handler.calls["i"] == 0  # never reached the network
+
+
+def test_fetch_html_is_tool_with_doc_preserved():
+    assert callable(fetch_html)
+    assert fetch_html.__doc__ is not None
+    assert "selector" in fetch_html.__doc__
+    assert "Returns:" in fetch_html.__doc__
+
+
+# ===========================================================================
+# T7 — parse_article (issue #6)
+# ===========================================================================
+
+
+ARTICLE_HTML = """<!DOCTYPE html>
+<html>
+<head>
+  <title>New Open-Weights Model Released</title>
+  <meta name="author" content="Jane Doe"/>
+  <meta property="article:published_time" content="2026-05-20T08:00:00Z"/>
+</head>
+<body>
+  <nav>Home About Contact</nav>
+  <article>
+    <h1>New Open-Weights Model Released</h1>
+    <p>A new open-weights language model was released today by a research lab,
+    marking a notable step for local inference. The model targets consumer
+    hardware and ships with a permissive license for developers everywhere.</p>
+    <p>According to the announcement, the model improves reasoning while keeping
+    memory requirements modest. Early testers report strong tool-calling
+    behaviour and stable long-context performance across a wide range of tasks.</p>
+    <p>The release includes quantized variants intended for laptops and edge
+    devices, alongside documentation and example code to help teams get started.</p>
+  </article>
+  <footer>Copyright 2026</footer>
+</body>
+</html>"""
+
+
+def test_parse_article_extracts_body_and_metadata(monkeypatch):
+    """Exercises the real trafilatura extraction offline (HTML supplied via the
+    mock transport — trafilatura itself does no network I/O)."""
+    _patch_make_client(monkeypatch, lambda req: _html_response(ARTICLE_HTML))
+
+    result = parse_article("https://example.com/article")
+
+    assert set(result.keys()) == {
+        "title",
+        "content",
+        "author",
+        "date",
+        "url",
+        "fetched_at",
+    }
+    assert "open-weights language model" in result["content"]
+    # Boilerplate (nav/footer) is stripped by trafilatura's main-content model.
+    assert "Copyright 2026" not in result["content"]
+    assert result["title"]
+    assert result["url"] == "https://example.com/article"
+
+
+def test_parse_article_no_main_content_returns_error(monkeypatch):
+    _patch_make_client(monkeypatch, lambda req: _html_response(HTML_PAGE))
+    # Deterministic: force trafilatura to find nothing extractable.
+    monkeypatch.setattr(scraping.trafilatura, "extract", lambda *a, **k: None)
+
+    result = parse_article("https://example.com/thin")
+
+    assert result["error"] == "no_content"
+    assert result["content"] == ""
+
+
+def test_parse_article_handles_extraction_exception(monkeypatch):
+    _patch_make_client(monkeypatch, lambda req: _html_response(ARTICLE_HTML))
+
+    def _boom(*_a, **_kw):
+        raise ValueError("bad html")
+
+    monkeypatch.setattr(scraping.trafilatura, "extract", _boom)
+
+    result = parse_article("https://example.com/article")
+
+    assert result["error"].startswith("extract_error")
+    assert result["content"] == ""
+
+
+def test_parse_article_handles_malformed_json(monkeypatch):
+    """trafilatura returning a non-JSON string must not raise out of the tool."""
+    _patch_make_client(monkeypatch, lambda req: _html_response(ARTICLE_HTML))
+    monkeypatch.setattr(scraping.trafilatura, "extract", lambda *a, **k: "not json{{{")
+
+    result = parse_article("https://example.com/article")
+
+    assert result["error"] == "json_decode_error"
+    assert result["content"] == ""
+
+
+def test_parse_article_returns_error_dict_on_4xx(monkeypatch):
+    handler = _counting_handler([httpx.Response(404)])
+    _patch_make_client(monkeypatch, handler)
+
+    result = parse_article("https://example.com/missing")
+
+    assert result["error"] == "http_404"
+    assert handler.calls["i"] == 1
 
 
 # ===========================================================================
@@ -648,3 +846,20 @@ def test_fetch_rss_against_arxiv():
 def test_fetch_rss_against_simon_willison():
     result = fetch_rss("https://simonwillison.net/atom/everything/", since_hours=720)
     _assert_real_feed_contract(result)
+
+
+@pytest.mark.integration
+def test_fetch_html_against_real_page():
+    result = fetch_html("https://example.com/")
+    assert "error" not in result
+    assert result["title"]
+    assert "example" in result["content"].lower()
+
+
+@pytest.mark.integration
+def test_parse_article_against_real_page():
+    # A stable, text-heavy page that trafilatura extracts reliably.
+    result = parse_article("https://en.wikipedia.org/wiki/Pittsburgh_Penguins")
+    assert "error" not in result
+    assert result["title"]
+    assert len(result["content"]) > 500


### PR DESCRIPTION
## Summary
Implements **#6** — the HTML scraping tools for the digest pipeline:
- `fetch_html(url, selector=None)` — fetch a page and extract title, visible text, and absolute http(s) links, optionally scoped to a CSS selector.
- `parse_article(url)` — extract clean article body + metadata (title, author, date) via `trafilatura`.

Both are GAIA `@tool` functions that reuse the existing SSRF defense, per-domain rate limiting, and the retry + 10 MB-capped byte fetcher (`_fetch_feed_bytes` renamed to `_fetch_bytes`, now shared through a new `_fetch_document` helper). Per the `@tool` contract neither raises — every failure path returns the documented dict shape with an `"error"` key.

Also includes a **test-isolation fix**: importing GAIA calls `load_dotenv()` at import time, leaking the host `.env` into `os.environ` and breaking `test_config.py` on any machine that has a `.env` (CI and clean dev machines passed, the Strix Halo host failed). An autouse fixture now clears each Settings-field env var before every test.

## Testing (real-life, on the Strix Halo host)
- `ruff check` + `ruff format --check`: clean
- Unit tests: **65 passed** (incl. the 3 now-fixed config tests and the new tool tests)
- Live: `parse_article` on Wikipedia (86,928 chars, title + date extracted); `fetch_html` on example.com (clean text + absolutized link)
- `fetch_html` uses the simplest extraction for now; refinement tracked in #41

## Follow-ups
- #41 — evaluate/refine `fetch_html` content-extraction quality
- #42 — `fetch_rss` returns 0 entries for arxiv (feed has no per-item dates; pre-existing #5 integration test)

## Notes
- Recommend **squash-merge**: the branch carries 3 small `conftest.py` commits from debugging the env-isolation issue.

Closes #6