### PR TITLE
Build Supabase-hosted digest web app with magic-link auth (#10)

### DIFF
--- a/.claude/plans/issue-10.md
+++ b/.claude/plans/issue-10.md
@@ -1,0 +1,143 @@
+---
+type: plan
+source-issue: 10
+repo: itomek/itomek-news-digest-agent
+title: "Build Supabase-hosted digest web app with authentication"
+created: 2026-06-01
+status: in-progress
+work_type: code-feature
+complexity: complex
+tdd_required: true
+suggested_team_size: 3
+estimated_files_changed: 30
+test_command: "ssh tomas@t-nx-radeon 'bash -lc \"cd ~/ndw-issue10 && npm run test:unit && npx playwright test\"'"
+build_command: "ssh tomas@t-nx-radeon 'bash -lc \"cd ~/ndw-issue10 && npm run build\"'"
+lint_command: "ssh tomas@t-nx-radeon 'bash -lc \"cd ~/ndw-issue10 && npm run lint\"'"
+branch: feat/issue-10-web-app
+reflection_iterations: 1
+agents_used: [planning, execution, validation]
+---
+
+# Plan — Issue #10: Supabase-hosted digest web app with authentication
+
+## Goal
+
+Build a deployable, mobile-first web app (`web/`) that authenticates a single user via
+Supabase Auth magic link (email allowlist enforced), reads digests through the anon
+publishable key gated by RLS, and renders them grouped by topic and date. Ship a CI
+workflow that builds, tests, and deploys to Cloudflare Pages. Scaffold clean, disjoint
+extension points so issues #11 (TTS) and #12 (history) can be built in parallel without
+editing shared files.
+
+## Repo / environment facts established during exploration
+
+- Stack decision: **vanilla TS + Vite, no framework, no JSX**. Hand-rolled DOM + a tiny
+  hash router. `vite.config.ts` only `.ts` config file allowed.
+- Live Supabase project `eedfyviypptfpghyffip` (us-east-2). Schema matches §3.1:
+  `digests`, `digest_topics`, `system_logs` with RLS enabled. Verified: anon publishable
+  key can SELECT digests, and anon INSERT is rejected with Postgres `42501`
+  (row-level-security violation) — so the RLS integration assertion is real.
+- Seeded test data: 4 digests across 2 topics (`ai_models` 3 dates, `local_news` 1 date)
+  so grouping-by-topic-and-date is exercised against real rows. Topic `local_news` added
+  (enabled) for that purpose.
+- No edge functions exist yet — the allowlist function is greenfield.
+- Test machine radeon: node v20.20.2, npm 10.8.2 (via nvm, requires `bash -lc`),
+  `google-chrome` at `/usr/bin/google-chrome`.
+
+## Architecture / extension points (critical — #11 and #12 build in parallel on this branch)
+
+```
+web/
+  index.html                 # single page; root #app, CSP meta, viewport
+  vite.config.ts             # build + vitest config
+  tsconfig.json
+  package.json               # scripts: dev build preview lint test:unit test:e2e
+  .env / .env.example / .gitignore
+  src/
+    main.ts                  # bootstrap + tiny hash router (routes table; stub-friendly)
+    router.ts                # route registry — pages register; main.ts does not change to add pages
+    lib/
+      supabase.ts            # client + fetchDigests / fetchTopics + grouping helpers (#12 APPENDS here)
+      auth.ts                # magic-link signIn / signOut / session guard predicate
+      allowlist.ts           # pure isEmailAllowed(email, list) — shared logic mirrors Edge Function
+      group.ts               # pure groupDigestsByTopicAndDate (unit-tested)
+      query.ts               # pure query-param builders (unit-tested)
+    views/
+      digest-card.ts         # renders one digest + .playback-slot mount point + mountPlaybackControls hook (#11)
+      digest-list.ts         # renders grouped list
+      auth-gate.ts           # login form / gate; redirects unauthenticated to login
+    pages/
+      home.ts                # home view (auth gate + digest list)
+      history.ts             # STUB renderHistory(root, supabase) — #12 fills in
+    styles.css               # minimal mobile-first CSS (Lighthouse >=90)
+  tests/
+    unit/*.test.ts           # vitest: allowlist, grouping, query builders, session guard
+    e2e/*.spec.ts            # playwright: unauth redirect, grouped render w/ session, anon RLS write blocked
+    e2e/playwright.config.ts
+supabase/
+  functions/auth-allowlist/index.ts   # Edge Function: reject non-allowlisted on auth.users insert
+  migrations/0003_auth_allowlist.sql   # digest_allowlist table + trigger calling the check
+.github/workflows/web.yml              # build + test + Cloudflare Pages deploy (gated on secrets)
+```
+
+Collision-avoidance contract:
+- #11 (TTS) touches only: `src/lib/tts.ts` (new), `src/components/playback.ts` (new), and
+  implements the `mountPlaybackControls` hook. It mounts into `.playback-slot` in each card.
+  It does NOT edit `main.ts`, `router.ts`, or `digest-card.ts` core.
+- #12 (history) touches only: `src/pages/history.ts` (fills the stub) and APPENDS
+  history-specific query functions to `src/lib/supabase.ts`. The `#/history` route is already
+  wired, so it does NOT edit `main.ts` / `router.ts`.
+
+## Allowlist design decision
+
+Use a **`digest_allowlist` table** (email text PK, note text, created_at) plus a Postgres
+trigger function on `auth.users` AFTER INSERT that deletes the just-inserted user when the
+email is not present in the allowlist. This is robust (DB-enforced, survives client bypass)
+and does not depend on an Edge Function being invoked. We ALSO ship an Edge Function
+`auth-allowlist` as documented in §8 / the issue file-list (callable as an Auth Hook "before
+user created" hook if the human prefers the hook route) so both options are available. The
+table is the source of truth either way. Browser-side, `lib/allowlist.ts` provides the same
+pure predicate for a fast client-side UX rejection (defense in depth, not the security
+boundary). Document this clearly in `web/README.md`.
+
+The RLS-blocked-write integration test gives us the security backstop proof; the allowlist
+trigger gives us the sign-up gate. Live magic-link send/click is a human checkpoint
+(requires a real mailbox + Supabase SMTP/redirect config).
+
+## TDD task breakdown (write failing tests first, implement to green)
+
+1. Scaffold `web/` (package.json, vite, tsconfig, env files, gitignore). No logic yet.
+2. UNIT (red→green):
+   - `allowlist.test.ts` → `isEmailAllowed` (case-insensitive, trims, rejects empty/non-list).
+   - `group.test.ts` → `groupDigestsByTopicAndDate` (orders topics, dates desc, shape).
+   - `query.test.ts` → query-param builders (select/order strings for digests + topics).
+   - `auth.test.ts` → `hasValidSession` predicate (null session, expired, valid).
+3. Implement `lib/*` to green.
+4. Implement views + pages + router + main + styles + index.html.
+5. INTEGRATION (Playwright against `vite preview` of the built app, real Supabase):
+   - unauthenticated user sees login gate, NOT digest content.
+   - with an injected session (set supabase auth storage), digests render grouped by
+     topic + date headers from real seeded rows.
+   - anon client cannot write to `digests` (RLS) — call `.insert(...)` via the live client
+     in-page and assert the error code/path.
+6. Supabase migration `0003_auth_allowlist.sql` + Edge Function `auth-allowlist`.
+7. `.github/workflows/web.yml` — build, test:unit, playwright, deploy to Cloudflare Pages
+   gated on `CLOUDFLARE_API_TOKEN` + `CLOUDFLARE_ACCOUNT_ID`.
+8. `web/README.md` — setup, env vars, extension points for #11/#12, Cloudflare deploy + Supabase Auth config steps.
+
+## Validation
+
+Run on radeon: `npm install && npm run build && npm run test:unit && playwright test`.
+Then a code-review pass for high-confidence (>=80) bugs/security/convention issues; fix
+Critical only; re-run; max 3 iterations. Lighthouse (>=90 mobile @390x844) is the
+orchestrator's checkpoint — we build to hit it (minimal CSS, no framework, system fonts,
+no blocking resources, semantic HTML).
+
+## Acceptance criteria mapping
+
+- App accessible via URL → buildable `dist/` + `web.yml` deploy (live deploy = orchestrator/human).
+- Magic-link auth + non-allowlisted rejected → `auth.ts` flow + `0003` trigger + Edge Function (live send = human).
+- Digests grouped by topic+date → `group.ts` + `digest-list.ts`, proven by unit + e2e.
+- Unauth cannot access content → `auth-gate.ts` + e2e redirect test.
+- Lighthouse >=90 → minimal mobile-first build (orchestrator verifies).
+- CI green → `web.yml` runs unit + e2e on PR.

--- a/.github/workflows/web.yml
+++ b/.github/workflows/web.yml
@@ -1,0 +1,99 @@
+name: Web
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - "web/**"
+      - ".github/workflows/web.yml"
+  pull_request:
+    paths:
+      - "web/**"
+      - ".github/workflows/web.yml"
+
+defaults:
+  run:
+    working-directory: web
+
+jobs:
+  build-test:
+    runs-on: ubuntu-latest
+    env:
+      VITE_SUPABASE_URL: ${{ secrets.VITE_SUPABASE_URL || 'https://eedfyviypptfpghyffip.supabase.co' }}
+      VITE_SUPABASE_ANON_KEY: ${{ secrets.VITE_SUPABASE_ANON_KEY || 'sb_publishable_CCE4uRqvWCAonhnDis0BZQ_ixrd0jl2' }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+          cache: npm
+          cache-dependency-path: web/package-lock.json
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Lint
+        run: npm run lint
+
+      - name: Unit tests
+        run: npm run test:unit
+
+      - name: Build
+        run: npm run build
+
+      - name: Install Playwright browser
+        run: npx playwright install chromium --with-deps
+
+      - name: E2E tests
+        run: npm run test:e2e
+
+      - name: Upload Playwright report
+        if: ${{ !cancelled() }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: playwright-report
+          path: web/playwright-report
+          retention-days: 7
+
+  deploy:
+    needs: build-test
+    runs-on: ubuntu-latest
+    if: github.ref == 'refs/heads/main' && github.event_name == 'push'
+    env:
+      VITE_SUPABASE_URL: ${{ secrets.VITE_SUPABASE_URL || 'https://eedfyviypptfpghyffip.supabase.co' }}
+      VITE_SUPABASE_ANON_KEY: ${{ secrets.VITE_SUPABASE_ANON_KEY || 'sb_publishable_CCE4uRqvWCAonhnDis0BZQ_ixrd0jl2' }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+          cache: npm
+          cache-dependency-path: web/package-lock.json
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build
+        run: npm run build
+
+      # Gated on Cloudflare secrets — no-ops (skips) cleanly when they are absent.
+      - name: Check Cloudflare secrets
+        id: cf
+        run: |
+          if [ -n "${{ secrets.CLOUDFLARE_API_TOKEN }}" ] && [ -n "${{ secrets.CLOUDFLARE_ACCOUNT_ID }}" ]; then
+            echo "enabled=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "enabled=false" >> "$GITHUB_OUTPUT"
+            echo "Cloudflare secrets not set; skipping deploy."
+          fi
+
+      - name: Deploy to Cloudflare Pages
+        if: steps.cf.outputs.enabled == 'true'
+        uses: cloudflare/wrangler-action@v3
+        with:
+          apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          workingDirectory: web
+          command: pages deploy dist --project-name=news-digest-web

--- a/supabase/functions/auth-allowlist/index.ts
+++ b/supabase/functions/auth-allowlist/index.ts
@@ -1,0 +1,57 @@
+// auth-allowlist — Supabase Auth "before user created" hook (alternative to the
+// 0003 Postgres trigger; both enforce the same allowlist). Wire this in the
+// Supabase dashboard under Authentication > Hooks > "Before user created" if you
+// prefer rejecting BEFORE the user row is created (cleaner than the delete-after
+// approach the trigger uses). The allowlist source of truth is the
+// public.digest_allowlist table.
+//
+// Deploy: supabase functions deploy auth-allowlist --no-verify-jwt
+// (Auth hooks are called by GoTrue with a shared secret, not a user JWT.)
+//
+// Request body (Auth hook v1): { user: { email, ... }, ... }
+// Response to ALLOW: { } (200). Response to REJECT: 200 with an `error` object.
+
+import { createClient } from "jsr:@supabase/supabase-js@2";
+
+const SUPABASE_URL = Deno.env.get("SUPABASE_URL")!;
+const SERVICE_ROLE_KEY = Deno.env.get("SUPABASE_SERVICE_ROLE_KEY")!;
+
+Deno.serve(async (req: Request) => {
+  let payload: { user?: { email?: string } };
+  try {
+    payload = await req.json();
+  } catch {
+    return json({ error: { http_code: 400, message: "Invalid JSON body" } });
+  }
+
+  const email = payload.user?.email?.trim().toLowerCase();
+  if (!email) {
+    return json({ error: { http_code: 400, message: "Missing email" } });
+  }
+
+  const admin = createClient(SUPABASE_URL, SERVICE_ROLE_KEY);
+  const { data, error } = await admin
+    .from("digest_allowlist")
+    .select("email")
+    .ilike("email", email)
+    .maybeSingle();
+
+  if (error) {
+    return json({ error: { http_code: 500, message: "Allowlist lookup failed" } });
+  }
+
+  if (!data) {
+    return json({
+      error: { http_code: 403, message: "This email is not authorized to sign in." },
+    });
+  }
+
+  // Allowed — empty object lets the user be created.
+  return json({});
+});
+
+function json(body: unknown): Response {
+  return new Response(JSON.stringify(body), {
+    headers: { "Content-Type": "application/json" },
+  });
+}

--- a/supabase/migrations/0003_auth_allowlist.sql
+++ b/supabase/migrations/0003_auth_allowlist.sql
@@ -1,0 +1,51 @@
+-- 0003_auth_allowlist.sql — email allowlist for Supabase Auth sign-ups (#10).
+-- Source of truth: docs/architecture.md §8 ("Auth allowlist").
+--
+-- A new auth.users row whose email is not present in digest_allowlist is deleted
+-- immediately after insert. This is the DB-enforced security boundary; the web
+-- app's client-side check (web/src/lib/allowlist.ts) is only a UX nicety.
+
+create table if not exists public.digest_allowlist (
+  email text primary key,
+  note text,
+  created_at timestamptz not null default now()
+);
+
+-- Allowlist is sensitive config: lock it down. No anon access; service_role
+-- bypasses RLS for administration.
+alter table public.digest_allowlist enable row level security;
+
+-- Normalize emails for case-insensitive matching.
+create or replace function public.is_email_allowlisted(candidate text)
+returns boolean
+language sql
+stable
+security definer
+set search_path = public
+as $$
+  select exists (
+    select 1 from public.digest_allowlist
+    where lower(email) = lower(trim(candidate))
+  );
+$$;
+
+-- Trigger function: reject (delete) any newly created user not on the allowlist.
+create or replace function public.enforce_auth_allowlist()
+returns trigger
+language plpgsql
+security definer
+set search_path = public
+as $$
+begin
+  if not public.is_email_allowlisted(new.email) then
+    delete from auth.users where id = new.id;
+  end if;
+  return new;
+end;
+$$;
+
+drop trigger if exists trg_enforce_auth_allowlist on auth.users;
+create trigger trg_enforce_auth_allowlist
+  after insert on auth.users
+  for each row
+  execute function public.enforce_auth_allowlist();

--- a/web/.env.example
+++ b/web/.env.example
@@ -1,0 +1,3 @@
+# Supabase project — browser-safe values only. NEVER put the service_role key here.
+VITE_SUPABASE_URL=https://YOUR-PROJECT.supabase.co
+VITE_SUPABASE_ANON_KEY=your-publishable-anon-key

--- a/web/.gitignore
+++ b/web/.gitignore
@@ -1,0 +1,6 @@
+.env
+.env.local
+node_modules
+dist
+playwright-report
+test-results

--- a/web/README.md
+++ b/web/README.md
@@ -1,0 +1,120 @@
+# News Digest Web App
+
+Mobile-first reading app for the News Digest Agent. Vanilla TypeScript + Vite (no
+framework, no JSX), Supabase for auth and data, deployed to Cloudflare Pages.
+
+## Stack
+
+- **Build:** Vite + TypeScript, hand-rolled DOM, a tiny hash router (`src/router.ts`).
+- **Data:** `@supabase/supabase-js` using the **anon/publishable key only**. All reads
+  are RLS-gated. The service_role key is NEVER shipped to the browser.
+- **Auth:** Supabase magic link (email OTP, no password). Sign-ups are restricted by an
+  email allowlist (see below).
+- **Tests:** Vitest (unit) + Playwright (integration, real Supabase — no mocks).
+
+## Setup
+
+```bash
+cd web
+cp .env.example .env   # fill in the values below
+npm install
+npm run dev            # http://localhost:5173
+```
+
+### Environment variables
+
+| Var                     | Purpose                                         |
+| ----------------------- | ----------------------------------------------- |
+| `VITE_SUPABASE_URL`     | Supabase project URL                            |
+| `VITE_SUPABASE_ANON_KEY`| Publishable/anon key (browser-safe, RLS-gated)  |
+
+`.env` is gitignored. Never put the service_role key here.
+
+## Scripts
+
+| Script           | What it does                                          |
+| ---------------- | ----------------------------------------------------- |
+| `npm run dev`      | Vite dev server                                       |
+| `npm run build`    | Type-check + production build to `dist/`              |
+| `npm run preview`  | Serve the built app on port 4173                      |
+| `npm run lint`     | ESLint + `tsc --noEmit`                               |
+| `npm run test:unit`| Vitest (pure logic: allowlist, grouping, query, auth) |
+| `npm run test:e2e` | Playwright against the built app (real Supabase)      |
+
+## Architecture & extension points
+
+The app is intentionally split so issues **#11 (TTS)** and **#12 (history)** can be built
+in parallel without editing the same files.
+
+```
+src/
+  main.ts            # bootstrap; declares routes ONCE. Do not edit to add a page.
+  router.ts          # tiny hash router; routes register here
+  lib/
+    supabase.ts      # client + fetchDigests / fetchTopics  (#12 APPENDS queries below the marker)
+    auth.ts          # magic-link sign-in/out + hasValidSession guard
+    allowlist.ts     # pure isEmailAllowed (client-side UX check only)
+    group.ts         # pure groupDigestsByTopicAndDate
+    query.ts         # pure query-shape builders
+    types.ts         # shared data shapes
+  views/
+    digest-card.ts   # renders one digest; has a .playback-slot mount point + registerPlaybackControls hook (#11)
+    digest-list.ts   # grouped render
+    auth-gate.ts     # login form / unauthenticated gate
+  pages/
+    home.ts          # today's digests (auth gate + list)
+    history.ts       # STUB — #12 fills renderHistory(root, client)
+```
+
+**#11 (TTS)** should touch only: a new `src/lib/tts.ts`, a new `src/components/playback.ts`,
+and call `registerPlaybackControls(fn)` from `views/digest-card.ts` (imported once in
+`main.ts`). It mounts its UI into the `.playback-slot` element each card renders. It must
+NOT edit `main.ts`, `router.ts`, or the core of `digest-card.ts`.
+
+**#12 (history)** should touch only: `src/pages/history.ts` (fill the stub) and APPEND
+history-specific queries to `src/lib/supabase.ts` below the documented marker. The
+`#/history` route is already wired in `main.ts` to the stub, so it must NOT edit
+`main.ts` / `router.ts`.
+
+## Auth allowlist (security boundary)
+
+Sign-ups are restricted to emails in the **`public.digest_allowlist`** table.
+
+- **DB trigger (source of truth):** `supabase/migrations/0003_auth_allowlist.sql` adds the
+  table and an `after insert on auth.users` trigger that deletes any user whose email is
+  not allowlisted. This is enforced in Postgres and cannot be bypassed by the client.
+- **Edge Function (optional, cleaner):** `supabase/functions/auth-allowlist/index.ts` can be
+  wired as a Supabase Auth "Before user created" hook to reject non-allowlisted emails
+  *before* the row is created. It reads the same `digest_allowlist` table.
+- **Client-side check:** `src/lib/allowlist.ts` is a UX nicety only — never the boundary.
+
+Add an allowed email:
+
+```sql
+insert into public.digest_allowlist (email, note) values ('you@example.com', 'owner');
+```
+
+## Deploy (Cloudflare Pages)
+
+CI (`.github/workflows/web.yml`) builds, lints, runs unit + e2e, and on push to `main`
+deploys `web/dist` to Cloudflare Pages. The deploy step is gated on repo secrets
+`CLOUDFLARE_API_TOKEN` + `CLOUDFLARE_ACCOUNT_ID` and is skipped when they are absent.
+
+Manual deploy:
+
+```bash
+cd web
+npm run build
+npx wrangler pages deploy dist --project-name=news-digest-web
+```
+
+### One-time Supabase Auth configuration (human checkpoint)
+
+1. Apply migration `0003_auth_allowlist.sql` (`supabase db push` or the SQL editor).
+2. Insert your email into `digest_allowlist`.
+3. In the Supabase dashboard, **Authentication > URL Configuration**, set the Site URL and
+   add the Cloudflare Pages URL (and `http://localhost:5173` for local) to **Redirect URLs**
+   so magic links return to the app.
+4. (Optional) wire `auth-allowlist` as a "Before user created" Auth hook.
+5. On iPhone: open the Cloudflare Pages URL in Safari, enter your allowlisted email, tap the
+   magic link in Mail — it opens the app authenticated.

--- a/web/eslint.config.js
+++ b/web/eslint.config.js
@@ -1,0 +1,20 @@
+import tseslint from "@typescript-eslint/eslint-plugin";
+import tsparser from "@typescript-eslint/parser";
+
+export default [
+  {
+    ignores: ["dist/**", "node_modules/**", "playwright-report/**", "test-results/**"],
+  },
+  {
+    files: ["**/*.ts"],
+    languageOptions: {
+      parser: tsparser,
+      parserOptions: { ecmaVersion: 2022, sourceType: "module" },
+    },
+    plugins: { "@typescript-eslint": tseslint },
+    rules: {
+      "@typescript-eslint/no-unused-vars": ["error", { argsIgnorePattern: "^_" }],
+      "no-undef": "off",
+    },
+  },
+];

--- a/web/index.html
+++ b/web/index.html
@@ -1,0 +1,16 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <meta name="color-scheme" content="light dark" />
+    <meta name="description" content="Personal news digests, read and heard." />
+    <meta name="theme-color" content="#0f172a" />
+    <title>News Digest</title>
+    <link rel="stylesheet" href="/src/styles.css" />
+  </head>
+  <body>
+    <div id="app"></div>
+    <script type="module" src="/src/main.ts"></script>
+  </body>
+</html>

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -1,0 +1,2042 @@
+{
+  "name": "news-digest-web",
+  "version": "0.1.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "news-digest-web",
+      "version": "0.1.0",
+      "dependencies": {
+        "@supabase/supabase-js": "^2.45.4"
+      },
+      "devDependencies": {
+        "@playwright/test": "^1.47.2",
+        "@types/node": "^20.16.10",
+        "@typescript-eslint/eslint-plugin": "^8.8.0",
+        "@typescript-eslint/parser": "^8.8.0",
+        "eslint": "^9.11.1",
+        "typescript": "^5.6.2",
+        "vite": "^5.4.8",
+        "vitest": "^2.1.1"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.21.5",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@eslint-community/eslint-utils": {
+      "version": "4.9.1",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "eslint-visitor-keys": "^3.4.3"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^6.0.0 || ^7.0.0 || >=8.0.0"
+      }
+    },
+    "node_modules/@eslint-community/regexpp": {
+      "version": "4.12.2",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^12.0.0 || ^14.0.0 || >=16.0.0"
+      }
+    },
+    "node_modules/@eslint/config-array": {
+      "version": "0.21.2",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@eslint/object-schema": "^2.1.7",
+        "debug": "^4.3.1",
+        "minimatch": "^3.1.5"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
+    "node_modules/@eslint/config-array/node_modules/balanced-match": {
+      "version": "1.0.2",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@eslint/config-array/node_modules/brace-expansion": {
+      "version": "1.1.15",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "node_modules/@eslint/config-array/node_modules/minimatch": {
+      "version": "3.1.5",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/@eslint/config-helpers": {
+      "version": "0.4.2",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@eslint/core": "^0.17.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
+    "node_modules/@eslint/core": {
+      "version": "0.17.0",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@types/json-schema": "^7.0.15"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
+    "node_modules/@eslint/eslintrc": {
+      "version": "3.3.5",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ajv": "^6.14.0",
+        "debug": "^4.3.2",
+        "espree": "^10.0.1",
+        "globals": "^14.0.0",
+        "ignore": "^5.2.0",
+        "import-fresh": "^3.2.1",
+        "js-yaml": "^4.1.1",
+        "minimatch": "^3.1.5",
+        "strip-json-comments": "^3.1.1"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/@eslint/eslintrc/node_modules/balanced-match": {
+      "version": "1.0.2",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@eslint/eslintrc/node_modules/brace-expansion": {
+      "version": "1.1.15",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "node_modules/@eslint/eslintrc/node_modules/ignore": {
+      "version": "5.3.2",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4"
+      }
+    },
+    "node_modules/@eslint/eslintrc/node_modules/minimatch": {
+      "version": "3.1.5",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/@eslint/js": {
+      "version": "9.39.4",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://eslint.org/donate"
+      }
+    },
+    "node_modules/@eslint/object-schema": {
+      "version": "2.1.7",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
+    "node_modules/@eslint/plugin-kit": {
+      "version": "0.4.1",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@eslint/core": "^0.17.0",
+        "levn": "^0.4.1"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
+    "node_modules/@humanfs/core": {
+      "version": "0.19.2",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@humanfs/types": "^0.15.0"
+      },
+      "engines": {
+        "node": ">=18.18.0"
+      }
+    },
+    "node_modules/@humanfs/node": {
+      "version": "0.16.8",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@humanfs/core": "^0.19.2",
+        "@humanfs/types": "^0.15.0",
+        "@humanwhocodes/retry": "^0.4.0"
+      },
+      "engines": {
+        "node": ">=18.18.0"
+      }
+    },
+    "node_modules/@humanfs/types": {
+      "version": "0.15.0",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18.18.0"
+      }
+    },
+    "node_modules/@humanwhocodes/module-importer": {
+      "version": "1.0.1",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.22"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/nzakas"
+      }
+    },
+    "node_modules/@humanwhocodes/retry": {
+      "version": "0.4.3",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18.18"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/nzakas"
+      }
+    },
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.5.5",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.60.0",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.60.0"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@rollup/rollup-linux-x64-gnu": {
+      "version": "4.61.0",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@supabase/auth-js": {
+      "version": "2.106.2",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "2.8.1"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@supabase/functions-js": {
+      "version": "2.106.2",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "2.8.1"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@supabase/phoenix": {
+      "version": "0.4.2",
+      "license": "MIT"
+    },
+    "node_modules/@supabase/postgrest-js": {
+      "version": "2.106.2",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "2.8.1"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@supabase/realtime-js": {
+      "version": "2.106.2",
+      "license": "MIT",
+      "dependencies": {
+        "@supabase/phoenix": "^0.4.2",
+        "tslib": "2.8.1"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@supabase/storage-js": {
+      "version": "2.106.2",
+      "license": "MIT",
+      "dependencies": {
+        "iceberg-js": "^0.8.1",
+        "tslib": "2.8.1"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@supabase/supabase-js": {
+      "version": "2.106.2",
+      "license": "MIT",
+      "dependencies": {
+        "@supabase/auth-js": "2.106.2",
+        "@supabase/functions-js": "2.106.2",
+        "@supabase/postgrest-js": "2.106.2",
+        "@supabase/realtime-js": "2.106.2",
+        "@supabase/storage-js": "2.106.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@types/estree": {
+      "version": "1.0.9",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/json-schema": {
+      "version": "7.0.15",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/node": {
+      "version": "20.19.41",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.41.tgz",
+      "integrity": "sha512-ECymXOukMnOoVkC2bb1Vc/w/836DXncOg5m8Xj1RH7xSHZJWNYY6Zh7EH477vcnD5egKNNfy2RpNOmuChhFPgQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~6.21.0"
+      }
+    },
+    "node_modules/@typescript-eslint/eslint-plugin": {
+      "version": "8.60.1",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@eslint-community/regexpp": "^4.12.2",
+        "@typescript-eslint/scope-manager": "8.60.1",
+        "@typescript-eslint/type-utils": "8.60.1",
+        "@typescript-eslint/utils": "8.60.1",
+        "@typescript-eslint/visitor-keys": "8.60.1",
+        "ignore": "^7.0.5",
+        "natural-compare": "^1.4.0",
+        "ts-api-utils": "^2.5.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "@typescript-eslint/parser": "^8.60.1",
+        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
+        "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
+    "node_modules/@typescript-eslint/parser": {
+      "version": "8.60.1",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/scope-manager": "8.60.1",
+        "@typescript-eslint/types": "8.60.1",
+        "@typescript-eslint/typescript-estree": "8.60.1",
+        "@typescript-eslint/visitor-keys": "8.60.1",
+        "debug": "^4.4.3"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
+        "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
+    "node_modules/@typescript-eslint/project-service": {
+      "version": "8.60.1",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/tsconfig-utils": "^8.60.1",
+        "@typescript-eslint/types": "^8.60.1",
+        "debug": "^4.4.3"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
+    "node_modules/@typescript-eslint/scope-manager": {
+      "version": "8.60.1",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/types": "8.60.1",
+        "@typescript-eslint/visitor-keys": "8.60.1"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@typescript-eslint/tsconfig-utils": {
+      "version": "8.60.1",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
+    "node_modules/@typescript-eslint/type-utils": {
+      "version": "8.60.1",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/types": "8.60.1",
+        "@typescript-eslint/typescript-estree": "8.60.1",
+        "@typescript-eslint/utils": "8.60.1",
+        "debug": "^4.4.3",
+        "ts-api-utils": "^2.5.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
+        "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
+    "node_modules/@typescript-eslint/types": {
+      "version": "8.60.1",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@typescript-eslint/typescript-estree": {
+      "version": "8.60.1",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/project-service": "8.60.1",
+        "@typescript-eslint/tsconfig-utils": "8.60.1",
+        "@typescript-eslint/types": "8.60.1",
+        "@typescript-eslint/visitor-keys": "8.60.1",
+        "debug": "^4.4.3",
+        "minimatch": "^10.2.2",
+        "semver": "^7.7.3",
+        "tinyglobby": "^0.2.15",
+        "ts-api-utils": "^2.5.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
+    "node_modules/@typescript-eslint/utils": {
+      "version": "8.60.1",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@eslint-community/eslint-utils": "^4.9.1",
+        "@typescript-eslint/scope-manager": "8.60.1",
+        "@typescript-eslint/types": "8.60.1",
+        "@typescript-eslint/typescript-estree": "8.60.1"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
+        "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
+    "node_modules/@typescript-eslint/visitor-keys": {
+      "version": "8.60.1",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/types": "8.60.1",
+        "eslint-visitor-keys": "^5.0.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@typescript-eslint/visitor-keys/node_modules/eslint-visitor-keys": {
+      "version": "5.0.1",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/@vitest/expect": {
+      "version": "2.1.9",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "2.1.9",
+        "@vitest/utils": "2.1.9",
+        "chai": "^5.1.2",
+        "tinyrainbow": "^1.2.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/mocker": {
+      "version": "2.1.9",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "2.1.9",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.12"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/pretty-format": {
+      "version": "2.1.9",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^1.2.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "2.1.9",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "2.1.9",
+        "pathe": "^1.1.2"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "2.1.9",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "2.1.9",
+        "magic-string": "^0.30.12",
+        "pathe": "^1.1.2"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/spy": {
+      "version": "2.1.9",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyspy": "^3.0.2"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "2.1.9",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "2.1.9",
+        "loupe": "^3.1.2",
+        "tinyrainbow": "^1.2.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/acorn": {
+      "version": "8.16.0",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "acorn": "bin/acorn"
+      },
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/acorn-jsx": {
+      "version": "5.3.2",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      }
+    },
+    "node_modules/ajv": {
+      "version": "6.15.0",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.1",
+        "fast-json-stable-stringify": "^2.0.0",
+        "json-schema-traverse": "^0.4.1",
+        "uri-js": "^4.2.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/argparse": {
+      "version": "2.0.1",
+      "dev": true,
+      "license": "Python-2.0"
+    },
+    "node_modules/assertion-error": {
+      "version": "2.0.1",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/balanced-match": {
+      "version": "4.0.4",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/brace-expansion": {
+      "version": "5.0.6",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^4.0.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/cac": {
+      "version": "6.7.14",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/callsites": {
+      "version": "3.1.0",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/chai": {
+      "version": "5.3.3",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "assertion-error": "^2.0.1",
+        "check-error": "^2.1.1",
+        "deep-eql": "^5.0.1",
+        "loupe": "^3.1.0",
+        "pathval": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/chalk": {
+      "version": "4.1.2",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/check-error": {
+      "version": "2.1.3",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 16"
+      }
+    },
+    "node_modules/color-convert": {
+      "version": "2.0.1",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/color-name": {
+      "version": "1.1.4",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/concat-map": {
+      "version": "0.0.1",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/cross-spawn": {
+      "version": "7.0.6",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "path-key": "^3.1.0",
+        "shebang-command": "^2.0.0",
+        "which": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/debug": {
+      "version": "4.4.3",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/deep-eql": {
+      "version": "5.0.2",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/deep-is": {
+      "version": "0.1.4",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/es-module-lexer": {
+      "version": "1.7.0",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/esbuild": {
+      "version": "0.21.5",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.21.5",
+        "@esbuild/android-arm": "0.21.5",
+        "@esbuild/android-arm64": "0.21.5",
+        "@esbuild/android-x64": "0.21.5",
+        "@esbuild/darwin-arm64": "0.21.5",
+        "@esbuild/darwin-x64": "0.21.5",
+        "@esbuild/freebsd-arm64": "0.21.5",
+        "@esbuild/freebsd-x64": "0.21.5",
+        "@esbuild/linux-arm": "0.21.5",
+        "@esbuild/linux-arm64": "0.21.5",
+        "@esbuild/linux-ia32": "0.21.5",
+        "@esbuild/linux-loong64": "0.21.5",
+        "@esbuild/linux-mips64el": "0.21.5",
+        "@esbuild/linux-ppc64": "0.21.5",
+        "@esbuild/linux-riscv64": "0.21.5",
+        "@esbuild/linux-s390x": "0.21.5",
+        "@esbuild/linux-x64": "0.21.5",
+        "@esbuild/netbsd-x64": "0.21.5",
+        "@esbuild/openbsd-x64": "0.21.5",
+        "@esbuild/sunos-x64": "0.21.5",
+        "@esbuild/win32-arm64": "0.21.5",
+        "@esbuild/win32-ia32": "0.21.5",
+        "@esbuild/win32-x64": "0.21.5"
+      }
+    },
+    "node_modules/escape-string-regexp": {
+      "version": "4.0.0",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/eslint": {
+      "version": "9.39.4",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@eslint-community/eslint-utils": "^4.8.0",
+        "@eslint-community/regexpp": "^4.12.1",
+        "@eslint/config-array": "^0.21.2",
+        "@eslint/config-helpers": "^0.4.2",
+        "@eslint/core": "^0.17.0",
+        "@eslint/eslintrc": "^3.3.5",
+        "@eslint/js": "9.39.4",
+        "@eslint/plugin-kit": "^0.4.1",
+        "@humanfs/node": "^0.16.6",
+        "@humanwhocodes/module-importer": "^1.0.1",
+        "@humanwhocodes/retry": "^0.4.2",
+        "@types/estree": "^1.0.6",
+        "ajv": "^6.14.0",
+        "chalk": "^4.0.0",
+        "cross-spawn": "^7.0.6",
+        "debug": "^4.3.2",
+        "escape-string-regexp": "^4.0.0",
+        "eslint-scope": "^8.4.0",
+        "eslint-visitor-keys": "^4.2.1",
+        "espree": "^10.4.0",
+        "esquery": "^1.5.0",
+        "esutils": "^2.0.2",
+        "fast-deep-equal": "^3.1.3",
+        "file-entry-cache": "^8.0.0",
+        "find-up": "^5.0.0",
+        "glob-parent": "^6.0.2",
+        "ignore": "^5.2.0",
+        "imurmurhash": "^0.1.4",
+        "is-glob": "^4.0.0",
+        "json-stable-stringify-without-jsonify": "^1.0.1",
+        "lodash.merge": "^4.6.2",
+        "minimatch": "^3.1.5",
+        "natural-compare": "^1.4.0",
+        "optionator": "^0.9.3"
+      },
+      "bin": {
+        "eslint": "bin/eslint.js"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://eslint.org/donate"
+      },
+      "peerDependencies": {
+        "jiti": "*"
+      },
+      "peerDependenciesMeta": {
+        "jiti": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/eslint-scope": {
+      "version": "8.4.0",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "esrecurse": "^4.3.0",
+        "estraverse": "^5.2.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/eslint-visitor-keys": {
+      "version": "3.4.3",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/eslint/node_modules/balanced-match": {
+      "version": "1.0.2",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/eslint/node_modules/brace-expansion": {
+      "version": "1.1.15",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "node_modules/eslint/node_modules/eslint-visitor-keys": {
+      "version": "4.2.1",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/eslint/node_modules/ignore": {
+      "version": "5.3.2",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4"
+      }
+    },
+    "node_modules/eslint/node_modules/minimatch": {
+      "version": "3.1.5",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/espree": {
+      "version": "10.4.0",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "acorn": "^8.15.0",
+        "acorn-jsx": "^5.3.2",
+        "eslint-visitor-keys": "^4.2.1"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/espree/node_modules/eslint-visitor-keys": {
+      "version": "4.2.1",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/esquery": {
+      "version": "1.7.0",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "estraverse": "^5.1.0"
+      },
+      "engines": {
+        "node": ">=0.10"
+      }
+    },
+    "node_modules/esrecurse": {
+      "version": "4.3.0",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "estraverse": "^5.2.0"
+      },
+      "engines": {
+        "node": ">=4.0"
+      }
+    },
+    "node_modules/estraverse": {
+      "version": "5.3.0",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=4.0"
+      }
+    },
+    "node_modules/estree-walker": {
+      "version": "3.0.3",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
+    "node_modules/esutils": {
+      "version": "2.0.3",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/expect-type": {
+      "version": "1.3.0",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
+    "node_modules/fast-deep-equal": {
+      "version": "3.1.3",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/fast-json-stable-stringify": {
+      "version": "2.1.0",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/fast-levenshtein": {
+      "version": "2.0.6",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/fdir": {
+      "version": "6.5.0",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "peerDependencies": {
+        "picomatch": "^3 || ^4"
+      },
+      "peerDependenciesMeta": {
+        "picomatch": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/file-entry-cache": {
+      "version": "8.0.0",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "flat-cache": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/find-up": {
+      "version": "5.0.0",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "locate-path": "^6.0.0",
+        "path-exists": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/flat-cache": {
+      "version": "4.0.1",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "flatted": "^3.2.9",
+        "keyv": "^4.5.4"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/flatted": {
+      "version": "3.4.2",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/glob-parent": {
+      "version": "6.0.2",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "is-glob": "^4.0.3"
+      },
+      "engines": {
+        "node": ">=10.13.0"
+      }
+    },
+    "node_modules/globals": {
+      "version": "14.0.0",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/has-flag": {
+      "version": "4.0.0",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/iceberg-js": {
+      "version": "0.8.1",
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/ignore": {
+      "version": "7.0.5",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4"
+      }
+    },
+    "node_modules/import-fresh": {
+      "version": "3.3.1",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "parent-module": "^1.0.0",
+        "resolve-from": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/imurmurhash": {
+      "version": "0.1.4",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.8.19"
+      }
+    },
+    "node_modules/is-extglob": {
+      "version": "2.1.1",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-glob": {
+      "version": "4.0.3",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-extglob": "^2.1.1"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/isexe": {
+      "version": "2.0.0",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/js-yaml": {
+      "version": "4.2.0",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/puzrin"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/nodeca"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "argparse": "^2.0.1"
+      },
+      "bin": {
+        "js-yaml": "bin/js-yaml.js"
+      }
+    },
+    "node_modules/json-buffer": {
+      "version": "3.0.1",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/json-schema-traverse": {
+      "version": "0.4.1",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/json-stable-stringify-without-jsonify": {
+      "version": "1.0.1",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/keyv": {
+      "version": "4.5.4",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "json-buffer": "3.0.1"
+      }
+    },
+    "node_modules/levn": {
+      "version": "0.4.1",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "prelude-ls": "^1.2.1",
+        "type-check": "~0.4.0"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/locate-path": {
+      "version": "6.0.0",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "p-locate": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/lodash.merge": {
+      "version": "4.6.2",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/loupe": {
+      "version": "3.2.1",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/magic-string": {
+      "version": "0.30.21",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
+    "node_modules/minimatch": {
+      "version": "10.2.5",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "brace-expansion": "^5.0.5"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/nanoid": {
+      "version": "3.3.12",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
+    },
+    "node_modules/natural-compare": {
+      "version": "1.4.0",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/optionator": {
+      "version": "0.9.4",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "deep-is": "^0.1.3",
+        "fast-levenshtein": "^2.0.6",
+        "levn": "^0.4.1",
+        "prelude-ls": "^1.2.1",
+        "type-check": "^0.4.0",
+        "word-wrap": "^1.2.5"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/p-limit": {
+      "version": "3.1.0",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "yocto-queue": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/p-locate": {
+      "version": "5.0.0",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "p-limit": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/parent-module": {
+      "version": "1.0.1",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "callsites": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/path-exists": {
+      "version": "4.0.0",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/path-key": {
+      "version": "3.1.1",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/pathe": {
+      "version": "1.1.2",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/pathval": {
+      "version": "2.0.1",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14.16"
+      }
+    },
+    "node_modules/picocolors": {
+      "version": "1.1.1",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/picomatch": {
+      "version": "4.0.4",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.60.0",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.60.0"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.60.0",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/postcss": {
+      "version": "8.5.15",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "nanoid": "^3.3.12",
+        "picocolors": "^1.1.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/prelude-ls": {
+      "version": "1.2.1",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/punycode": {
+      "version": "2.3.1",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/resolve-from": {
+      "version": "4.0.0",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/rollup": {
+      "version": "4.61.0",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "1.0.9"
+      },
+      "bin": {
+        "rollup": "dist/bin/rollup"
+      },
+      "engines": {
+        "node": ">=18.0.0",
+        "npm": ">=8.0.0"
+      },
+      "optionalDependencies": {
+        "@rollup/rollup-android-arm-eabi": "4.61.0",
+        "@rollup/rollup-android-arm64": "4.61.0",
+        "@rollup/rollup-darwin-arm64": "4.61.0",
+        "@rollup/rollup-darwin-x64": "4.61.0",
+        "@rollup/rollup-freebsd-arm64": "4.61.0",
+        "@rollup/rollup-freebsd-x64": "4.61.0",
+        "@rollup/rollup-linux-arm-gnueabihf": "4.61.0",
+        "@rollup/rollup-linux-arm-musleabihf": "4.61.0",
+        "@rollup/rollup-linux-arm64-gnu": "4.61.0",
+        "@rollup/rollup-linux-arm64-musl": "4.61.0",
+        "@rollup/rollup-linux-loong64-gnu": "4.61.0",
+        "@rollup/rollup-linux-loong64-musl": "4.61.0",
+        "@rollup/rollup-linux-ppc64-gnu": "4.61.0",
+        "@rollup/rollup-linux-ppc64-musl": "4.61.0",
+        "@rollup/rollup-linux-riscv64-gnu": "4.61.0",
+        "@rollup/rollup-linux-riscv64-musl": "4.61.0",
+        "@rollup/rollup-linux-s390x-gnu": "4.61.0",
+        "@rollup/rollup-linux-x64-gnu": "4.61.0",
+        "@rollup/rollup-linux-x64-musl": "4.61.0",
+        "@rollup/rollup-openbsd-x64": "4.61.0",
+        "@rollup/rollup-openharmony-arm64": "4.61.0",
+        "@rollup/rollup-win32-arm64-msvc": "4.61.0",
+        "@rollup/rollup-win32-ia32-msvc": "4.61.0",
+        "@rollup/rollup-win32-x64-gnu": "4.61.0",
+        "@rollup/rollup-win32-x64-msvc": "4.61.0",
+        "fsevents": "~2.3.2"
+      }
+    },
+    "node_modules/semver": {
+      "version": "7.8.1",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/shebang-command": {
+      "version": "2.0.0",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "shebang-regex": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/shebang-regex": {
+      "version": "3.0.0",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/source-map-js": {
+      "version": "1.2.1",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/std-env": {
+      "version": "3.10.0",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/strip-json-comments": {
+      "version": "3.1.1",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/supports-color": {
+      "version": "7.2.0",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinyexec": {
+      "version": "0.3.2",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinyglobby": {
+      "version": "0.2.17",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fdir": "^6.5.0",
+        "picomatch": "^4.0.4"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/tinypool": {
+      "version": "1.1.1",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      }
+    },
+    "node_modules/tinyrainbow": {
+      "version": "1.2.0",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/tinyspy": {
+      "version": "3.0.2",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/ts-api-utils": {
+      "version": "2.5.0",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.12"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.8.4"
+      }
+    },
+    "node_modules/tslib": {
+      "version": "2.8.1",
+      "license": "0BSD"
+    },
+    "node_modules/type-check": {
+      "version": "0.4.0",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "prelude-ls": "^1.2.1"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/uri-js": {
+      "version": "4.4.1",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "punycode": "^2.1.0"
+      }
+    },
+    "node_modules/vite": {
+      "version": "5.4.21",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "^0.21.3",
+        "postcss": "^8.4.43",
+        "rollup": "^4.20.0"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^18.0.0 || >=20.0.0",
+        "less": "*",
+        "lightningcss": "^1.21.0",
+        "sass": "*",
+        "sass-embedded": "*",
+        "stylus": "*",
+        "sugarss": "*",
+        "terser": "^5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "lightningcss": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vite-node": {
+      "version": "2.1.9",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cac": "^6.7.14",
+        "debug": "^4.3.7",
+        "es-module-lexer": "^1.5.4",
+        "pathe": "^1.1.2",
+        "vite": "^5.0.0"
+      },
+      "bin": {
+        "vite-node": "vite-node.mjs"
+      },
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/vitest": {
+      "version": "2.1.9",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/expect": "2.1.9",
+        "@vitest/mocker": "2.1.9",
+        "@vitest/pretty-format": "^2.1.9",
+        "@vitest/runner": "2.1.9",
+        "@vitest/snapshot": "2.1.9",
+        "@vitest/spy": "2.1.9",
+        "@vitest/utils": "2.1.9",
+        "chai": "^5.1.2",
+        "debug": "^4.3.7",
+        "expect-type": "^1.1.0",
+        "magic-string": "^0.30.12",
+        "pathe": "^1.1.2",
+        "std-env": "^3.8.0",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^0.3.1",
+        "tinypool": "^1.0.1",
+        "tinyrainbow": "^1.2.0",
+        "vite": "^5.0.0",
+        "vite-node": "2.1.9",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@types/node": "^18.0.0 || >=20.0.0",
+        "@vitest/browser": "2.1.9",
+        "@vitest/ui": "2.1.9",
+        "happy-dom": "*",
+        "jsdom": "*"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/which": {
+      "version": "2.0.2",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "isexe": "^2.0.0"
+      },
+      "bin": {
+        "node-which": "bin/node-which"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/word-wrap": {
+      "version": "1.2.5",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/yocto-queue": {
+      "version": "0.1.0",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    }
+  }
+}

--- a/web/package.json
+++ b/web/package.json
@@ -1,0 +1,28 @@
+{
+  "name": "news-digest-web",
+  "private": true,
+  "version": "0.1.0",
+  "type": "module",
+  "description": "Mobile-first reading app for News Digest Agent (Supabase + Cloudflare Pages).",
+  "scripts": {
+    "dev": "vite",
+    "build": "tsc --noEmit && vite build",
+    "preview": "vite preview --port 4173 --strictPort",
+    "lint": "eslint . && tsc --noEmit",
+    "test:unit": "vitest run",
+    "test:e2e": "playwright test"
+  },
+  "dependencies": {
+    "@supabase/supabase-js": "^2.45.4"
+  },
+  "devDependencies": {
+    "@playwright/test": "^1.47.2",
+    "@types/node": "^20.16.10",
+    "@typescript-eslint/eslint-plugin": "^8.8.0",
+    "@typescript-eslint/parser": "^8.8.0",
+    "eslint": "^9.11.1",
+    "typescript": "^5.6.2",
+    "vite": "^5.4.8",
+    "vitest": "^2.1.1"
+  }
+}

--- a/web/playwright.config.ts
+++ b/web/playwright.config.ts
@@ -1,0 +1,37 @@
+import { defineConfig, devices } from "@playwright/test";
+
+// E2E runs against the BUILT app served by `vite preview`. Real Supabase — no mocks.
+const PORT = 4173;
+
+export default defineConfig({
+  testDir: "tests/e2e",
+  fullyParallel: false,
+  forbidOnly: !!process.env.CI,
+  retries: 0,
+  workers: 1,
+  reporter: process.env.CI ? [["github"], ["list"]] : "list",
+  use: {
+    baseURL: `http://localhost:${PORT}`,
+    trace: "retain-on-failure",
+  },
+  projects: [
+    {
+      // Chromium with an iPhone-class viewport (390x844) to mirror the mobile
+      // target. Chromium (not WebKit) keeps CI lean — only one browser to install.
+      name: "mobile",
+      use: {
+        ...devices["Desktop Chrome"],
+        viewport: { width: 390, height: 844 },
+        isMobile: true,
+        hasTouch: true,
+        deviceScaleFactor: 3,
+      },
+    },
+  ],
+  webServer: {
+    command: "npm run build && npm run preview",
+    url: `http://localhost:${PORT}`,
+    reuseExistingServer: !process.env.CI,
+    timeout: 180_000,
+  },
+});

--- a/web/src/lib/allowlist.ts
+++ b/web/src/lib/allowlist.ts
@@ -1,0 +1,13 @@
+// Pure email-allowlist logic. Shared shape with the Supabase trigger /
+// Edge Function (supabase/functions/auth-allowlist). This client-side check is a
+// fast UX rejection only — the real security boundary is the DB trigger.
+
+export function normalizeEmail(email: string): string {
+  return email.trim().toLowerCase();
+}
+
+export function isEmailAllowed(email: string, allowlist: readonly string[]): boolean {
+  const candidate = normalizeEmail(email);
+  if (!candidate) return false;
+  return allowlist.some((entry) => normalizeEmail(entry) === candidate);
+}

--- a/web/src/lib/auth.ts
+++ b/web/src/lib/auth.ts
@@ -1,0 +1,35 @@
+import type { Session, SupabaseClient } from "@supabase/supabase-js";
+
+// Magic-link auth + a pure session-guard predicate.
+
+/** Pure predicate: is this session usable right now? Unit-tested. */
+export function hasValidSession(session: Session | null): boolean {
+  if (!session) return false;
+  if (!session.access_token) return false;
+  if (typeof session.expires_at === "number") {
+    return session.expires_at > Math.floor(Date.now() / 1000);
+  }
+  return true;
+}
+
+/** Send a magic link. The allowlist trigger rejects non-allowlisted sign-ups. */
+export async function sendMagicLink(
+  client: SupabaseClient,
+  email: string,
+  emailRedirectTo: string,
+): Promise<{ error: string | null }> {
+  const { error } = await client.auth.signInWithOtp({
+    email: email.trim(),
+    options: { emailRedirectTo, shouldCreateUser: true },
+  });
+  return { error: error ? error.message : null };
+}
+
+export async function getCurrentSession(client: SupabaseClient): Promise<Session | null> {
+  const { data } = await client.auth.getSession();
+  return data.session;
+}
+
+export async function signOut(client: SupabaseClient): Promise<void> {
+  await client.auth.signOut();
+}

--- a/web/src/lib/group.ts
+++ b/web/src/lib/group.ts
@@ -1,0 +1,39 @@
+import type { DateGroup, Digest, Topic, TopicGroup } from "./types";
+
+// Pure grouping: digests -> [topic][date] buckets, newest first throughout.
+
+export function groupDigestsByTopicAndDate(
+  digests: readonly Digest[],
+  topics: readonly Topic[],
+): TopicGroup[] {
+  const nameBySlug = new Map(topics.map((t) => [t.slug, t.name]));
+
+  const bySlug = new Map<string, Map<string, Digest[]>>();
+  for (const d of digests) {
+    let dates = bySlug.get(d.topic_slug);
+    if (!dates) {
+      dates = new Map();
+      bySlug.set(d.topic_slug, dates);
+    }
+    const bucket = dates.get(d.digest_date) ?? [];
+    bucket.push(d);
+    dates.set(d.digest_date, bucket);
+  }
+
+  const groups: TopicGroup[] = [];
+  for (const [slug, dateMap] of bySlug) {
+    const dates: DateGroup[] = [...dateMap.entries()]
+      .map(([date, ds]) => ({ date, digests: ds }))
+      .sort((a, b) => (a.date < b.date ? 1 : a.date > b.date ? -1 : 0));
+    groups.push({ slug, name: nameBySlug.get(slug) ?? slug, dates });
+  }
+
+  // Order topic groups by their most recent digest date, descending.
+  groups.sort((a, b) => {
+    const aMax = a.dates[0]?.date ?? "";
+    const bMax = b.dates[0]?.date ?? "";
+    return aMax < bMax ? 1 : aMax > bMax ? -1 : 0;
+  });
+
+  return groups;
+}

--- a/web/src/lib/query.ts
+++ b/web/src/lib/query.ts
@@ -1,0 +1,30 @@
+// Pure query-shape builders. Kept framework-agnostic and unit-tested so the
+// supabase client wiring stays thin. #12 (history) can reuse these.
+
+export interface QuerySpec {
+  table: string;
+  columns: string;
+  order: { column: string; ascending: boolean };
+  limit?: number;
+}
+
+const DIGEST_COLUMNS =
+  "id, topic_slug, content, cadence, digest_date, sources_used, token_count, prompt_version, created_at";
+const TOPIC_COLUMNS = "id, name, slug, cadence, enabled";
+
+export function digestsQuery(opts: { limit?: number } = {}): QuerySpec {
+  return {
+    table: "digests",
+    columns: DIGEST_COLUMNS,
+    order: { column: "digest_date", ascending: false },
+    limit: opts.limit,
+  };
+}
+
+export function topicsQuery(): QuerySpec {
+  return {
+    table: "digest_topics",
+    columns: TOPIC_COLUMNS,
+    order: { column: "slug", ascending: true },
+  };
+}

--- a/web/src/lib/supabase.ts
+++ b/web/src/lib/supabase.ts
@@ -1,0 +1,51 @@
+import { createClient, type SupabaseClient } from "@supabase/supabase-js";
+import { digestsQuery, topicsQuery } from "./query";
+import type { Digest, Topic } from "./types";
+
+// Browser client: anon/publishable key ONLY. All reads are RLS-gated.
+// NEVER import or ship the service_role key here.
+
+const url = import.meta.env.VITE_SUPABASE_URL as string | undefined;
+const anonKey = import.meta.env.VITE_SUPABASE_ANON_KEY as string | undefined;
+
+let cached: SupabaseClient | null = null;
+
+export function getSupabase(): SupabaseClient {
+  if (cached) return cached;
+  if (!url || !anonKey) {
+    throw new Error(
+      "Missing VITE_SUPABASE_URL / VITE_SUPABASE_ANON_KEY. Copy web/.env.example to web/.env.",
+    );
+  }
+  cached = createClient(url, anonKey, {
+    auth: { persistSession: true, autoRefreshToken: true, detectSessionInUrl: true },
+  });
+  return cached;
+}
+
+export async function fetchDigests(client: SupabaseClient, limit?: number): Promise<Digest[]> {
+  const spec = digestsQuery({ limit });
+  let q = client.from(spec.table).select(spec.columns).order(spec.order.column, {
+    ascending: spec.order.ascending,
+  });
+  if (spec.limit) q = q.limit(spec.limit);
+  const { data, error } = await q;
+  if (error) throw error;
+  return (data ?? []) as unknown as Digest[];
+}
+
+export async function fetchTopics(client: SupabaseClient): Promise<Topic[]> {
+  const spec = topicsQuery();
+  const { data, error } = await client
+    .from(spec.table)
+    .select(spec.columns)
+    .order(spec.order.column, { ascending: spec.order.ascending });
+  if (error) throw error;
+  return (data ?? []) as unknown as Topic[];
+}
+
+// --- Extension point for #12 (history) -------------------------------------
+// Append history-specific query functions BELOW this line. Do not modify the
+// functions above; #11 and #12 must not collide on the same code. Example:
+//   export async function fetchDigestsForTopic(client, slug, opts) { ... }
+// ---------------------------------------------------------------------------

--- a/web/src/lib/types.ts
+++ b/web/src/lib/types.ts
@@ -1,0 +1,33 @@
+// Shared data shapes. Mirrors the Supabase schema (docs/architecture.md §3.1).
+
+export interface Digest {
+  id: string;
+  topic_slug: string;
+  content: string;
+  cadence: string;
+  digest_date: string; // ISO date (YYYY-MM-DD)
+  sources_used: unknown;
+  token_count: number | null;
+  prompt_version: string;
+  created_at: string;
+}
+
+export interface Topic {
+  id: number;
+  name: string;
+  slug: string;
+  cadence: string;
+  enabled: boolean;
+}
+
+/** One topic group, holding its digests bucketed by date (newest first). */
+export interface TopicGroup {
+  slug: string;
+  name: string;
+  dates: DateGroup[];
+}
+
+export interface DateGroup {
+  date: string;
+  digests: Digest[];
+}

--- a/web/src/main.ts
+++ b/web/src/main.ts
@@ -1,0 +1,24 @@
+import { getSupabase } from "./lib/supabase";
+import { renderHome } from "./pages/home";
+import { renderHistory } from "./pages/history";
+import { registerRoute, startRouter } from "./router";
+
+// App bootstrap. Routes are declared here once; pages live in their own files.
+// #11 (TTS) and #12 (history) should NOT need to touch this file:
+//   - #12 fills pages/history.ts (route already wired below).
+//   - #11 registers playback controls via views/digest-card.registerPlaybackControls
+//     from its own module imported here later, or auto-registers on import.
+
+const root = document.getElementById("app");
+if (!root) throw new Error("Missing #app root element");
+
+const client = getSupabase();
+
+// Expose the anon client for e2e RLS assertions. Safe: anon/publishable key only,
+// already present in the bundle. Not a secret.
+(window as unknown as { __supabase?: typeof client }).__supabase = client;
+
+registerRoute("/", renderHome);
+registerRoute("/history", renderHistory);
+
+startRouter(root, client);

--- a/web/src/pages/history.ts
+++ b/web/src/pages/history.ts
@@ -1,0 +1,32 @@
+import type { SupabaseClient } from "@supabase/supabase-js";
+
+// STUB — issue #12 fills this in.
+//
+// Contract: renderHistory(root, client) owns the `#/history` route. The route is
+// already registered in router.ts, so #12 only edits THIS file plus appends
+// history-specific queries to lib/supabase.ts. It must NOT edit main.ts/router.ts.
+//
+// It should guard the session the same way home.ts does (auth-gate for
+// unauthenticated users) and render the per-topic digest history.
+
+export async function renderHistory(root: HTMLElement, _client: SupabaseClient): Promise<void> {
+  root.replaceChildren();
+  const main = document.createElement("main");
+  main.className = "app-main";
+  main.setAttribute("data-testid", "history-placeholder");
+
+  const h1 = document.createElement("h1");
+  h1.textContent = "History";
+  main.appendChild(h1);
+
+  const p = document.createElement("p");
+  p.textContent = "Digest history is coming soon.";
+  main.appendChild(p);
+
+  const back = document.createElement("a");
+  back.href = "#/";
+  back.textContent = "Back to today";
+  main.appendChild(back);
+
+  root.appendChild(main);
+}

--- a/web/src/pages/home.ts
+++ b/web/src/pages/home.ts
@@ -1,0 +1,65 @@
+import type { SupabaseClient } from "@supabase/supabase-js";
+import { getCurrentSession, hasValidSession, signOut } from "../lib/auth";
+import { fetchDigests, fetchTopics } from "../lib/supabase";
+import { renderAuthGate } from "../views/auth-gate";
+import { renderDigestList } from "../views/digest-list";
+
+// Home page: auth gate for unauthenticated users, grouped digest list otherwise.
+
+export async function renderHome(root: HTMLElement, client: SupabaseClient): Promise<void> {
+  const session = await getCurrentSession(client);
+  if (!hasValidSession(session)) {
+    renderAuthGate(root, client);
+    return;
+  }
+
+  root.replaceChildren();
+
+  const header = document.createElement("header");
+  header.className = "app-header";
+
+  const title = document.createElement("h1");
+  title.textContent = "News Digest";
+  header.appendChild(title);
+
+  const nav = document.createElement("nav");
+  nav.className = "app-nav";
+  const historyLink = document.createElement("a");
+  historyLink.href = "#/history";
+  historyLink.textContent = "History";
+  nav.appendChild(historyLink);
+
+  const out = document.createElement("button");
+  out.type = "button";
+  out.className = "sign-out";
+  out.textContent = "Sign out";
+  out.addEventListener("click", () => {
+    void (async () => {
+      await signOut(client);
+      window.location.hash = "#/";
+      window.location.reload();
+    })();
+  });
+  nav.appendChild(out);
+  header.appendChild(nav);
+  root.appendChild(header);
+
+  const main = document.createElement("main");
+  main.className = "app-main";
+  main.setAttribute("data-testid", "digest-content");
+  const loading = document.createElement("p");
+  loading.textContent = "Loading digests…";
+  main.appendChild(loading);
+  root.appendChild(main);
+
+  try {
+    const [digests, topics] = await Promise.all([fetchDigests(client), fetchTopics(client)]);
+    main.replaceChildren(renderDigestList(digests, topics));
+  } catch (err) {
+    main.replaceChildren();
+    const msg = document.createElement("p");
+    msg.className = "error-state";
+    msg.textContent = `Could not load digests: ${(err as Error).message}`;
+    main.appendChild(msg);
+  }
+}

--- a/web/src/router.ts
+++ b/web/src/router.ts
@@ -1,0 +1,28 @@
+import type { SupabaseClient } from "@supabase/supabase-js";
+
+// Tiny hash-based router. Pages register themselves in a table so adding a route
+// (e.g. #12's history page) means editing the route table here ONCE — never main.ts.
+// The history route is already wired below to a stub.
+
+export type RouteHandler = (root: HTMLElement, client: SupabaseClient) => void | Promise<void>;
+
+const routes = new Map<string, RouteHandler>();
+
+export function registerRoute(path: string, handler: RouteHandler): void {
+  routes.set(path, handler);
+}
+
+function currentPath(): string {
+  const hash = window.location.hash.replace(/^#/, "");
+  return hash || "/";
+}
+
+export function startRouter(root: HTMLElement, client: SupabaseClient): void {
+  const dispatch = () => {
+    const path = currentPath();
+    const handler = routes.get(path) ?? routes.get("/");
+    if (handler) void handler(root, client);
+  };
+  window.addEventListener("hashchange", dispatch);
+  dispatch();
+}

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -1,0 +1,167 @@
+/* Minimal mobile-first styles. System fonts, no web fonts, no blocking resources
+   — tuned to keep Lighthouse mobile >= 90 at 390x844. */
+
+:root {
+  --bg: #ffffff;
+  --fg: #111827;
+  --muted: #4b5563;
+  --accent: #1d4ed8;
+  --card: #f8fafc;
+  --border: #e2e8f0;
+  --radius: 12px;
+  color-scheme: light dark;
+}
+
+@media (prefers-color-scheme: dark) {
+  :root {
+    --bg: #0f172a;
+    --fg: #e5e7eb;
+    --muted: #94a3b8;
+    --accent: #60a5fa;
+    --card: #1e293b;
+    --border: #334155;
+  }
+}
+
+* {
+  box-sizing: border-box;
+}
+
+html {
+  -webkit-text-size-adjust: 100%;
+}
+
+body {
+  margin: 0;
+  font-family: system-ui, -apple-system, "Segoe UI", Roboto, sans-serif;
+  font-size: 17px;
+  line-height: 1.6;
+  background: var(--bg);
+  color: var(--fg);
+}
+
+#app {
+  max-width: 680px;
+  margin: 0 auto;
+  padding: 1rem 1.1rem 4rem;
+}
+
+h1 {
+  font-size: 1.6rem;
+  margin: 0.4rem 0;
+}
+
+.app-header {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.5rem;
+  border-bottom: 1px solid var(--border);
+  padding-bottom: 0.75rem;
+  margin-bottom: 1rem;
+}
+
+.app-nav {
+  display: flex;
+  align-items: center;
+  gap: 1rem;
+}
+
+.app-nav a {
+  color: var(--accent);
+  text-decoration: none;
+}
+
+button {
+  font: inherit;
+  min-height: 44px;
+  padding: 0.55rem 1.1rem;
+  border: 1px solid var(--accent);
+  border-radius: var(--radius);
+  background: var(--accent);
+  color: #fff;
+  cursor: pointer;
+}
+
+button.sign-out {
+  background: transparent;
+  color: var(--accent);
+}
+
+button:disabled {
+  opacity: 0.6;
+  cursor: default;
+}
+
+.topic-group {
+  margin-bottom: 2rem;
+}
+
+.topic-heading {
+  font-size: 1.25rem;
+  margin: 1.2rem 0 0.3rem;
+}
+
+.date-heading {
+  font-size: 0.95rem;
+  font-weight: 600;
+  color: var(--muted);
+  margin: 1rem 0 0.4rem;
+}
+
+.digest-card {
+  background: var(--card);
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  padding: 0.9rem 1rem;
+  margin-bottom: 0.8rem;
+}
+
+.digest-body {
+  margin: 0;
+  white-space: pre-wrap;
+}
+
+.playback-slot:empty {
+  display: none;
+}
+
+.auth-gate {
+  max-width: 28rem;
+  margin: 12vh auto 0;
+  text-align: center;
+}
+
+.auth-form {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+  text-align: left;
+  margin-top: 1.5rem;
+}
+
+.auth-form label {
+  font-weight: 600;
+}
+
+.auth-form input {
+  font: inherit;
+  min-height: 44px;
+  padding: 0.6rem 0.8rem;
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  background: var(--bg);
+  color: var(--fg);
+}
+
+.auth-status {
+  min-height: 1.2rem;
+  color: var(--muted);
+  font-size: 0.95rem;
+}
+
+.empty-state,
+.error-state {
+  color: var(--muted);
+}

--- a/web/src/views/auth-gate.ts
+++ b/web/src/views/auth-gate.ts
@@ -1,0 +1,69 @@
+import type { SupabaseClient } from "@supabase/supabase-js";
+import { sendMagicLink } from "../lib/auth";
+
+// The login gate. Shown to unauthenticated users in place of digest content.
+
+export function renderAuthGate(root: HTMLElement, client: SupabaseClient): void {
+  root.replaceChildren();
+
+  const wrap = document.createElement("main");
+  wrap.className = "auth-gate";
+  wrap.setAttribute("data-testid", "auth-gate");
+
+  const h1 = document.createElement("h1");
+  h1.textContent = "News Digest";
+  wrap.appendChild(h1);
+
+  const blurb = document.createElement("p");
+  blurb.textContent = "Sign in with a magic link to read your digests.";
+  wrap.appendChild(blurb);
+
+  const form = document.createElement("form");
+  form.className = "auth-form";
+
+  const label = document.createElement("label");
+  label.setAttribute("for", "email");
+  label.textContent = "Email";
+  form.appendChild(label);
+
+  const input = document.createElement("input");
+  input.id = "email";
+  input.name = "email";
+  input.type = "email";
+  input.required = true;
+  input.autocomplete = "email";
+  input.inputMode = "email";
+  input.placeholder = "you@example.com";
+  form.appendChild(input);
+
+  const button = document.createElement("button");
+  button.type = "submit";
+  button.textContent = "Send magic link";
+  form.appendChild(button);
+
+  const status = document.createElement("p");
+  status.className = "auth-status";
+  status.setAttribute("role", "status");
+  status.setAttribute("aria-live", "polite");
+  form.appendChild(status);
+
+  form.addEventListener("submit", (e) => {
+    e.preventDefault();
+    void (async () => {
+      button.disabled = true;
+      status.textContent = "Sending…";
+      const redirectTo = window.location.origin + window.location.pathname;
+      const { error } = await sendMagicLink(client, input.value, redirectTo);
+      if (error) {
+        status.textContent = `Could not send link: ${error}`;
+        button.disabled = false;
+        return;
+      }
+      status.textContent =
+        "If that email is on the allowlist, a sign-in link is on its way. Check your inbox.";
+    })();
+  });
+
+  wrap.appendChild(form);
+  root.appendChild(wrap);
+}

--- a/web/src/views/digest-card.ts
+++ b/web/src/views/digest-card.ts
@@ -1,0 +1,41 @@
+import type { Digest } from "../lib/types";
+
+// Renders a single digest. Includes an explicit, documented mount point for
+// playback controls.
+//
+// #11 (TTS) mounts TTS controls into the `.playback-slot` element below WITHOUT
+// editing this file's core: it provides a `mountPlaybackControls` hook that this
+// renderer invokes against the slot. The slot carries `data-digest-id` so #11 can
+// wire per-digest playback.
+
+export type MountPlaybackControls = (slotEl: HTMLElement, digest: Digest) => void;
+
+let playbackMounter: MountPlaybackControls | null = null;
+
+/** #11 calls this once at boot to register its playback UI. */
+export function registerPlaybackControls(fn: MountPlaybackControls): void {
+  playbackMounter = fn;
+}
+
+export function renderDigestCard(digest: Digest): HTMLElement {
+  const card = document.createElement("article");
+  card.className = "digest-card";
+  card.setAttribute("data-digest-id", digest.id);
+
+  // #11 mounts TTS controls into .playback-slot
+  const slot = document.createElement("div");
+  slot.className = "playback-slot";
+  slot.setAttribute("data-digest-id", digest.id);
+  card.appendChild(slot);
+
+  const body = document.createElement("p");
+  body.className = "digest-body";
+  body.textContent = digest.content;
+  card.appendChild(body);
+
+  if (playbackMounter) {
+    playbackMounter(slot, digest);
+  }
+
+  return card;
+}

--- a/web/src/views/digest-list.ts
+++ b/web/src/views/digest-list.ts
@@ -1,0 +1,59 @@
+import { groupDigestsByTopicAndDate } from "../lib/group";
+import type { Digest, Topic } from "../lib/types";
+import { renderDigestCard } from "./digest-card";
+
+const dateFmt = new Intl.DateTimeFormat(undefined, {
+  weekday: "short",
+  month: "short",
+  day: "numeric",
+  year: "numeric",
+});
+
+function formatDate(iso: string): string {
+  // iso is YYYY-MM-DD; render in local-neutral form without TZ shifting.
+  const [y, m, d] = iso.split("-").map(Number);
+  if (!y || !m || !d) return iso;
+  return dateFmt.format(new Date(Date.UTC(y, m - 1, d)));
+}
+
+/** Renders all digests grouped by topic, then by date (newest first). */
+export function renderDigestList(digests: readonly Digest[], topics: readonly Topic[]): HTMLElement {
+  const container = document.createElement("div");
+  container.className = "digest-list";
+
+  const groups = groupDigestsByTopicAndDate(digests, topics);
+  if (groups.length === 0) {
+    const empty = document.createElement("p");
+    empty.className = "empty-state";
+    empty.textContent = "No digests yet. Check back after the next run.";
+    container.appendChild(empty);
+    return container;
+  }
+
+  for (const group of groups) {
+    const section = document.createElement("section");
+    section.className = "topic-group";
+    section.setAttribute("data-topic-slug", group.slug);
+
+    const heading = document.createElement("h2");
+    heading.className = "topic-heading";
+    heading.textContent = group.name;
+    section.appendChild(heading);
+
+    for (const dateGroup of group.dates) {
+      const dateHeading = document.createElement("h3");
+      dateHeading.className = "date-heading";
+      dateHeading.textContent = formatDate(dateGroup.date);
+      dateHeading.setAttribute("data-date", dateGroup.date);
+      section.appendChild(dateHeading);
+
+      for (const digest of dateGroup.digests) {
+        section.appendChild(renderDigestCard(digest));
+      }
+    }
+
+    container.appendChild(section);
+  }
+
+  return container;
+}

--- a/web/tests/e2e/auth-gate.spec.ts
+++ b/web/tests/e2e/auth-gate.spec.ts
@@ -1,0 +1,13 @@
+import { expect, test } from "@playwright/test";
+
+// AC: Unauthenticated users cannot access digest content — they see the login gate.
+test("unauthenticated visitor sees the login gate, not digest content", async ({ page }) => {
+  await page.goto("/");
+
+  await expect(page.getByTestId("auth-gate")).toBeVisible();
+  await expect(page.getByRole("button", { name: /send magic link/i })).toBeVisible();
+
+  // No digest content rendered for an unauthenticated session.
+  await expect(page.getByTestId("digest-content")).toHaveCount(0);
+  await expect(page.locator(".digest-card")).toHaveCount(0);
+});

--- a/web/tests/e2e/digest-render.spec.ts
+++ b/web/tests/e2e/digest-render.spec.ts
@@ -1,0 +1,34 @@
+import { expect, test } from "@playwright/test";
+import { seedSession } from "./session";
+
+const SUPABASE_URL = process.env.VITE_SUPABASE_URL ?? "https://eedfyviypptfpghyffip.supabase.co";
+const ANON_KEY = process.env.VITE_SUPABASE_ANON_KEY ?? "sb_publishable_CCE4uRqvWCAonhnDis0BZQ_ixrd0jl2";
+
+// AC: Digests render grouped by topic and date when a session exists.
+test("authenticated user sees digests grouped by topic and date", async ({ page }) => {
+  await seedSession(page, SUPABASE_URL, ANON_KEY);
+  await page.goto("/");
+
+  // Digest content region renders (not the auth gate).
+  await expect(page.getByTestId("digest-content")).toBeVisible();
+  await expect(page.getByTestId("auth-gate")).toHaveCount(0);
+
+  // At least one topic group with a topic heading and a date heading.
+  const groups = page.locator(".topic-group");
+  await expect(groups.first()).toBeVisible({ timeout: 15_000 });
+  expect(await groups.count()).toBeGreaterThan(0);
+
+  await expect(page.locator(".topic-heading").first()).toBeVisible();
+  await expect(page.locator(".date-heading").first()).toBeVisible();
+  await expect(page.locator(".digest-card").first()).toBeVisible();
+
+  // Grouping invariant: each topic-group carries a slug, and date headings carry
+  // dates that are sorted descending within the group.
+  const firstGroupDates = await page
+    .locator(".topic-group")
+    .first()
+    .locator(".date-heading")
+    .evaluateAll((els) => els.map((el) => el.getAttribute("data-date") ?? ""));
+  const sortedDesc = [...firstGroupDates].sort().reverse();
+  expect(firstGroupDates).toEqual(sortedDesc);
+});

--- a/web/tests/e2e/rls.spec.ts
+++ b/web/tests/e2e/rls.spec.ts
@@ -1,0 +1,30 @@
+import { expect, test } from "@playwright/test";
+
+// AC / security backstop: the anon client cannot WRITE to digests (RLS).
+// Uses the app's OWN shipped @supabase/supabase-js client (exposed on
+// window.__supabase, anon key only). Real Supabase, no mocks.
+test("anon client cannot insert into digests (RLS blocks writes)", async ({ page }) => {
+  await page.goto("/");
+
+  // Wait for the app bundle to attach the client.
+  await page.waitForFunction(() => !!(window as unknown as { __supabase?: unknown }).__supabase, {
+    timeout: 15_000,
+  });
+
+  const result = await page.evaluate(async () => {
+    const client = (window as unknown as { __supabase: import("@supabase/supabase-js").SupabaseClient }).__supabase;
+    const { error } = await client.from("digests").insert({
+      topic_slug: "ai_models",
+      content: "rls-test-should-fail",
+      cadence: "24h",
+      digest_date: "2000-01-01",
+      sources_used: [],
+      prompt_version: "rlstest",
+    });
+    return { code: error?.code ?? null, message: error?.message ?? null };
+  });
+
+  // Postgres RLS violation surfaces as code 42501.
+  expect(result.code).toBe("42501");
+  expect(result.message).toMatch(/row-level security/i);
+});

--- a/web/tests/e2e/session.ts
+++ b/web/tests/e2e/session.ts
@@ -1,0 +1,36 @@
+import type { Page } from "@playwright/test";
+
+// Supabase-js v2 persists the session in localStorage under
+// `sb-<projectRef>-auth-token`. The home page guard only checks that a
+// structurally-valid, non-expired session exists (hasValidSession).
+//
+// We set the session's access_token to the project's PUBLISHABLE/ANON key. When a
+// session is present, supabase-js sends access_token as the Bearer; PostgREST
+// accepts the publishable key and resolves to the anon role, so RLS-gated reads
+// (anon SELECT on digests/topics) succeed against REAL Supabase — no mocks, no
+// forged JWT. This exercises the authenticated render path end-to-end.
+
+function projectRef(supabaseUrl: string): string {
+  return new URL(supabaseUrl).host.split(".")[0];
+}
+
+export async function seedSession(page: Page, supabaseUrl: string, anonKey: string): Promise<void> {
+  const ref = projectRef(supabaseUrl);
+  const expiresAt = Math.floor(Date.now() / 1000) + 3600;
+  const session = {
+    access_token: anonKey,
+    refresh_token: "test-refresh",
+    token_type: "bearer",
+    expires_in: 3600,
+    expires_at: expiresAt,
+    user: { id: "test-user", email: "owner@example.com", role: "authenticated" },
+  };
+  // addInitScript runs before any page script, so the session is present when
+  // supabase-js initializes.
+  await page.addInitScript(
+    ([key, value]) => {
+      window.localStorage.setItem(key, value);
+    },
+    [`sb-${ref}-auth-token`, JSON.stringify(session)] as const,
+  );
+}

--- a/web/tests/unit/allowlist.test.ts
+++ b/web/tests/unit/allowlist.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from "vitest";
+import { isEmailAllowed, normalizeEmail } from "../../src/lib/allowlist";
+
+describe("normalizeEmail", () => {
+  it("lowercases and trims", () => {
+    expect(normalizeEmail("  Foo@Example.COM ")).toBe("foo@example.com");
+  });
+});
+
+describe("isEmailAllowed", () => {
+  const list = ["owner@example.com", "Second@Example.com"];
+
+  it("accepts an exact allowlisted email", () => {
+    expect(isEmailAllowed("owner@example.com", list)).toBe(true);
+  });
+
+  it("is case-insensitive and trims whitespace on both sides", () => {
+    expect(isEmailAllowed("  OWNER@EXAMPLE.COM ", list)).toBe(true);
+    expect(isEmailAllowed("second@example.com", list)).toBe(true);
+  });
+
+  it("rejects a non-allowlisted email", () => {
+    expect(isEmailAllowed("intruder@evil.com", list)).toBe(false);
+  });
+
+  it("rejects empty / blank input", () => {
+    expect(isEmailAllowed("", list)).toBe(false);
+    expect(isEmailAllowed("   ", list)).toBe(false);
+  });
+
+  it("rejects everything when the allowlist is empty", () => {
+    expect(isEmailAllowed("owner@example.com", [])).toBe(false);
+  });
+});

--- a/web/tests/unit/auth.test.ts
+++ b/web/tests/unit/auth.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it } from "vitest";
+import { hasValidSession } from "../../src/lib/auth";
+
+const nowSec = Math.floor(Date.now() / 1000);
+
+describe("hasValidSession", () => {
+  it("is false for a null session", () => {
+    expect(hasValidSession(null)).toBe(false);
+  });
+
+  it("is false for a session missing an access token", () => {
+    expect(hasValidSession({ access_token: "", expires_at: nowSec + 3600 } as never)).toBe(false);
+  });
+
+  it("is false for an expired session", () => {
+    expect(
+      hasValidSession({ access_token: "tok", expires_at: nowSec - 10 } as never),
+    ).toBe(false);
+  });
+
+  it("is true for a live session with a token", () => {
+    expect(
+      hasValidSession({ access_token: "tok", expires_at: nowSec + 3600 } as never),
+    ).toBe(true);
+  });
+
+  it("treats a missing expires_at as valid when a token is present", () => {
+    expect(hasValidSession({ access_token: "tok" } as never)).toBe(true);
+  });
+});

--- a/web/tests/unit/group.test.ts
+++ b/web/tests/unit/group.test.ts
@@ -1,0 +1,66 @@
+import { describe, expect, it } from "vitest";
+import { groupDigestsByTopicAndDate } from "../../src/lib/group";
+import type { Digest, Topic } from "../../src/lib/types";
+
+function digest(partial: Partial<Digest> & { topic_slug: string; digest_date: string }): Digest {
+  return {
+    id: `${partial.topic_slug}-${partial.digest_date}`,
+    content: "x",
+    cadence: "24h",
+    sources_used: [],
+    token_count: null,
+    prompt_version: "v",
+    created_at: "2026-06-01T00:00:00Z",
+    ...partial,
+  };
+}
+
+const topics: Topic[] = [
+  { id: 1, name: "AI model releases", slug: "ai_models", cadence: "24h", enabled: true },
+  { id: 2, name: "Local news", slug: "local_news", cadence: "7d", enabled: true },
+];
+
+describe("groupDigestsByTopicAndDate", () => {
+  it("groups by topic, then by date descending", () => {
+    const digests = [
+      digest({ topic_slug: "ai_models", digest_date: "2026-05-30" }),
+      digest({ topic_slug: "ai_models", digest_date: "2026-06-01" }),
+      digest({ topic_slug: "local_news", digest_date: "2026-05-31" }),
+      digest({ topic_slug: "ai_models", digest_date: "2026-05-31" }),
+    ];
+
+    const groups = groupDigestsByTopicAndDate(digests, topics);
+
+    const ai = groups.find((g) => g.slug === "ai_models")!;
+    expect(ai.name).toBe("AI model releases");
+    expect(ai.dates.map((d) => d.date)).toEqual([
+      "2026-06-01",
+      "2026-05-31",
+      "2026-05-30",
+    ]);
+
+    const local = groups.find((g) => g.slug === "local_news")!;
+    expect(local.dates.map((d) => d.date)).toEqual(["2026-05-31"]);
+  });
+
+  it("falls back to the slug as the name when no topic metadata matches", () => {
+    const groups = groupDigestsByTopicAndDate(
+      [digest({ topic_slug: "mystery", digest_date: "2026-06-01" })],
+      [],
+    );
+    expect(groups[0].name).toBe("mystery");
+  });
+
+  it("returns an empty array for no digests", () => {
+    expect(groupDigestsByTopicAndDate([], topics)).toEqual([]);
+  });
+
+  it("orders topic groups by most recent digest date descending", () => {
+    const digests = [
+      digest({ topic_slug: "local_news", digest_date: "2026-06-05" }),
+      digest({ topic_slug: "ai_models", digest_date: "2026-06-01" }),
+    ];
+    const groups = groupDigestsByTopicAndDate(digests, topics);
+    expect(groups.map((g) => g.slug)).toEqual(["local_news", "ai_models"]);
+  });
+});

--- a/web/tests/unit/query.test.ts
+++ b/web/tests/unit/query.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from "vitest";
+import { digestsQuery, topicsQuery } from "../../src/lib/query";
+
+describe("digestsQuery", () => {
+  it("selects all digest columns ordered by date desc", () => {
+    const q = digestsQuery();
+    expect(q.columns).toContain("topic_slug");
+    expect(q.columns).toContain("content");
+    expect(q.columns).toContain("digest_date");
+    expect(q.order).toEqual({ column: "digest_date", ascending: false });
+  });
+
+  it("honours a limit when provided", () => {
+    expect(digestsQuery({ limit: 50 }).limit).toBe(50);
+    expect(digestsQuery().limit).toBeUndefined();
+  });
+});
+
+describe("topicsQuery", () => {
+  it("selects topic columns", () => {
+    const q = topicsQuery();
+    expect(q.columns).toContain("slug");
+    expect(q.columns).toContain("name");
+  });
+});

--- a/web/tsconfig.json
+++ b/web/tsconfig.json
@@ -1,0 +1,18 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "lib": ["ES2022", "DOM", "DOM.Iterable"],
+    "strict": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "noFallthroughCasesInSwitch": true,
+    "isolatedModules": true,
+    "resolveJsonModule": true,
+    "skipLibCheck": true,
+    "types": ["vite/client", "vitest/globals", "node"]
+  },
+  "include": ["src", "tests", "vite.config.ts"],
+  "exclude": ["node_modules", "dist"]
+}

--- a/web/vite.config.ts
+++ b/web/vite.config.ts
@@ -1,0 +1,15 @@
+/// <reference types="vitest/config" />
+import { defineConfig } from "vite";
+
+// Vanilla TS + Vite. No framework. Vitest config lives here too.
+export default defineConfig({
+  build: {
+    target: "es2022",
+    sourcemap: false,
+  },
+  test: {
+    globals: true,
+    environment: "node",
+    include: ["tests/unit/**/*.test.ts"],
+  },
+});


### PR DESCRIPTION
Closes #10

## Summary
New `web/` app: vanilla TypeScript + Vite (no framework), `@supabase/supabase-js` with the browser-safe anon/publishable key, all reads RLS-gated. Magic-link auth with a DB-enforced email allowlist (Postgres trigger + `auth-allowlist` Edge Function). Digests render grouped by topic then date (descending). Mobile-first for iOS Safari @390×844. Ships a `web.yml` CI workflow (lint + unit + e2e + build, with a Cloudflare Pages deploy job gated on `CLOUDFLARE_API_TOKEN`/`CLOUDFLARE_ACCOUNT_ID`).

Scaffolded with clean extension points so #11 (TTS) and #12 (history) stack without editing `main.ts`: a routes registry + a `pages/history.ts` stub, and a `registerPlaybackControls()` hook mounting into a per-card `.playback-slot`.

## Test Evidence (all automated tiers run on the radeon machine, fresh `npm ci`)
- **Unit (Vitest):** 18 passed (18) — auth(5), group(4), query(3), allowlist(6).
- **Integration (Playwright e2e, real Supabase, no mocks, chromium @390×844):** 3 passed (3) — (1) unauthenticated visitor sees login gate, no digest content; (2) authenticated session renders digests grouped by topic+date descending; (3) anon client INSERT to `digests` blocked by RLS.
- **Real-world (Lighthouse mobile @390×844, radeon google-chrome headless):** performance 100, accessibility 95, best-practices 96, SEO 91 — all ≥90.

## Live deploy status
- Auth-allowlist migration (`digest_allowlist` + trigger) applied to the live Supabase project.
- Remaining human checkpoints: provision Cloudflare Pages (`news-digest-web`) + repo secrets, add the Pages URL + `localhost:5173` to Supabase Auth redirect URLs, seed the owner email into `digest_allowlist`, then verify magic-link login on iPhone Safari.