### PR TITLE
Web Speech API text-to-speech for digest playback (#11)

### DIFF
--- a/.claude/plans/issue-11.md
+++ b/.claude/plans/issue-11.md
@@ -1,0 +1,108 @@
+---
+type: plan
+source-issue: 11
+repo: itomek/itomek-news-digest-agent
+title: "Implement Web Speech API text-to-speech for digest playback"
+created: 2026-06-01
+status: in-progress
+work_type: code-feature
+complexity: standard
+tdd_required: true
+suggested_team_size: 2
+estimated_files_changed: 6
+test_command: "ssh tomas@t-nx-radeon 'bash -lc \"cd ~/ndw-issue11 && npm run test:unit && npm run test:e2e\"'"
+build_command: "ssh tomas@t-nx-radeon 'bash -lc \"cd ~/ndw-issue11 && npm run build\"'"
+lint_command: "ssh tomas@t-nx-radeon 'bash -lc \"cd ~/ndw-issue11 && npm run lint\"'"
+branch: feat/issue-11-tts
+reflection_iterations: 1
+agents_used: [planning, execution, validation]
+---
+
+# Issue #11 — Web Speech API TTS for digest playback
+
+## #10 hooks (mapped)
+
+- `web/src/views/digest-card.ts` exports `registerPlaybackControls(fn: MountPlaybackControls)`
+  and a `MountPlaybackControls = (slotEl: HTMLElement, digest: Digest) => void` type.
+  Each rendered card creates a `.playback-slot` div carrying `data-digest-id`, and invokes
+  the registered mounter against that slot. This is the ONLY hook I implement against.
+- `web/src/main.ts` imports pages once. The single allowed touchpoint: add one import line
+  for `./components/playback` so it auto-registers on boot.
+- `web/styles.css` has `.playback-slot:empty { display:none }`. I will NOT edit styles.css;
+  playback.ts injects a scoped `<style id="tts-styles">` block once on first mount to stay in lane.
+- Cards render newest-first grouped by topic/date (`digest-list.ts`). "Play all today" must
+  enqueue digests in DOM order. The playback registry tracks every mounted digest in order;
+  a play-all bar is mounted into the first card's slot region (a `.tts-playall` element).
+
+## Design
+
+### `web/src/lib/tts.ts` (pure-ish, unit-tested)
+- `stripFormatting(text)`: remove markdown headers (`#`), bold/italic asterisks & underscores,
+  list markers (`-`, `*`, `1.`), links `[text](url)` -> `text`, inline code backticks, blockquote
+  `>`, stray `#`/`*`/`_`. Collapse whitespace. Pure fn — directly unit-tested.
+- `chunkText(text, max=200)`: split on sentence boundaries (`.`/`!`/`?` + space) accumulating
+  up to ~200 chars to dodge iOS long-utterance cutoff. Long sentences split on clause/space.
+  Pure fn — unit-tested.
+- `loadPrefs()/savePrefs()`: voice (URI string) + rate from localStorage keys
+  `tts.voiceURI`, `tts.rate`. Default rate 1.2. Unit-tested for round-trip + defaults.
+- `class TtsPlayer`: wraps `speechSynthesis`. Holds a `playlist` (array of {id, text}).
+  - `play(items)`: builds queue, sets current index, speaks first chunk. First `speak()` must
+    fire from the caller's user gesture (we never auto-speak).
+  - chunk queue: each item is split via chunkText; `onend` advances to next chunk, then next item.
+  - `pause()/resume()/stop()`: map to speechSynthesis. stop clears queue + resets index.
+  - `skip(seconds=30)`: estimate words/sec from rate (~2.7 wps * rate baseline 150wpm),
+    advance within current item's remaining text by that many words → re-chunk + speak.
+    Unit-tested: given text + rate, skip advances the word offset by the expected count.
+  - `visibilitychange` handler: on `visible` if state was "playing" and synthesis is paused
+    (iOS suspends on background), call `resume()`. Registered in constructor; idempotent.
+  - Events: emits state changes via a callback so UI can reflect play/pause/stop.
+  - Injectable `synth` + `utteranceFactory` for tests (default to globals).
+
+### `web/src/components/playback.ts` (DOM, e2e-tested)
+- `registerPlaybackControls()` calls digest-card's `registerPlaybackControls(mountFn)`.
+- `mountFn(slot, digest)`: renders per-card controls — Play, Pause, Stop, Skip 30s buttons,
+  plus a voice `<select>` + rate `<input type=range>` (persist to localStorage on change).
+  Tracks the digest in an ordered registry (Map keyed by id, insertion order). On the FIRST
+  mount, also inserts a "Play all today" bar at the top of that slot.
+- A single shared `TtsPlayer` instance drives everything. Play on a card enqueues just that
+  digest; Play-all enqueues every registered digest in order.
+- Injects scoped styles once.
+- Auto-registers at import time (so the one main.ts import wires it).
+
+## TDD test breakdown
+
+### Unit (Vitest, jsdom) — `web/tests/unit/tts.test.ts`
+1. stripFormatting: `**bold**`, `## Header`, `- item`, `[link](url)`, backticks, `>` → clean.
+2. chunkText: long multi-sentence text → chunks each <= ~200 chars, split on sentence ends;
+   no chunk empty; concatenation preserves words.
+3. prefs: default rate 1.2 & null voice; save then load round-trips; rate persists as number.
+4. queue advance: TtsPlayer with stubbed synth — play([2 items]); firing onend N times walks
+   through all chunks/items in order; speak called once per chunk.
+5. skip-30s math: pure helper `wordsForSkip(rate, seconds)` and offset advance — given rate 1.2,
+   skip(30) advances ~ (150*1.2/60*30)=90 words; assert exact via helper.
+- Requires adding `jsdom` devDep + `environment: "jsdom"` for the new file. Use a per-file
+  `// @vitest-environment jsdom` docblock so existing node-env tests are untouched, and
+  stub `globalThis.speechSynthesis` / `SpeechSynthesisUtterance` in the test.
+
+### Integration (Playwright chromium @390x844) — `web/tests/e2e/playback.spec.ts`
+- `page.addInitScript` stubs `window.speechSynthesis` + `SpeechSynthesisUtterance` to record
+  speak/pause/cancel calls on `window.__tts` and auto-fire `onend` on demand.
+- Seed session (reuse `./session`), goto `/`.
+- Assert each `.digest-card` has playback controls (play/pause/stop/skip buttons render).
+- Click Play → assert `speechSynthesis.speak` called + button state transitions to playing.
+- Pause → recorded pause; Stop → recorded cancel + state reset.
+- Skip-30s → speak called again (re-utter from advanced offset).
+- Play-all → queue advances across >1 digest (speak called for multiple ids in order).
+
+## Validation
+- rsync to radeon ~/ndw-issue11; npm install (adds jsdom); build; test:unit; test:e2e.
+- code-reviewer subagent (high-confidence >=80), fix Critical only, max 3 iterations.
+- Lighthouse mobile >=90: note in handoff (orchestrator may run). No headless audio.
+
+## Acceptance criteria mapping
+- Play/pause/stop/skip-30s per digest → playback.ts per-card buttons + TtsPlayer; e2e + unit.
+- Play-all queue across today's digests → ordered registry + TtsPlayer.play(all); e2e.
+- Voice+rate persist in localStorage → loadPrefs/savePrefs; unit.
+- iOS first speak from gesture + visibilitychange resume → no autoplay; visibilitychange
+  handler; CP-3 human checkpoint for real device.
+- No TTS artifacts → stripFormatting before speaking; unit.

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -16,9 +16,139 @@
         "@typescript-eslint/eslint-plugin": "^8.8.0",
         "@typescript-eslint/parser": "^8.8.0",
         "eslint": "^9.11.1",
+        "jsdom": "^25.0.1",
         "typescript": "^5.6.2",
         "vite": "^5.4.8",
         "vitest": "^2.1.1"
+      }
+    },
+    "node_modules/@asamuzakjp/css-color": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/css-color/-/css-color-3.2.0.tgz",
+      "integrity": "sha512-K1A6z8tS3XsmCMM86xoWdn7Fkdn9m6RSVtocUrJYIwZnFVkng/PvkEoWtOWmP+Scc6saYWHWZYbndEEXxl24jw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@csstools/css-calc": "^2.1.3",
+        "@csstools/css-color-parser": "^3.0.9",
+        "@csstools/css-parser-algorithms": "^3.0.4",
+        "@csstools/css-tokenizer": "^3.0.3",
+        "lru-cache": "^10.4.3"
+      }
+    },
+    "node_modules/@csstools/color-helpers": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/@csstools/color-helpers/-/color-helpers-5.1.0.tgz",
+      "integrity": "sha512-S11EXWJyy0Mz5SYvRmY8nJYTFFd1LCNV+7cXyAgQtOOuzb4EsgfqDufL+9esx72/eLhsRdGZwaldu/h+E4t4BA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT-0",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@csstools/css-calc": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/@csstools/css-calc/-/css-calc-2.1.4.tgz",
+      "integrity": "sha512-3N8oaj+0juUw/1H3YwmDDJXCgTB1gKU6Hc/bB502u9zR0q2vd786XJH9QfrKIEgFlZmhZiq6epXl4rHqhzsIgQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^3.0.5",
+        "@csstools/css-tokenizer": "^3.0.4"
+      }
+    },
+    "node_modules/@csstools/css-color-parser": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-color-parser/-/css-color-parser-3.1.0.tgz",
+      "integrity": "sha512-nbtKwh3a6xNVIp/VRuXV64yTKnb1IjTAEEh3irzS+HkKjAOYLTGNb9pmVNntZ8iVBHcWDA2Dof0QtPgFI1BaTA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@csstools/color-helpers": "^5.1.0",
+        "@csstools/css-calc": "^2.1.4"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^3.0.5",
+        "@csstools/css-tokenizer": "^3.0.4"
+      }
+    },
+    "node_modules/@csstools/css-parser-algorithms": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/@csstools/css-parser-algorithms/-/css-parser-algorithms-3.0.5.tgz",
+      "integrity": "sha512-DaDeUkXZKjdGhgYaHNJTV9pV7Y9B3b644jCLs9Upc3VeNGg6LWARAT6O+Q+/COo+2gg/bM5rhpMAtf70WqfBdQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@csstools/css-tokenizer": "^3.0.4"
+      }
+    },
+    "node_modules/@csstools/css-tokenizer": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@csstools/css-tokenizer/-/css-tokenizer-3.0.4.tgz",
+      "integrity": "sha512-Vd/9EVDiu6PPJt9yAh6roZP6El1xHrdvIVGjyBsHR0RYwNHgL7FJPyIIW4fANJNG6FtyZfvlRPpFI4ZM/lubvw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@esbuild/linux-x64": {
@@ -713,6 +843,16 @@
         "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
       }
     },
+    "node_modules/agent-base": {
+      "version": "7.1.4",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
+      "integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14"
+      }
+    },
     "node_modules/ajv": {
       "version": "6.15.0",
       "dev": true,
@@ -755,6 +895,13 @@
         "node": ">=12"
       }
     },
+    "node_modules/asynckit": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/balanced-match": {
       "version": "4.0.4",
       "dev": true,
@@ -780,6 +927,20 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/call-bind-apply-helpers": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
+      "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
       }
     },
     "node_modules/callsites": {
@@ -844,6 +1005,19 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/combined-stream": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
+      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "delayed-stream": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
     "node_modules/concat-map": {
       "version": "0.0.1",
       "dev": true,
@@ -862,6 +1036,41 @@
         "node": ">= 8"
       }
     },
+    "node_modules/cssstyle": {
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/cssstyle/-/cssstyle-4.6.0.tgz",
+      "integrity": "sha512-2z+rWdzbbSZv6/rhtvzvqeZQHrBaqgogqt85sqFNbabZOuFbCVFb8kPeEtZjiKkbrm395irpNKiYeFeLiQnFPg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@asamuzakjp/css-color": "^3.2.0",
+        "rrweb-cssom": "^0.8.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/cssstyle/node_modules/rrweb-cssom": {
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/rrweb-cssom/-/rrweb-cssom-0.8.0.tgz",
+      "integrity": "sha512-guoltQEx+9aMf2gDZ0s62EcV8lsXR+0w8915TC3ITdn2YueuNjdAYh/levpU9nFaoChh9RUS5ZdQMrKfVEN9tw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/data-urls": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-5.0.0.tgz",
+      "integrity": "sha512-ZYP5VBHshaDAiVZxjbRVcFJpc+4xGgT0bK3vzy1HLN8jTO975HEbuYzZJcHoQEY5K1a0z8YayJkyVETa08eNTg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-mimetype": "^4.0.0",
+        "whatwg-url": "^14.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/debug": {
       "version": "4.4.3",
       "dev": true,
@@ -878,6 +1087,13 @@
         }
       }
     },
+    "node_modules/decimal.js": {
+      "version": "10.6.0",
+      "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.6.0.tgz",
+      "integrity": "sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/deep-eql": {
       "version": "5.0.2",
       "dev": true,
@@ -891,10 +1107,97 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/delayed-stream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+      "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/dunder-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
+      "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/entities": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-6.0.1.tgz",
+      "integrity": "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
+    "node_modules/es-define-property": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
+      "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-errors": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
     "node_modules/es-module-lexer": {
       "version": "1.7.0",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/es-object-atoms": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.2.tgz",
+      "integrity": "sha512-HWcBoN6NileqtSydK2FqHbS/LoDd2pqrnQHLyJzBj4kOp/ky2MWMN694xOfkK8/SnUsW2DH7EfyVlydKCsm1Zw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-set-tostringtag": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.1.0.tgz",
+      "integrity": "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.6",
+        "has-tostringtag": "^1.0.2",
+        "hasown": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
     },
     "node_modules/esbuild": {
       "version": "0.21.5",
@@ -1227,6 +1530,72 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/form-data": {
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.5.tgz",
+      "integrity": "sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "es-set-tostringtag": "^2.1.0",
+        "hasown": "^2.0.2",
+        "mime-types": "^2.1.12"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/function-bind": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-intrinsic": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
+      "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "es-define-property": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.1.1",
+        "function-bind": "^1.1.2",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "has-symbols": "^1.1.0",
+        "hasown": "^2.0.2",
+        "math-intrinsics": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
+      "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "dunder-proto": "^1.0.1",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
     "node_modules/glob-parent": {
       "version": "6.0.2",
       "dev": true,
@@ -1249,6 +1618,19 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/gopd": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
+      "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/has-flag": {
       "version": "4.0.0",
       "dev": true,
@@ -1257,11 +1639,107 @@
         "node": ">=8"
       }
     },
+    "node_modules/has-symbols": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
+      "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-tostringtag": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
+      "integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-symbols": "^1.0.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/hasown": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.4.tgz",
+      "integrity": "sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/html-encoding-sniffer": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-4.0.0.tgz",
+      "integrity": "sha512-Y22oTqIU4uuPgEemfz7NDJz6OeKf12Lsu+QC+s3BVpda64lTiMYCyGwg5ki4vFxkMwQdeZDl2adZoqUgdFuTgQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-encoding": "^3.1.1"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/http-proxy-agent": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-7.0.2.tgz",
+      "integrity": "sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.0",
+        "debug": "^4.3.4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/https-proxy-agent": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
+      "integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.2",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
     "node_modules/iceberg-js": {
       "version": "0.8.1",
       "license": "MIT",
       "engines": {
         "node": ">=20.0.0"
+      }
+    },
+    "node_modules/iconv-lite": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
+      "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/ignore": {
@@ -1314,6 +1792,13 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/is-potential-custom-element-name": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.1.tgz",
+      "integrity": "sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/isexe": {
       "version": "2.0.0",
       "dev": true,
@@ -1338,6 +1823,47 @@
       },
       "bin": {
         "js-yaml": "bin/js-yaml.js"
+      }
+    },
+    "node_modules/jsdom": {
+      "version": "25.0.1",
+      "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-25.0.1.tgz",
+      "integrity": "sha512-8i7LzZj7BF8uplX+ZyOlIz86V6TAsSs+np6m1kpW9u0JWi4z/1t+FzcK1aek+ybTnAC4KhBL4uXCNT0wcUIeCw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cssstyle": "^4.1.0",
+        "data-urls": "^5.0.0",
+        "decimal.js": "^10.4.3",
+        "form-data": "^4.0.0",
+        "html-encoding-sniffer": "^4.0.0",
+        "http-proxy-agent": "^7.0.2",
+        "https-proxy-agent": "^7.0.5",
+        "is-potential-custom-element-name": "^1.0.1",
+        "nwsapi": "^2.2.12",
+        "parse5": "^7.1.2",
+        "rrweb-cssom": "^0.7.1",
+        "saxes": "^6.0.0",
+        "symbol-tree": "^3.2.4",
+        "tough-cookie": "^5.0.0",
+        "w3c-xmlserializer": "^5.0.0",
+        "webidl-conversions": "^7.0.0",
+        "whatwg-encoding": "^3.1.1",
+        "whatwg-mimetype": "^4.0.0",
+        "whatwg-url": "^14.0.0",
+        "ws": "^8.18.0",
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "canvas": "^2.11.2"
+      },
+      "peerDependenciesMeta": {
+        "canvas": {
+          "optional": true
+        }
       }
     },
     "node_modules/json-buffer": {
@@ -1399,12 +1925,52 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/lru-cache": {
+      "version": "10.4.3",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
+      "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/magic-string": {
       "version": "0.30.21",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
+    "node_modules/math-intrinsics": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
+      "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/mime-db": {
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime-types": {
+      "version": "2.1.35",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "1.52.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
       }
     },
     "node_modules/minimatch": {
@@ -1445,6 +2011,13 @@
     },
     "node_modules/natural-compare": {
       "version": "1.4.0",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/nwsapi": {
+      "version": "2.2.23",
+      "resolved": "https://registry.npmjs.org/nwsapi/-/nwsapi-2.2.23.tgz",
+      "integrity": "sha512-7wfH4sLbt4M0gCDzGE6vzQBo0bfTKjU7Sfpqy/7gs1qBfYz2vEJH6vXcBKpO3+6Yu1telwd0t9HpyOoLEQQbIQ==",
       "dev": true,
       "license": "MIT"
     },
@@ -1501,6 +2074,19 @@
       },
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/parse5": {
+      "version": "7.3.0",
+      "resolved": "https://registry.npmjs.org/parse5/-/parse5-7.3.0.tgz",
+      "integrity": "sha512-IInvU7fabl34qmi9gY8XOVxhYyMyuH2xUNpb2q8/Y+7552KlejkRvqvD19nMoUW/uQGGbqNpA6Tufu5FL5BZgw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "entities": "^6.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/inikulin/parse5?sponsor=1"
       }
     },
     "node_modules/path-exists": {
@@ -1670,6 +2256,33 @@
         "fsevents": "~2.3.2"
       }
     },
+    "node_modules/rrweb-cssom": {
+      "version": "0.7.1",
+      "resolved": "https://registry.npmjs.org/rrweb-cssom/-/rrweb-cssom-0.7.1.tgz",
+      "integrity": "sha512-TrEMa7JGdVm0UThDJSx7ddw5nVm3UJS9o9CCIZ72B1vSyEZoziDqBYP3XIoi/12lKrJR8rE3jeFHMok2F/Mnsg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/saxes": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/saxes/-/saxes-6.0.0.tgz",
+      "integrity": "sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "xmlchars": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=v12.22.7"
+      }
+    },
     "node_modules/semver": {
       "version": "7.8.1",
       "dev": true,
@@ -1745,6 +2358,13 @@
         "node": ">=8"
       }
     },
+    "node_modules/symbol-tree": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
+      "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/tinybench": {
       "version": "2.9.0",
       "dev": true,
@@ -1792,6 +2412,52 @@
       "license": "MIT",
       "engines": {
         "node": ">=14.0.0"
+      }
+    },
+    "node_modules/tldts": {
+      "version": "6.1.86",
+      "resolved": "https://registry.npmjs.org/tldts/-/tldts-6.1.86.tgz",
+      "integrity": "sha512-WMi/OQ2axVTf/ykqCQgXiIct+mSQDFdH2fkwhPwgEwvJ1kSzZRiinb0zF2Xb8u4+OqPChmyI6MEu4EezNJz+FQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tldts-core": "^6.1.86"
+      },
+      "bin": {
+        "tldts": "bin/cli.js"
+      }
+    },
+    "node_modules/tldts-core": {
+      "version": "6.1.86",
+      "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-6.1.86.tgz",
+      "integrity": "sha512-Je6p7pkk+KMzMv2XXKmAE3McmolOQFdxkKw0R8EYNr7sELW46JqnNeTX8ybPiQgvg1ymCoF8LXs5fzFaZvJPTA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tough-cookie": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-5.1.2.tgz",
+      "integrity": "sha512-FVDYdxtnj0G6Qm/DhNPSb8Ju59ULcup3tuJxkFb5K8Bv2pUXILbf0xZWU8PX8Ov19OXljbUyveOFwRMwkXzO+A==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "tldts": "^6.1.32"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/tr46": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-5.1.1.tgz",
+      "integrity": "sha512-hdF5ZgjTqgAntKkklYw0R03MG2x/bSzTtkxmIRw/sTNV8YXsCJ1tfLAX23lhxhHJlEf3CRCOCGGWw3vI3GaSPw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "punycode": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/ts-api-utils": {
@@ -1990,6 +2656,67 @@
         }
       }
     },
+    "node_modules/w3c-xmlserializer": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/w3c-xmlserializer/-/w3c-xmlserializer-5.0.0.tgz",
+      "integrity": "sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/webidl-conversions": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-7.0.0.tgz",
+      "integrity": "sha512-VwddBukDzu71offAQR975unBIGqfKZpM+8ZX6ySk8nYhVoo5CYaZyzt3YBvYtRtO+aoGlqxPg/B87NGVZ/fu6g==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/whatwg-encoding": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/whatwg-encoding/-/whatwg-encoding-3.1.1.tgz",
+      "integrity": "sha512-6qN4hJdMwfYBtE3YBTTHhoeuUrDBPZmbQaxWAqSALV/MeEnR5z1xd8UKud2RAkFoPkmB+hli1TZSnyi84xz1vQ==",
+      "deprecated": "Use @exodus/bytes instead for a more spec-conformant and faster implementation",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "iconv-lite": "0.6.3"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/whatwg-mimetype": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-4.0.0.tgz",
+      "integrity": "sha512-QaKxh0eNIi2mE9p2vEdzfagOKHCcj1pJ56EEHGQOVxp8r9/iszLUUV7v89x9O1p/T+NlTM5W7jW6+cz4Fq1YVg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/whatwg-url": {
+      "version": "14.2.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-14.2.0.tgz",
+      "integrity": "sha512-De72GdQZzNTUBBChsXueQUnPKDkg/5A5zp7pFDuQAj5UFoENpiACU0wlCvzpAGnTkj++ihpKwKyYewn/XNUbKw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tr46": "^5.1.0",
+        "webidl-conversions": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/which": {
       "version": "2.0.2",
       "dev": true,
@@ -2026,6 +2753,45 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/ws": {
+      "version": "8.21.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.0.tgz",
+      "integrity": "sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/xml-name-validator": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-5.0.0.tgz",
+      "integrity": "sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/xmlchars": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/xmlchars/-/xmlchars-2.2.0.tgz",
+      "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/yocto-queue": {
       "version": "0.1.0",

--- a/web/package.json
+++ b/web/package.json
@@ -21,6 +21,7 @@
     "@typescript-eslint/eslint-plugin": "^8.8.0",
     "@typescript-eslint/parser": "^8.8.0",
     "eslint": "^9.11.1",
+    "jsdom": "^25.0.1",
     "typescript": "^5.6.2",
     "vite": "^5.4.8",
     "vitest": "^2.1.1"

--- a/web/src/components/playback.ts
+++ b/web/src/components/playback.ts
@@ -1,0 +1,232 @@
+// Per-digest playback controls + a "play all today" control (#11).
+//
+// Mounts into each card's `.playback-slot` via the hook #10 left in
+// views/digest-card.ts. A single shared TtsPlayer drives all cards; an ordered
+// registry of mounted digests powers "Play all today" (DOM/registration order,
+// which is newest-first by topic+date from digest-list.ts).
+//
+// This module is self-contained: it injects its own scoped styles and
+// auto-registers on import, so main.ts only needs a single import line.
+
+import { registerPlaybackControls as registerCardHook } from "../views/digest-card";
+import type { Digest } from "../lib/types";
+import { TtsPlayer, type TtsItem, type TtsState, loadPrefs } from "../lib/tts";
+
+let player: TtsPlayer | null = null;
+// Ordered registry: insertion order === card render order.
+const registry = new Map<string, { digest: Digest; card: HTMLElement }>();
+// All digests ever mounted, keyed by id, so finalize can resolve content even
+// after a re-render. Card refs are resolved live from the DOM at finalize time.
+const knownDigests = new Map<string, Digest>();
+let playAllBtn: HTMLButtonElement | null = null;
+let finalizeScheduled = false;
+
+function getPlayer(): TtsPlayer {
+  if (player) return player;
+  player = new TtsPlayer({ onStateChange: handleStateChange });
+  return player;
+}
+
+function setCardState(cardEl: HTMLElement, state: TtsState): void {
+  cardEl.setAttribute("data-tts-state", state);
+  const playBtn = cardEl.querySelector<HTMLButtonElement>(".tts-play");
+  const pauseBtn = cardEl.querySelector<HTMLButtonElement>(".tts-pause");
+  if (playBtn) playBtn.disabled = state === "playing";
+  if (pauseBtn) {
+    // Pause doubles as Resume while paused, so it stays enabled unless idle.
+    pauseBtn.disabled = state === "idle";
+    pauseBtn.textContent = state === "paused" ? "Resume" : "Pause";
+  }
+}
+
+function handleStateChange(state: TtsState, currentId: string | null): void {
+  // Reset all cards, then mark the active one.
+  for (const [id, { card }] of registry) {
+    setCardState(card, state !== "idle" && id === currentId ? state : "idle");
+  }
+  if (playAllBtn) {
+    playAllBtn.setAttribute("aria-pressed", String(state !== "idle"));
+  }
+}
+
+function injectStyles(): void {
+  if (typeof document === "undefined") return;
+  if (document.getElementById("tts-styles")) return;
+  const style = document.createElement("style");
+  style.id = "tts-styles";
+  style.textContent = `
+    .tts-controls { display:flex; flex-wrap:wrap; gap:0.4rem; align-items:center; margin-bottom:0.6rem; }
+    .tts-controls button { min-height:40px; padding:0.4rem 0.7rem; font-size:0.9rem; }
+    .tts-controls .tts-prefs { display:flex; gap:0.4rem; align-items:center; margin-left:auto; }
+    .tts-controls select.tts-voice { font:inherit; min-height:40px; max-width:9rem; border:1px solid var(--border); border-radius:var(--radius); background:var(--bg); color:var(--fg); padding:0 0.4rem; }
+    .tts-controls input.tts-rate { accent-color: var(--accent); }
+    .tts-rate-label { font-size:0.8rem; color:var(--muted); white-space:nowrap; }
+    .tts-playall { display:flex; align-items:center; gap:0.5rem; margin:0 0 1rem; }
+    .tts-playall button[aria-pressed="true"] { background: var(--card); color: var(--accent); }
+    .digest-card[data-tts-state="playing"] { outline:2px solid var(--accent); outline-offset:2px; }
+  `;
+  document.head.appendChild(style);
+}
+
+function populateVoices(select: HTMLSelectElement): void {
+  const synth = (globalThis as unknown as { speechSynthesis?: SpeechSynthesis }).speechSynthesis;
+  if (!synth) return;
+  const render = (): void => {
+    const voices = synth.getVoices();
+    const current = loadPrefs().voiceURI;
+    select.replaceChildren();
+    const def = document.createElement("option");
+    def.value = "";
+    def.textContent = "Default voice";
+    select.appendChild(def);
+    for (const v of voices) {
+      const opt = document.createElement("option");
+      opt.value = v.voiceURI;
+      opt.textContent = v.name;
+      if (current && (v.voiceURI === current || v.name === current)) opt.selected = true;
+      select.appendChild(opt);
+    }
+  };
+  render();
+  // Voices often load asynchronously.
+  if (typeof synth.addEventListener === "function") {
+    synth.addEventListener("voiceschanged", render);
+  }
+}
+
+function makeButton(label: string, cls: string): HTMLButtonElement {
+  const btn = document.createElement("button");
+  btn.type = "button";
+  btn.className = cls;
+  btn.textContent = label;
+  return btn;
+}
+
+function orderedItems(): TtsItem[] {
+  return [...registry.values()].map(({ digest }) => ({ id: digest.id, text: digest.content }));
+}
+
+// Rebuild the ordered registry from the live DOM and (re)mount a single
+// play-all bar. Runs in a microtask after the synchronous render batch, so the
+// cards are attached and querySelectorAll reflects true DOM order.
+function finalize(): void {
+  finalizeScheduled = false;
+  if (typeof document === "undefined") return;
+
+  registry.clear();
+  const cards = document.querySelectorAll<HTMLElement>(".digest-card");
+  let firstSlot: HTMLElement | null = null;
+  for (const card of cards) {
+    const id = card.getAttribute("data-digest-id");
+    if (!id) continue;
+    const digest = knownDigests.get(id);
+    if (!digest) continue;
+    registry.set(id, { digest, card });
+    if (!firstSlot) firstSlot = card.querySelector<HTMLElement>(".playback-slot");
+  }
+
+  // Drop any stale play-all bar, then mount exactly one above the first card.
+  document.querySelectorAll(".tts-playall").forEach((el) => el.remove());
+  playAllBtn = null;
+  if (firstSlot) firstSlot.prepend(buildPlayAllBar());
+}
+
+function scheduleFinalize(): void {
+  if (finalizeScheduled) return;
+  finalizeScheduled = true;
+  const run = () => finalize();
+  if (typeof queueMicrotask === "function") queueMicrotask(run);
+  else Promise.resolve().then(run);
+}
+
+function buildPlayAllBar(): HTMLElement {
+  const bar = document.createElement("div");
+  bar.className = "tts-playall";
+  const btn = makeButton("Play all today", "tts-playall-btn");
+  btn.setAttribute("aria-pressed", "false");
+  btn.addEventListener("click", () => {
+    getPlayer().play(orderedItems());
+  });
+  const stopAll = makeButton("Stop", "tts-playall-stop");
+  stopAll.addEventListener("click", () => getPlayer().stop());
+  bar.append(btn, stopAll);
+  playAllBtn = btn;
+  return bar;
+}
+
+function mountControls(slot: HTMLElement, digest: Digest): void {
+  injectStyles();
+  knownDigests.set(digest.id, digest);
+  // The play-all bar + ordered registry are (re)built once per render batch in a
+  // microtask, after all cards are attached to the DOM.
+  scheduleFinalize();
+
+  const controls = document.createElement("div");
+  controls.className = "tts-controls";
+
+  const play = makeButton("Play", "tts-play");
+  const pause = makeButton("Pause", "tts-pause");
+  pause.disabled = true;
+  const stop = makeButton("Stop", "tts-stop");
+  const skip = makeButton("Skip 30s", "tts-skip");
+
+  play.addEventListener("click", () => {
+    const p = getPlayer();
+    // First speak fires here, inside the user gesture — required for iOS.
+    p.play([{ id: digest.id, text: digest.content }]);
+  });
+  pause.addEventListener("click", () => {
+    const p = getPlayer();
+    if (p.getState() === "paused") p.resume();
+    else p.pause();
+  });
+  stop.addEventListener("click", () => getPlayer().stop());
+  skip.addEventListener("click", () => getPlayer().skip(30));
+
+  controls.append(play, pause, stop, skip);
+
+  // Voice + rate prefs (shared across cards, but each card carries a copy so the
+  // controls are reachable per-card).
+  const prefs = document.createElement("div");
+  prefs.className = "tts-prefs";
+
+  const voice = document.createElement("select");
+  voice.className = "tts-voice";
+  voice.setAttribute("aria-label", "Voice");
+  populateVoices(voice);
+  voice.addEventListener("change", () => {
+    getPlayer().setVoiceURI(voice.value || null);
+  });
+
+  const rateLabel = document.createElement("label");
+  rateLabel.className = "tts-rate-label";
+  const rate = document.createElement("input");
+  rate.type = "range";
+  rate.className = "tts-rate";
+  rate.min = "0.5";
+  rate.max = "2";
+  rate.step = "0.1";
+  const stored = loadPrefs().rate;
+  rate.value = String(stored);
+  rateLabel.textContent = `Speed ${stored.toFixed(1)}x`;
+  rate.setAttribute("aria-label", "Speech rate");
+  rate.addEventListener("input", () => {
+    const r = Number(rate.value);
+    rateLabel.textContent = `Speed ${r.toFixed(1)}x`;
+    getPlayer().setRate(r);
+  });
+
+  rateLabel.appendChild(rate);
+  prefs.append(voice, rateLabel);
+  controls.appendChild(prefs);
+
+  slot.appendChild(controls);
+}
+
+/** Wire playback controls into the digest-card render hook. Idempotent. */
+export function registerPlaybackControls(): void {
+  registerCardHook(mountControls);
+}
+
+// Auto-register on import so main.ts only needs a single import line.
+registerPlaybackControls();

--- a/web/src/lib/tts.ts
+++ b/web/src/lib/tts.ts
@@ -1,0 +1,448 @@
+// Web Speech API text-to-speech wrapper for digest playback (#11).
+//
+// Responsibilities:
+//   - Strip markdown/formatting artifacts so the synth never reads "asterisk" etc.
+//   - Chunk text on sentence boundaries (~200 chars) to dodge the iOS Safari
+//     long-utterance cutoff, where utterances over a few hundred chars get
+//     silently truncated.
+//   - Maintain a playlist queue; `onend` advances to the next chunk, then the
+//     next item.
+//   - Persist voice + rate in localStorage (default rate 1.2).
+//   - skip-30s: jump forward within the current item by an estimated word count.
+//   - iOS: never auto-speak (first speak must come from a user gesture handled by
+//     the UI layer); resume on `visibilitychange` since iOS suspends synthesis
+//     when the tab/screen backgrounds.
+
+export interface TtsItem {
+  id: string;
+  text: string;
+}
+
+export interface TtsPrefs {
+  rate: number;
+  voiceURI: string | null;
+}
+
+export type TtsState = "idle" | "playing" | "paused";
+
+const RATE_KEY = "tts.rate";
+const VOICE_KEY = "tts.voiceURI";
+export const DEFAULT_RATE = 1.2;
+
+// Rough spoken-words-per-minute at rate 1.0. Used only for skip estimation.
+const BASE_WPM = 150;
+
+const MIN_RATE = 0.5;
+const MAX_RATE = 3;
+
+// --- formatting stripping -------------------------------------------------
+
+/**
+ * Remove markdown/formatting artifacts so the speech synth reads clean prose.
+ * Handles headers, bold/italic, list markers, links, inline code, blockquotes.
+ */
+export function stripFormatting(text: string): string {
+  let out = text;
+
+  // Fenced code blocks: drop the fences, keep the inner text.
+  out = out.replace(/```[a-zA-Z0-9]*\n?/g, "");
+
+  // Links [text](url) -> text ; images ![alt](url) -> alt
+  out = out.replace(/!?\[([^\]]*)\]\([^)]*\)/g, "$1");
+
+  // Headers: strip leading # of any level.
+  out = out.replace(/^[ \t]*#{1,6}[ \t]+/gm, "");
+
+  // Blockquotes: strip leading >.
+  out = out.replace(/^[ \t]*>[ \t]?/gm, "");
+
+  // Unordered list markers at line start.
+  out = out.replace(/^[ \t]*[-*+][ \t]+/gm, "");
+
+  // Ordered list markers at line start (1. / 1) ).
+  out = out.replace(/^[ \t]*\d+[.)][ \t]+/gm, "");
+
+  // Bold/italic: **x**, __x__, *x*, _x_  -> x
+  out = out.replace(/(\*\*|__)(.*?)\1/g, "$2");
+  out = out.replace(/(\*|_)(.*?)\1/g, "$2");
+
+  // Inline code `x` -> x
+  out = out.replace(/`([^`]*)`/g, "$1");
+
+  // Strip any remaining stray markdown punctuation that would be read aloud.
+  out = out.replace(/[#*_`]/g, "");
+
+  // Collapse runs of spaces/tabs but preserve newlines.
+  out = out.replace(/[ \t]+/g, " ");
+  // Trim each line.
+  out = out
+    .split("\n")
+    .map((l) => l.trim())
+    .join("\n");
+
+  return out.trim();
+}
+
+// --- chunking -------------------------------------------------------------
+
+/**
+ * Split `text` into chunks no longer than `max` chars, breaking on sentence
+ * boundaries where possible. A single sentence longer than `max` is split on
+ * whitespace so no chunk exceeds the limit.
+ */
+export function chunkText(text: string, max = 200): string[] {
+  const clean = text.trim();
+  if (!clean) return [];
+
+  // Split into sentences, keeping terminal punctuation.
+  const sentences = clean.match(/[^.!?]+[.!?]+(?:["')\]]+)?|\S[^.!?]*$/g) ?? [clean];
+
+  const chunks: string[] = [];
+  let buffer = "";
+
+  const flush = (): void => {
+    const t = buffer.trim();
+    if (t) chunks.push(t);
+    buffer = "";
+  };
+
+  for (const raw of sentences) {
+    const sentence = raw.trim();
+    if (!sentence) continue;
+
+    if (sentence.length > max) {
+      // Over-long single sentence: flush buffer, then split on words.
+      flush();
+      let line = "";
+      for (const word of sentence.split(/\s+/)) {
+        if (word.length > max) {
+          // Pathological single token longer than max: hard-split it.
+          if (line.trim()) {
+            chunks.push(line.trim());
+            line = "";
+          }
+          for (let i = 0; i < word.length; i += max) {
+            chunks.push(word.slice(i, i + max));
+          }
+          continue;
+        }
+        if ((line + " " + word).trim().length > max) {
+          chunks.push(line.trim());
+          line = word;
+        } else {
+          line = line ? `${line} ${word}` : word;
+        }
+      }
+      if (line.trim()) chunks.push(line.trim());
+      continue;
+    }
+
+    if ((buffer + " " + sentence).trim().length > max) {
+      flush();
+      buffer = sentence;
+    } else {
+      buffer = buffer ? `${buffer} ${sentence}` : sentence;
+    }
+  }
+  flush();
+
+  return chunks;
+}
+
+// --- prefs ----------------------------------------------------------------
+
+function clampRate(n: number): number {
+  if (!Number.isFinite(n)) return DEFAULT_RATE;
+  return Math.min(MAX_RATE, Math.max(MIN_RATE, n));
+}
+
+export function loadPrefs(): TtsPrefs {
+  let rate = DEFAULT_RATE;
+  try {
+    const stored = localStorage.getItem(RATE_KEY);
+    if (stored !== null) {
+      const parsed = Number(stored);
+      rate = Number.isFinite(parsed) ? clampRate(parsed) : DEFAULT_RATE;
+    }
+  } catch {
+    // localStorage unavailable (private mode etc.) — fall back to defaults.
+  }
+  let voiceURI: string | null = null;
+  try {
+    voiceURI = localStorage.getItem(VOICE_KEY);
+  } catch {
+    voiceURI = null;
+  }
+  return { rate, voiceURI };
+}
+
+export function savePrefs(prefs: Partial<TtsPrefs>): void {
+  try {
+    if (prefs.rate !== undefined) localStorage.setItem(RATE_KEY, String(clampRate(prefs.rate)));
+    if (prefs.voiceURI !== undefined) {
+      if (prefs.voiceURI === null) localStorage.removeItem(VOICE_KEY);
+      else localStorage.setItem(VOICE_KEY, prefs.voiceURI);
+    }
+  } catch {
+    // Best-effort; ignore storage failures.
+  }
+}
+
+// --- skip math ------------------------------------------------------------
+
+/** Number of words spoken in `seconds` at the given `rate`. */
+export function wordsForSkip(rate: number, seconds: number): number {
+  return Math.round((BASE_WPM * rate) / 60 * seconds);
+}
+
+// --- player ---------------------------------------------------------------
+
+export interface TtsPlayerOptions {
+  synth?: SpeechSynthesis;
+  createUtterance?: (text: string) => SpeechSynthesisUtterance;
+  onStateChange?: (state: TtsState, currentId: string | null) => void;
+}
+
+interface QueuedItem {
+  id: string;
+  words: string[]; // cleaned, word-tokenized text
+  offset: number; // current word offset within the item
+  chunks: string[]; // chunks for the remaining text from `offset`
+  chunkIndex: number; // which chunk we are on
+}
+
+export class TtsPlayer {
+  private readonly synth: SpeechSynthesis;
+  private readonly createUtterance: (text: string) => SpeechSynthesisUtterance;
+  private readonly onStateChange?: (state: TtsState, currentId: string | null) => void;
+
+  private queue: QueuedItem[] = [];
+  private index = 0;
+  private state: TtsState = "idle";
+  private rate: number;
+  private voiceURI: string | null;
+  // Monotonic token incremented on every cancel()/stop()/skip()/play(). An
+  // utterance's onend/onerror only acts if its captured token still matches —
+  // this discards the spurious onend that browsers fire for a cancelled
+  // utterance, preventing a double-advance of the queue.
+  private generation = 0;
+
+  constructor(opts: TtsPlayerOptions = {}) {
+    this.synth = opts.synth ?? (globalThis as unknown as { speechSynthesis: SpeechSynthesis }).speechSynthesis;
+    this.createUtterance =
+      opts.createUtterance ??
+      ((text: string) =>
+        new (globalThis as unknown as {
+          SpeechSynthesisUtterance: new (t: string) => SpeechSynthesisUtterance;
+        }).SpeechSynthesisUtterance(text));
+    this.onStateChange = opts.onStateChange;
+
+    const prefs = loadPrefs();
+    this.rate = prefs.rate;
+    this.voiceURI = prefs.voiceURI;
+
+    // iOS suspends synthesis when the tab backgrounds; resume on return.
+    if (typeof document !== "undefined" && typeof document.addEventListener === "function") {
+      document.addEventListener("visibilitychange", this.handleVisibility);
+    }
+  }
+
+  private handleVisibility = (): void => {
+    if (typeof document === "undefined") return;
+    if (document.visibilityState === "visible" && this.state === "playing") {
+      // Nudge the engine: iOS leaves it paused after backgrounding.
+      try {
+        this.synth.resume();
+      } catch {
+        // ignore
+      }
+    }
+  };
+
+  setRate(rate: number): void {
+    this.rate = clampRate(rate);
+    savePrefs({ rate: this.rate });
+  }
+
+  getRate(): number {
+    return this.rate;
+  }
+
+  setVoiceURI(uri: string | null): void {
+    this.voiceURI = uri;
+    savePrefs({ voiceURI: uri });
+  }
+
+  getVoiceURI(): string | null {
+    return this.voiceURI;
+  }
+
+  isPlaying(): boolean {
+    return this.state === "playing";
+  }
+
+  getState(): TtsState {
+    return this.state;
+  }
+
+  currentId(): string | null {
+    return this.queue[this.index]?.id ?? null;
+  }
+
+  /** Build the queue and start speaking the first chunk. Must be called from a
+   *  user gesture (we never auto-speak). */
+  play(items: readonly TtsItem[]): void {
+    this.cancel();
+    this.queue = items
+      .map((it) => this.buildItem(it.id, it.text, 0))
+      .filter((q) => q.chunks.length > 0);
+    this.index = 0;
+    if (this.queue.length === 0) {
+      this.setState("idle");
+      return;
+    }
+    this.setState("playing");
+    this.speakCurrentChunk();
+  }
+
+  pause(): void {
+    if (this.state !== "playing") return;
+    try {
+      this.synth.pause();
+    } catch {
+      // ignore
+    }
+    this.setState("paused");
+  }
+
+  resume(): void {
+    if (this.state !== "paused") return;
+    try {
+      this.synth.resume();
+    } catch {
+      // ignore
+    }
+    this.setState("playing");
+  }
+
+  stop(): void {
+    this.cancel();
+    this.queue = [];
+    this.index = 0;
+    this.setState("idle");
+  }
+
+  /** Skip forward `seconds` within the current item. */
+  skip(seconds = 30): void {
+    const item = this.queue[this.index];
+    if (!item) return;
+    const advance = wordsForSkip(this.rate, seconds);
+    const newOffset = item.offset + advance;
+    if (newOffset >= item.words.length) {
+      // Past the end of this item — move to the next.
+      this.advanceItem();
+      return;
+    }
+    const rebuilt = this.buildItem(item.id, item.words.join(" "), newOffset);
+    this.queue[this.index] = rebuilt;
+    this.cancel();
+    if (this.state !== "paused") this.setState("playing");
+    this.speakCurrentChunk();
+  }
+
+  /** Tear down listeners. */
+  dispose(): void {
+    this.stop();
+    if (typeof document !== "undefined" && typeof document.removeEventListener === "function") {
+      document.removeEventListener("visibilitychange", this.handleVisibility);
+    }
+  }
+
+  // --- internals ----------------------------------------------------------
+
+  private buildItem(id: string, rawText: string, offset: number): QueuedItem {
+    const clean = stripFormatting(rawText);
+    const words = clean.split(/\s+/).filter(Boolean);
+    const remaining = words.slice(offset).join(" ");
+    return {
+      id,
+      words,
+      offset,
+      chunks: chunkText(remaining, 200),
+      chunkIndex: 0,
+    };
+  }
+
+  private cancel(): void {
+    // Invalidate any in-flight utterance callbacks before cancelling.
+    this.generation += 1;
+    try {
+      this.synth.cancel();
+    } catch {
+      // ignore
+    }
+  }
+
+  private setState(state: TtsState): void {
+    this.state = state;
+    this.onStateChange?.(state, this.currentId());
+  }
+
+  private speakCurrentChunk(): void {
+    const item = this.queue[this.index];
+    if (!item) {
+      this.setState("idle");
+      return;
+    }
+    const chunk = item.chunks[item.chunkIndex];
+    if (chunk === undefined) {
+      this.advanceItem();
+      return;
+    }
+    const u = this.createUtterance(chunk);
+    u.rate = this.rate;
+    if (this.voiceURI) {
+      const voice = this.findVoice(this.voiceURI);
+      if (voice) u.voice = voice;
+    }
+    const gen = this.generation;
+    u.onend = () => this.handleChunkEnd(gen);
+    u.onerror = () => this.handleChunkEnd(gen);
+    this.synth.speak(u);
+  }
+
+  private findVoice(uri: string): SpeechSynthesisVoice | null {
+    try {
+      return this.synth.getVoices().find((v) => v.voiceURI === uri || v.name === uri) ?? null;
+    } catch {
+      return null;
+    }
+  }
+
+  private handleChunkEnd(gen: number): void {
+    if (gen !== this.generation) return; // stale callback from a cancelled utterance
+    if (this.state === "idle") return; // stopped
+    const item = this.queue[this.index];
+    if (!item) {
+      this.setState("idle");
+      return;
+    }
+    item.chunkIndex += 1;
+    if (item.chunkIndex < item.chunks.length) {
+      this.speakCurrentChunk();
+    } else {
+      this.advanceItem();
+    }
+  }
+
+  private advanceItem(): void {
+    this.index += 1;
+    if (this.index >= this.queue.length) {
+      this.queue = [];
+      this.index = 0;
+      this.setState("idle");
+      return;
+    }
+    this.speakCurrentChunk();
+  }
+}

--- a/web/src/main.ts
+++ b/web/src/main.ts
@@ -1,3 +1,4 @@
+import "./components/playback"; // #11: auto-registers TTS playback controls
 import { getSupabase } from "./lib/supabase";
 import { renderHome } from "./pages/home";
 import { renderHistory } from "./pages/history";

--- a/web/tests/e2e/playback.spec.ts
+++ b/web/tests/e2e/playback.spec.ts
@@ -1,0 +1,176 @@
+import { expect, test, type Page } from "@playwright/test";
+import { seedSession } from "./session";
+
+const SUPABASE_URL = process.env.VITE_SUPABASE_URL ?? "https://eedfyviypptfpghyffip.supabase.co";
+const ANON_KEY = process.env.VITE_SUPABASE_ANON_KEY ?? "sb_publishable_CCE4uRqvWCAonhnDis0BZQ_ixrd0jl2";
+
+// Stub the Web Speech API before any app code runs. Headless chromium emits no
+// audio, so we record speak/pause/cancel calls and let tests fire `onend` to
+// drive the queue. Records land on window.__tts.
+async function stubSpeech(page: Page): Promise<void> {
+  await page.addInitScript(() => {
+    interface Rec {
+      speaks: string[];
+      pauses: number;
+      resumes: number;
+      cancels: number;
+      utterances: any[];
+    }
+    const rec: Rec = { speaks: [], pauses: 0, resumes: 0, cancels: 0, utterances: [] };
+    (window as any).__tts = rec;
+
+    class FakeUtterance {
+      text: string;
+      rate = 1;
+      voice: any = null;
+      lang = "";
+      onend: (() => void) | null = null;
+      onerror: (() => void) | null = null;
+      onstart: (() => void) | null = null;
+      constructor(text: string) {
+        this.text = text;
+      }
+    }
+    (window as any).SpeechSynthesisUtterance = FakeUtterance;
+
+    let current: FakeUtterance | null = null;
+    const synth = {
+      speaking: false,
+      paused: false,
+      pending: false,
+      speak(u: FakeUtterance) {
+        rec.speaks.push(u.text);
+        rec.utterances.push(u);
+        current = u;
+        synth.speaking = true;
+        synth.paused = false;
+      },
+      pause() {
+        rec.pauses += 1;
+        synth.paused = true;
+      },
+      resume() {
+        rec.resumes += 1;
+        synth.paused = false;
+      },
+      cancel() {
+        rec.cancels += 1;
+        synth.speaking = false;
+        current = null;
+      },
+      getVoices() {
+        return [];
+      },
+      addEventListener() {},
+      removeEventListener() {},
+    };
+    Object.defineProperty(window, "speechSynthesis", { value: synth, configurable: true });
+
+    // Test hook: fire onend of the most-recent utterance to advance the queue.
+    (window as any).__ttsFinish = () => {
+      const u = current;
+      current = null;
+      synth.speaking = false;
+      u?.onend?.();
+    };
+  });
+}
+
+async function gotoApp(page: Page): Promise<void> {
+  await stubSpeech(page);
+  await seedSession(page, SUPABASE_URL, ANON_KEY);
+  await page.goto("/");
+  await expect(page.locator(".digest-card").first()).toBeVisible({ timeout: 15_000 });
+}
+
+test("each digest card renders playback controls", async ({ page }) => {
+  await gotoApp(page);
+  // Scope to the per-card control group (.tts-controls) so the first card's
+  // play-all bar (which shares a Stop label) doesn't cause ambiguity.
+  const controls = page.locator(".digest-card").first().locator(".tts-controls");
+  await expect(controls.locator("button.tts-play")).toBeVisible();
+  await expect(controls.locator("button.tts-pause")).toBeVisible();
+  await expect(controls.locator("button.tts-stop")).toBeVisible();
+  await expect(controls.locator("button.tts-skip")).toBeVisible();
+  // Every card has its own control group.
+  const cardCount = await page.locator(".digest-card").count();
+  expect(await page.locator(".tts-controls").count()).toBe(cardCount);
+});
+
+test("clicking Play invokes speechSynthesis.speak and transitions UI state", async ({ page }) => {
+  await gotoApp(page);
+  const card = page.locator(".digest-card").first();
+  const controls = card.locator(".tts-controls");
+  await controls.locator("button.tts-play").click();
+
+  const speaks = await page.evaluate(() => (window as any).__tts.speaks.length);
+  expect(speaks).toBeGreaterThan(0);
+
+  // Playing state reflected on the card.
+  await expect(card).toHaveAttribute("data-tts-state", "playing");
+
+  // Pause records a pause and flips state.
+  await controls.locator("button.tts-pause").click();
+  await expect(card).toHaveAttribute("data-tts-state", "paused");
+  expect(await page.evaluate(() => (window as any).__tts.pauses)).toBeGreaterThan(0);
+
+  // Stop cancels and resets.
+  await controls.locator("button.tts-stop").click();
+  await expect(card).toHaveAttribute("data-tts-state", "idle");
+  expect(await page.evaluate(() => (window as any).__tts.cancels)).toBeGreaterThan(0);
+});
+
+test("skip-30s utters again from an advanced position", async ({ page }) => {
+  await gotoApp(page);
+  // Pick the card with the most body text so a 30s (~90 word) skip lands mid-item
+  // rather than past the end of a short digest.
+  const cardCount = await page.locator(".digest-card").count();
+  let target = 0;
+  let best = -1;
+  for (let i = 0; i < cardCount; i++) {
+    const len = (await page.locator(".digest-card").nth(i).locator(".digest-body").innerText()).length;
+    if (len > best) {
+      best = len;
+      target = i;
+    }
+  }
+  const controls = page.locator(".digest-card").nth(target).locator(".tts-controls");
+  await controls.locator("button.tts-play").click();
+  const before = await page.evaluate(() => (window as any).__tts.speaks.length);
+  await controls.locator("button.tts-skip").click();
+  const after = await page.evaluate(() => (window as any).__tts.speaks.length);
+  expect(after).toBeGreaterThan(before);
+});
+
+test("Play all advances the queue across multiple digests", async ({ page }) => {
+  await gotoApp(page);
+  const cardCount = await page.locator(".digest-card").count();
+  test.skip(cardCount < 2, "needs >= 2 digests to exercise the queue");
+
+  await page.getByRole("button", { name: /play all/i }).click();
+  const first = await page.evaluate(() => (window as any).__tts.speaks.length);
+  expect(first).toBeGreaterThan(0);
+
+  // Drive the queue to exhaustion; each finish should eventually trigger the
+  // next item's utterance. Assert more than one item got spoken.
+  for (let i = 0; i < 200; i++) {
+    await page.evaluate(() => (window as any).__ttsFinish());
+  }
+  const total = await page.evaluate(() => (window as any).__tts.speaks.length);
+  expect(total).toBeGreaterThan(first);
+});
+
+test("voice and rate persist to localStorage", async ({ page }) => {
+  await gotoApp(page);
+  const rate = page.locator(".digest-card").first().locator(".tts-controls input.tts-rate");
+  await expect(rate).toBeVisible();
+  // type=range isn't fillable; set the value and fire input/change so the
+  // component's listener persists it.
+  await rate.evaluate((el: HTMLInputElement) => {
+    el.value = "1.5";
+    el.dispatchEvent(new Event("input", { bubbles: true }));
+    el.dispatchEvent(new Event("change", { bubbles: true }));
+  });
+  const stored = await page.evaluate(() => window.localStorage.getItem("tts.rate"));
+  expect(Number(stored)).toBeCloseTo(1.5);
+});

--- a/web/tests/unit/tts.test.ts
+++ b/web/tests/unit/tts.test.ts
@@ -1,0 +1,275 @@
+// @vitest-environment jsdom
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  TtsPlayer,
+  chunkText,
+  loadPrefs,
+  savePrefs,
+  stripFormatting,
+  wordsForSkip,
+} from "../../src/lib/tts";
+
+// --- speechSynthesis stub -------------------------------------------------
+
+interface FakeUtterance {
+  text: string;
+  rate: number;
+  voice: SpeechSynthesisVoice | null;
+  onend: (() => void) | null;
+  onerror: (() => void) | null;
+}
+
+class FakeSynth {
+  spoken: FakeUtterance[] = [];
+  paused = false;
+  cancelled = 0;
+  private current: FakeUtterance | null = null;
+
+  speak(u: FakeUtterance): void {
+    this.spoken.push(u);
+    this.current = u;
+    this.paused = false;
+  }
+  pause(): void {
+    this.paused = true;
+  }
+  resume(): void {
+    this.paused = false;
+  }
+  cancel(): void {
+    this.cancelled += 1;
+    this.current = null;
+  }
+  // test helper: fire onend of the most recent utterance
+  finishCurrent(): void {
+    const u = this.current;
+    this.current = null;
+    u?.onend?.();
+  }
+  getVoices(): SpeechSynthesisVoice[] {
+    return [];
+  }
+}
+
+function fakeUtteranceFactory(text: string): FakeUtterance {
+  return { text, rate: 1, voice: null, onend: null, onerror: null };
+}
+
+beforeEach(() => {
+  localStorage.clear();
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+// --- stripFormatting ------------------------------------------------------
+
+describe("stripFormatting", () => {
+  it("removes bold/italic markers but keeps the words", () => {
+    expect(stripFormatting("This is **bold** and *italic* and _under_.")).toBe(
+      "This is bold and italic and under.",
+    );
+  });
+
+  it("strips markdown headers", () => {
+    expect(stripFormatting("## Big News\nBody text")).toBe("Big News\nBody text");
+  });
+
+  it("strips list markers", () => {
+    const out = stripFormatting("- first\n- second\n1. third");
+    expect(out).toContain("first");
+    expect(out).toContain("second");
+    expect(out).toContain("third");
+    expect(out).not.toMatch(/^- /m);
+    expect(out).not.toMatch(/^\d+\.\s/m);
+  });
+
+  it("turns links into their visible text", () => {
+    expect(stripFormatting("See [the report](https://example.com/x) today")).toBe(
+      "See the report today",
+    );
+  });
+
+  it("removes inline code backticks and blockquote markers", () => {
+    expect(stripFormatting("Run `npm test` now")).toBe("Run npm test now");
+    expect(stripFormatting("> quoted line")).toBe("quoted line");
+  });
+
+  it("leaves no stray markdown punctuation that TTS would read aloud", () => {
+    const out = stripFormatting("### **Title** — `code` [link](http://x) *em*");
+    expect(out).not.toMatch(/[#*_`]/);
+    expect(out).not.toContain("http://x");
+  });
+});
+
+// --- chunkText ------------------------------------------------------------
+
+describe("chunkText", () => {
+  it("returns a single chunk for short text", () => {
+    expect(chunkText("Hello world.", 200)).toEqual(["Hello world."]);
+  });
+
+  it("splits long text into <= max-length chunks on sentence boundaries", () => {
+    const sentence = "This is a sentence that is reasonably long. ";
+    const text = sentence.repeat(20).trim();
+    const chunks = chunkText(text, 200);
+    expect(chunks.length).toBeGreaterThan(1);
+    for (const c of chunks) {
+      expect(c.length).toBeLessThanOrEqual(200);
+      expect(c.trim().length).toBeGreaterThan(0);
+    }
+  });
+
+  it("preserves all words when rejoined", () => {
+    const text =
+      "Alpha beta gamma delta. Epsilon zeta eta theta! Iota kappa lambda mu? Nu xi omicron pi.";
+    const chunks = chunkText(text, 40);
+    const rejoined = chunks.join(" ").replace(/\s+/g, " ").trim();
+    const original = text.replace(/\s+/g, " ").trim();
+    expect(rejoined).toBe(original);
+  });
+
+  it("splits a single over-long sentence so no chunk exceeds max", () => {
+    const text = "word ".repeat(100).trim(); // 500 chars, no sentence boundary
+    const chunks = chunkText(text, 100);
+    for (const c of chunks) {
+      expect(c.length).toBeLessThanOrEqual(100);
+    }
+  });
+
+  it("ignores empty input", () => {
+    expect(chunkText("", 200)).toEqual([]);
+    expect(chunkText("   ", 200)).toEqual([]);
+  });
+});
+
+// --- prefs ----------------------------------------------------------------
+
+describe("prefs persistence", () => {
+  it("defaults to rate 1.2 and no voice when nothing stored", () => {
+    const prefs = loadPrefs();
+    expect(prefs.rate).toBeCloseTo(1.2);
+    expect(prefs.voiceURI).toBeNull();
+  });
+
+  it("round-trips voice and rate through localStorage", () => {
+    savePrefs({ rate: 1.5, voiceURI: "Daniel" });
+    const prefs = loadPrefs();
+    expect(prefs.rate).toBe(1.5);
+    expect(prefs.voiceURI).toBe("Daniel");
+    expect(localStorage.getItem("tts.rate")).toBe("1.5");
+    expect(localStorage.getItem("tts.voiceURI")).toBe("Daniel");
+  });
+
+  it("falls back to default rate when the stored value is garbage", () => {
+    localStorage.setItem("tts.rate", "not-a-number");
+    expect(loadPrefs().rate).toBeCloseTo(1.2);
+  });
+});
+
+// --- skip math ------------------------------------------------------------
+
+describe("wordsForSkip", () => {
+  it("computes words for a 30s skip at rate 1.2 (~90 words)", () => {
+    // baseline 150 wpm * rate, over 30s => 150*1.2/60*30 = 90
+    expect(wordsForSkip(1.2, 30)).toBe(90);
+  });
+
+  it("scales with rate", () => {
+    expect(wordsForSkip(1.0, 30)).toBe(75);
+    expect(wordsForSkip(2.0, 30)).toBe(150);
+  });
+});
+
+// --- TtsPlayer queue ------------------------------------------------------
+
+describe("TtsPlayer queue", () => {
+  function makePlayer(synth: FakeSynth) {
+    return new TtsPlayer({
+      synth: synth as unknown as SpeechSynthesis,
+      createUtterance: fakeUtteranceFactory as unknown as (t: string) => SpeechSynthesisUtterance,
+    });
+  }
+
+  it("speaks the first chunk on play and advances through chunks on onend", () => {
+    const synth = new FakeSynth();
+    const player = makePlayer(synth);
+    // Two short items, each one chunk.
+    player.play([
+      { id: "a", text: "First digest." },
+      { id: "b", text: "Second digest." },
+    ]);
+    expect(synth.spoken.length).toBe(1);
+    expect(synth.spoken[0].text).toContain("First digest");
+
+    synth.finishCurrent();
+    expect(synth.spoken.length).toBe(2);
+    expect(synth.spoken[1].text).toContain("Second digest");
+
+    synth.finishCurrent();
+    // queue exhausted, no more speaks
+    expect(synth.spoken.length).toBe(2);
+    expect(player.isPlaying()).toBe(false);
+  });
+
+  it("walks every chunk of a multi-chunk item before the next item", () => {
+    const synth = new FakeSynth();
+    const player = makePlayer(synth);
+    const long = "Sentence one is here. ".repeat(20).trim(); // many chunks
+    player.play([{ id: "a", text: long }, { id: "b", text: "Tail." }]);
+    let guard = 0;
+    while (synth.spoken[synth.spoken.length - 1].text !== "Tail." && guard < 100) {
+      synth.finishCurrent();
+      guard += 1;
+    }
+    expect(synth.spoken[synth.spoken.length - 1].text).toBe("Tail.");
+    expect(synth.spoken.length).toBeGreaterThan(2);
+  });
+
+  it("stop cancels synthesis and clears the queue", () => {
+    const synth = new FakeSynth();
+    const player = makePlayer(synth);
+    player.play([{ id: "a", text: "Hello there friend." }]);
+    player.stop();
+    expect(synth.cancelled).toBeGreaterThan(0);
+    expect(player.isPlaying()).toBe(false);
+  });
+
+  it("pause and resume map to the synth", () => {
+    const synth = new FakeSynth();
+    const player = makePlayer(synth);
+    player.play([{ id: "a", text: "Hello there friend." }]);
+    player.pause();
+    expect(synth.paused).toBe(true);
+    player.resume();
+    expect(synth.paused).toBe(false);
+  });
+
+  it("strips formatting from item text before speaking", () => {
+    const synth = new FakeSynth();
+    const player = makePlayer(synth);
+    player.play([{ id: "a", text: "## Heading\n**Bold** point." }]);
+    const allSpoken = synth.spoken.map((u) => u.text).join(" ");
+    expect(allSpoken).not.toMatch(/[#*]/);
+    expect(allSpoken).toContain("Heading");
+    expect(allSpoken).toContain("Bold point");
+  });
+
+  it("skip advances within the current item by the computed word count", () => {
+    const synth = new FakeSynth();
+    const player = makePlayer(synth);
+    // 200 words, single item; at rate 1.2 a 30s skip ~ 90 words.
+    const words = Array.from({ length: 200 }, (_, i) => `w${i}`).join(" ") + ".";
+    player.setRate(1.2);
+    player.play([{ id: "a", text: words }]);
+    const before = synth.spoken.length;
+    player.skip(30);
+    expect(synth.spoken.length).toBeGreaterThan(before);
+    // After skipping ~90 words, the freshly spoken chunk should start near w90,
+    // not back at w0.
+    const latest = synth.spoken[synth.spoken.length - 1].text;
+    expect(latest).not.toContain("w0 ");
+    expect(latest).toMatch(/w(8[5-9]|9[0-5])/);
+  });
+});


### PR DESCRIPTION
Closes #11

Stacked on #45 (base branch `feat/issue-10-web-app`).

## Summary
Adds Web Speech API playback. `src/lib/tts.ts` is a `speechSynthesis` wrapper: a playlist queue (`onend` advances), ~200-char sentence chunking to dodge the iOS long-utterance cutoff, formatting-artifact stripping before every utterance, voice+rate persisted in `localStorage` (default 1.2x), skip-30s, first-`speak()`-from-gesture guard, and a `visibilitychange` resume nudge. `src/components/playback.ts` renders per-card play/pause/stop/skip-30s controls plus a "Play all today" bar, wired via the `registerPlaybackControls()` hook #10 left in the digest card. Single sanctioned touchpoint in `main.ts` (one import line); no other shared files touched.

## Test Evidence (run on the radeon machine, fresh `npm ci`)
- **Unit (Vitest):** 40 passed (40) — incl. 22 new TTS tests (queue advance, chunking, artifact stripping for bold/headers/lists/links/code/blockquotes, localStorage persistence, skip-30s).
- **Integration (Playwright, chromium @390×844):** 8 passed (8) — controls render per card; Play invokes `speechSynthesis.speak` + play/pause/stop state transitions; skip-30s re-utters from an advanced position; Play-all advances the queue; voice/rate persist. #10's 3 specs still green (no regression).
- **Real-world (Lighthouse mobile @390×844, radeon):** performance 100, accessibility 95, best-practices 96, SEO 91 — no regression.

## Remaining (human checkpoint CP-3 — iPhone Safari, device-specific API)
On the deployed app, after magic-link sign-in: Play starts audio from the tap (gesture), spoken text has no markdown artifacts, pause/resume/stop/skip-30s work, Play-all reads in order, voice+rate persist across reload, and playback resumes after a ~10s screen-lock/app-switch (`visibilitychange`). Headless Chromium cannot emit audio, so real iOS behavior must be confirmed on device.