### PR TITLE
Fix Cloudflare Pages deploy: self-bootstrap project

### DIFF
--- a/.github/workflows/web.yml
+++ b/.github/workflows/web.yml
@@ -89,6 +89,16 @@ jobs:
             echo "Cloudflare secrets not set; skipping deploy."
           fi
 
+      # Self-bootstrap: create the Pages project on first run. Idempotent —
+      # if it already exists, wrangler exits non-zero and we ignore it.
+      - name: Ensure Cloudflare Pages project exists
+        if: steps.cf.outputs.enabled == 'true'
+        working-directory: web
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+        run: npx --yes wrangler@3 pages project create news-digest-web --production-branch=main || echo "project already exists (or create not permitted); continuing to deploy"
+
       - name: Deploy to Cloudflare Pages
         if: steps.cf.outputs.enabled == 'true'
         uses: cloudflare/wrangler-action@v3


### PR DESCRIPTION
The Epic 3 deploy job (added in #10) failed on first run to `main`:

```
[ERROR] A request to the Cloudflare API (/accounts/***/pages/projects/news-digest-web) failed.
  Project not found. The specified project name does not match any of your existing projects. [code: 8000007]
```

`wrangler pages deploy` does not create the project if it's missing. This adds an idempotent "Ensure Cloudflare Pages project exists" step before deploy (`wrangler pages project create … --production-branch=main`, create error ignored on later runs). First run provisions `news-digest-web`; later runs no-op and deploy.

Follow-up to #10 — CI hotfix so the live-deploy acceptance criterion can complete.