### PR TITLE
Add local_news topic + fetch_pdf_text scraping tool

### DIFF
--- a/.claude/plans/issue-18.md
+++ b/.claude/plans/issue-18.md
@@ -1,0 +1,81 @@
+---
+type: plan
+source-issue: 18
+repo: itomek/itomek-news-digest-agent
+title: "Add topic: local news (Bucks County / Quakertown, 7d) + PDF extraction tool"
+created: 2026-06-03
+status: draft
+work_type: code-feature
+complexity: complex
+tdd_required: true
+suggested_team_size: 1
+estimated_files_changed: 4
+test_command: "ssh tomas@t-nx-strx-halo 'bash -lc \"cd ~/src/itomek/itomek-news-digest-agent && git fetch origin && git checkout feat/issue-18-local-news && git pull --ff-only && source .venv/bin/activate && pip install -e .[dev] -q && pytest -m \\\"not integration\\\" -q\"'"
+build_command: "ssh tomas@t-nx-strx-halo 'bash -lc \"cd ~/src/itomek/itomek-news-digest-agent && source .venv/bin/activate && pip install -e .[dev] -q && python -c \\\"import news_digest.tools.scraping, pypdf\\\"\"'"
+lint_command: "ruff check src tests && ruff format --check src tests"
+branch: feat/issue-18-local-news
+reflection_iterations: 0
+agents_used: [planning, execution, validation]
+---
+
+# Plan — Issue #18: local news (`local_news`, 7d) + generic PDF text tool
+
+Hyperlocal sources are small, inconsistently structured, and often lack RSS — and
+township meeting material is published as PDF. The durable capability this topic
+needs is **PDF text extraction**, which is generically useful, so build that rather
+than a BoardDocs-only scraper.
+
+## Architecture decision (orchestrator) — generic `fetch_pdf_text`, BoardDocs only if confirmed
+The issue hedges on BoardDocs ("if the format requires it") and on whether Richland
+Township even uses it. Resolve the uncertainty by building a **generic
+`fetch_pdf_text(url)`** tool (pypdf) that extracts text from ANY PDF (agendas,
+minutes), plus HTML/RSS scraping of local news sites via the existing tools. Do NOT
+build BoardDocs-platform-specific crawling in this issue — if the real-world run
+confirms Richland uses BoardDocs and a stable PDF URL pattern, note it in the PR as
+a fast-follow; the generic tool already extracts those PDFs once their URLs are known.
+This keeps the issue tractable and the new code broadly reusable.
+
+## Acceptance criteria → evidence
+- [ ] Topic seeded (`local_news`, 7d, sources, prompt_hint) → migration `0008`, applied live (orchestrator).
+- [ ] Listed sources produce content OR are documented unavailable → real-world run + PR notes; thin coverage is logged, never silent.
+- [ ] Meeting-PDF text extracted cleanly → `fetch_pdf_text` unit tests + a real PDF in the integration/real-world run.
+- [ ] Thin-coverage failure mode logged clearly → tool logs (existing `log()` pattern) + prompt_hint instruction to state when sources were unavailable.
+
+## File ownership (strict — do NOT touch files outside this list)
+- APPEND to `src/news_digest/tools/scraping.py`: the `fetch_pdf_text` tool (and a small private `_extract_pdf_text(raw: bytes) -> str` helper). REUSE `_fetch_document(url, "fetch_pdf_text")` for validate+throttle+fetch, `_now_utc`, `log`. Never raises; returns the page-shape dict below.
+- EDIT `pyproject.toml`: add `"pypdf>=4.0,<6.0"` to `[project].dependencies` (alphabetical-ish, near the other parse deps). This is the ONLY file outside scraping/tests/migrations you may edit; no other issue in this wave touches it.
+- NEW `supabase/migrations/0008_seed_local_news_topic.sql`. Number is FIXED at 0008.
+- NEW/EDIT `tests/test_scraping_tools.py`: add `fetch_pdf_text` unit cases (mock bytes; do not hit the network in non-integration tests). You may add `@pytest.mark.integration` cases that fetch a real PDF (these run only on the host).
+- Do NOT edit `agent.py`, `prompts.py`, `publishing.py`, `analysis.py`, `config.py`, `tests/test_prompts.py`, `tests/test_publishing_tools.py`.
+
+## Design — `fetch_pdf_text(url: str) -> dict`
+Mirror `parse_article`'s contract exactly so the LLM sees a familiar shape:
+- Returns `{"title": str, "content": str, "url": str, "fetched_at": iso, "pages": int}`; on any failure the same shape with empty content + an `"error"` key. Never raises.
+- Flow: `raw, err = _fetch_document(url, "fetch_pdf_text")`; if err → `{**base, "error": err}`. Else `_extract_pdf_text(raw)` via `pypdf.PdfReader(io.BytesIO(raw))`, concatenating `page.extract_text()` across pages with `\n` joins; strip; cap to a sane size (reuse the spirit of the 10 MB byte cap — extracted text can be large; truncate to e.g. 200k chars and log if truncated).
+- Error handling: wrap pypdf in try/except → log warn + `error="pdf_parse_error: <cls>"`. Empty extraction (scanned/image PDF) → `error="no_text"` (info log), content "".
+- Register via `@tool` (auto-discovered on import). Add it to the module docstring's tool list and the `__main__` debug dispatch (`--pdf <url>`), matching the existing style.
+
+## TDD (tests FIRST, then green) — `tests/test_scraping_tools.py`
+The file already mocks HTTP via httpx `MockTransport` and patches `_validate_url`/throttle for unit tests — reuse those patterns (read the top of the file first). Unit cases (no network):
+1. Valid multi-page PDF bytes → `content` contains text from each page; `pages` correct. Build a tiny PDF in-test (pypdf can write one) or commit a small fixture under `tests/`.
+2. Non-PDF / corrupt bytes → `error` set, `content == ""`, never raises.
+3. Image-only / no extractable text → `error == "no_text"`.
+4. Fetch failure (transport error / non-retryable HTTP) → propagates `_fetch_document`'s error into the dict; never raises.
+5. SSRF-blocked URL → blocked before fetch (reuse the existing unsafe-url test pattern).
+Integration (host-only, `@pytest.mark.integration`): fetch one real public PDF and assert non-empty `content`.
+
+## Design — `0008_seed_local_news_topic.sql`
+Follow `0002`'s shape; `on conflict (slug) do nothing`.
+- name `'Bucks County / Quakertown local news'`, slug `local_news`, cadence `'7d'`, enabled true.
+- sources (curate; many likely lack RSS → use HTML URLs the LLM scrapes with `fetch_html`, and PDF URLs it reads with `fetch_pdf_text`): Bucks County Herald, Quakertown "The Free Press", Richland Township site / meeting-minutes page, Bucks County Courier Times local section. Include any discovered township-meeting PDF URL.
+- prompt_hint: emphasise zoning changes, school-board decisions, township/borough meeting outcomes, local business, community events; instruct to read meeting agendas/minutes via `fetch_pdf_text`; and instruct: *"Coverage may be thin; if sources were unavailable or returned nothing, say so plainly rather than padding."*
+
+## Validation tiers
+- **Local (teammate):** `ruff`; code-reviewer subagent (Critical-only). Build a local 3.12 venv if possible for the red→green loop; else note pytest not run locally.
+- **Host unit + build (orchestrator):** `test_command` (installs pypdf) + `build_command` (imports pypdf).
+- **Real-world (orchestrator):** apply `0008`; `python -m news_digest "Generate the local news digest for this week"`; verify `digests` row + logs (including any "source unavailable" warns); if a real meeting PDF is reachable, confirm `fetch_pdf_text` extracted it; human rating on coverage/coherence. Confirm-or-deny BoardDocs for the PR notes.
+
+## Risks
+- Local sites are fragile / may lack feeds → expect drops; document dead sources, never crash (tools already return safe empties).
+- Scanned PDFs yield no text (no OCR in scope) → `no_text` is the correct, logged outcome.
+- pypdf version API: use `PdfReader` + `page.extract_text()` (pypdf ≥ 4). Confirm against installed version via Context7 if unsure.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,6 +23,7 @@ dependencies = [
     "trafilatura>=1.12.0",
     "pydantic-settings>=2.0",
     "apscheduler>=3.10.0,<4.0.0",
+    "pypdf>=4.0,<6.0",
     "supabase>=2.0,<3.0",
     "tenacity>=8.2.3",
 ]

--- a/src/news_digest/tools/scraping.py
+++ b/src/news_digest/tools/scraping.py
@@ -7,6 +7,7 @@ Tools:
     fetch_rss: Parse an RSS/Atom feed and return recent entries.
     fetch_html: Scrape an HTML page, optionally scoped to a CSS selector.
     parse_article: Extract the main article body + metadata from a URL.
+    fetch_pdf_text: Download a PDF and extract its text content.
 
 Note on architecture deviation: docs/architecture.md §5.3 shows @retry directly
 on the public tool function. We deviate intentionally: @retry lives on the
@@ -16,6 +17,7 @@ function never raises.
 """
 
 import hashlib
+import io
 import ipaddress
 import json
 import socket
@@ -29,6 +31,7 @@ from urllib.parse import urljoin, urlparse
 
 import feedparser
 import httpx
+import pypdf
 import trafilatura
 from bs4 import BeautifulSoup
 from gaia.agents.base.tools import tool
@@ -69,6 +72,7 @@ _MAX_RESPONSE_BYTES: int = 10 * 1024 * 1024  # 10 MB
 _USER_AGENT: str = (
     "news-digest-agent/0.1 (+https://github.com/itomek/itomek-news-digest-agent)"
 )
+_PDF_MAX_CHARS: int = 200_000
 
 # Per-domain last-fetch timestamp (monotonic clock). See _throttle.
 _last_fetch: dict[str, float] = {}
@@ -647,11 +651,116 @@ def parse_article(url: str) -> dict:
     return result
 
 
+def _extract_pdf_text(raw: bytes) -> tuple[str, int]:
+    """Extract text from raw PDF bytes using pypdf.
+
+    Returns:
+        (text, page_count) — text is the joined, stripped extraction across all
+        pages. Returns ("", 0) when pypdf raises (let the caller handle it).
+        Raises:
+            pypdf.errors.PdfReadError (and subclasses) on corrupt/invalid PDF.
+            Any other exception from pypdf on malformed content.
+    """
+    reader = pypdf.PdfReader(io.BytesIO(raw))
+    page_count = len(reader.pages)
+    parts: list[str] = []
+    for page in reader.pages:
+        extracted = page.extract_text() or ""
+        if extracted.strip():
+            parts.append(extracted)
+    return "\n".join(parts).strip(), page_count
+
+
+@tool
+def fetch_pdf_text(url: str) -> dict:
+    """Download a PDF from a URL and extract its text content.
+
+    Useful for reading meeting agendas, minutes, and other documents that are
+    only available as PDFs.  Image-only (scanned) PDFs will yield no text.
+
+    Args:
+        url: The PDF URL (http or https).
+
+    Returns:
+        A dict with keys: title (always ""), content (extracted text),
+        url, fetched_at (ISO-8601 UTC), pages (int, number of PDF pages).
+        On any failure the same shape is returned with empty content, pages=0,
+        and an "error" key. The call never raises. Scanned/image PDFs that
+        contain no text layer return error="no_text" with content="".
+    """
+    t_start = time.monotonic()
+    fetched_at = _now_utc().isoformat()
+    base: dict = {
+        "title": "",
+        "content": "",
+        "url": url,
+        "fetched_at": fetched_at,
+        "pages": 0,
+    }
+
+    raw, err = _fetch_document(url, "fetch_pdf_text")
+    if err is not None:
+        return {**base, "error": err}
+
+    try:
+        text, page_count = _extract_pdf_text(raw)
+    except Exception as exc:
+        log(
+            "warn",
+            "scrape",
+            f"fetch_pdf_text: pdf parse error for {url}: {exc.__class__.__name__}",
+            metadata={"url": url, "error_class": exc.__class__.__name__},
+        )
+        return {**base, "error": f"pdf_parse_error: {exc.__class__.__name__}"}
+
+    if not text:
+        log(
+            "info",
+            "scrape",
+            f"fetch_pdf_text: no_text (image/scanned PDF?) for {url}",
+            metadata={"url": url, "pages": page_count},
+        )
+        return {**base, "pages": page_count, "error": "no_text"}
+
+    if len(text) > _PDF_MAX_CHARS:
+        log(
+            "warn",
+            "scrape",
+            f"fetch_pdf_text: truncated {len(text)} -> {_PDF_MAX_CHARS} chars for {url}",
+            metadata={
+                "url": url,
+                "original_chars": len(text),
+                "truncated_chars": _PDF_MAX_CHARS,
+            },
+        )
+        text = text[:_PDF_MAX_CHARS]
+
+    log(
+        "info",
+        "scrape",
+        f"fetch_pdf_text: {len(text)} chars, {page_count} pages from {url}",
+        metadata={
+            "url": url,
+            "content_chars": len(text),
+            "pages": page_count,
+            "duration_ms": round((time.monotonic() - t_start) * 1000),
+        },
+    )
+    return {
+        "title": "",
+        "content": text,
+        "url": url,
+        "fetched_at": fetched_at,
+        "pages": page_count,
+    }
+
+
 # Debug entry point — bypasses scheduler / agent so a developer can validate a
 # single tool against a real URL in seconds:
 #   python -m news_digest.tools.scraping <feed_url> [since_hours]
 #   python -m news_digest.tools.scraping --html <url> [css_selector]
 #   python -m news_digest.tools.scraping --article <url>
+#   python -m news_digest.tools.scraping --pdf <url>
 if __name__ == "__main__":  # pragma: no cover
 
     def _emit(obj: object) -> None:
@@ -663,7 +772,8 @@ if __name__ == "__main__":  # pragma: no cover
             "usage:\n"
             "  python -m news_digest.tools.scraping <feed_url> [since_hours]\n"
             "  python -m news_digest.tools.scraping --html <url> [css_selector]\n"
-            "  python -m news_digest.tools.scraping --article <url>",
+            "  python -m news_digest.tools.scraping --article <url>\n"
+            "  python -m news_digest.tools.scraping --pdf <url>",
             file=sys.stderr,
         )
         sys.exit(2)
@@ -672,6 +782,8 @@ if __name__ == "__main__":  # pragma: no cover
         _emit(fetch_html(_args[1], selector=_args[2] if len(_args) > 2 else None))
     elif _args[0] == "--article":
         _emit(parse_article(_args[1]))
+    elif _args[0] == "--pdf":
+        _emit(fetch_pdf_text(_args[1]))
     else:
         _since = int(_args[1]) if len(_args) > 1 else 24
         _result = fetch_rss(_args[0], since_hours=_since)

--- a/supabase/migrations/0008_seed_local_news_topic.sql
+++ b/supabase/migrations/0008_seed_local_news_topic.sql
@@ -1,0 +1,22 @@
+-- 0008_seed_local_news_topic.sql — local_news topic row (Bucks County / Quakertown, 7d).
+-- Sources: mix of RSS, HTML scraped pages, and PDF meeting-minutes URLs.
+-- Coverage is intentionally thin — the agent is instructed to say so rather than pad.
+
+insert into digest_topics (name, slug, cadence, sources, prompt_hint, enabled)
+values (
+  'Bucks County / Quakertown local news',
+  'local_news',
+  '7d',
+  '[
+    {"type": "rss",  "url": "https://www.buckscountycouriertimes.com/arcio/rss/category/news/local/"},
+    {"type": "html", "url": "https://www.buckscountyherald.com/news/"},
+    {"type": "html", "url": "https://www.thefreepresspa.com/"},
+    {"type": "html", "url": "https://www.richlandtownship.org/meetings"},
+    {"type": "html", "url": "https://www.quakertownpa.gov/news"},
+    {"type": "html", "url": "https://www.centennialsd.org/news"},
+    {"type": "html", "url": "https://www.buckscountycouriertimes.com/news/local/"}
+  ]'::jsonb,
+  'Summarise local news and government activity for Bucks County and Quakertown, PA. Focus on: zoning changes and planning commission decisions, school-board votes and policy changes (Centennial SD), township/borough council meeting outcomes (Richland Township, Quakertown Borough), local business openings/closings, community events, and crime or public-safety notices. When township meeting materials (agendas, minutes) are available as PDFs, read them with fetch_pdf_text and surface key votes and decisions. Coverage may be thin; if sources were unavailable, returned no content, or produced nothing newsworthy, say so plainly rather than padding the digest.',
+  true
+)
+on conflict (slug) do nothing;

--- a/tests/test_scraping_tools.py
+++ b/tests/test_scraping_tools.py
@@ -1,7 +1,8 @@
 """Tests for src/news_digest/tools/scraping.py — issues #5 (fetch_rss) and #6
-(fetch_html, parse_article)."""
+(fetch_html, parse_article) and #18 (fetch_pdf_text)."""
 
 import hashlib
+import io
 from collections import Counter
 from datetime import UTC, datetime, timedelta
 from email.utils import format_datetime
@@ -12,7 +13,7 @@ import pytest
 
 from news_digest.tools import scraping
 from news_digest.tools.scraping import _validate_url as _REAL_VALIDATE_URL
-from news_digest.tools.scraping import fetch_html, fetch_rss, parse_article
+from news_digest.tools.scraping import fetch_html, fetch_pdf_text, fetch_rss, parse_article
 
 # ---------------------------------------------------------------------------
 # Synthetic feed XML helpers
@@ -930,3 +931,182 @@ def test_parse_article_against_real_page():
     assert "error" not in result
     assert result["title"]
     assert len(result["content"]) > 500
+
+
+# ===========================================================================
+# T10 — fetch_pdf_text (issue #18)
+# ===========================================================================
+
+
+def _make_pdf_bytes(pages: list[str]) -> bytes:
+    """Build a minimal valid PDF with text layers using pypdf's PdfWriter.
+
+    Each element of `pages` becomes the visible text on one page.  The output
+    is a real PDF that PdfReader can parse and extract_text() can read back —
+    no third-party fixture files needed.
+    """
+    from pypdf import PdfWriter
+
+    writer = PdfWriter()
+    for text in pages:
+        page = writer.add_blank_page(width=612, height=792)
+        page.compress_content_streams()
+        # Add a raw content stream with a simple text object.
+        stream = f"BT /F1 12 Tf 72 720 Td ({text}) Tj ET".encode()
+        # PdfWriter doesn't have a high-level add_text API, so we inject the
+        # stream directly; /F1 may not resolve but extract_text still returns
+        # the string from the Tj operand.
+        from pypdf.generic import DecodedStreamObject, NameObject
+
+        content_obj = DecodedStreamObject()
+        content_obj.set_data(stream)
+        page[NameObject("/Contents")] = writer._add_object(content_obj)
+    buf = io.BytesIO()
+    writer.write(buf)
+    return buf.getvalue()
+
+
+def test_fetch_pdf_text_is_tool_with_doc_preserved():
+    assert callable(fetch_pdf_text)
+    assert fetch_pdf_text.__doc__ is not None
+    assert "url" in fetch_pdf_text.__doc__.lower()
+    assert "Returns:" in fetch_pdf_text.__doc__
+
+
+def test_fetch_pdf_text_returns_expected_keys(monkeypatch):
+    pdf = _make_pdf_bytes(["Hello world"])
+    _patch_make_client(monkeypatch, lambda req: _ok_response(pdf))
+
+    result = fetch_pdf_text("https://example.com/doc.pdf")
+
+    assert set(result.keys()) == {"title", "content", "url", "fetched_at", "pages"}
+    assert result["url"] == "https://example.com/doc.pdf"
+    assert isinstance(result["pages"], int)
+    assert isinstance(datetime.fromisoformat(result["fetched_at"]), datetime)
+
+
+def test_fetch_pdf_text_extracts_text_from_multi_page_pdf(monkeypatch):
+    pdf = _make_pdf_bytes(["Page one text", "Page two text"])
+    _patch_make_client(monkeypatch, lambda req: _ok_response(pdf))
+
+    result = fetch_pdf_text("https://example.com/two-pages.pdf")
+
+    assert "error" not in result
+    assert result["pages"] == 2
+    # Both pages' text must be present in content.
+    assert "Page one text" in result["content"]
+    assert "Page two text" in result["content"]
+    assert len(result["content"]) > 0
+
+
+def test_fetch_pdf_text_never_raises_on_corrupt_bytes(monkeypatch):
+    _patch_make_client(monkeypatch, lambda req: _ok_response(b"not a pdf at all"))
+
+    result = fetch_pdf_text("https://example.com/bad.pdf")
+
+    assert result["content"] == ""
+    assert "error" in result
+    assert result["pages"] == 0
+
+
+def test_fetch_pdf_text_corrupt_returns_pdf_parse_error(monkeypatch, mock_log):
+    _patch_make_client(monkeypatch, lambda req: _ok_response(b"%%garbage"))
+
+    result = fetch_pdf_text("https://example.com/bad.pdf")
+
+    assert result["content"] == ""
+    assert "error" in result
+    # The tool must log a warn for parse failures.
+    warn_calls = [c for c in mock_log.call_args_list if c.args[0] == "warn"]
+    assert len(warn_calls) >= 1
+
+
+def test_fetch_pdf_text_image_only_pdf_returns_no_text_error(monkeypatch, mock_log):
+    """A valid PDF that yields no extractable text (e.g. scanned image) must
+    return error='no_text' and log at info level, not warn."""
+    # Build a valid PDF where extract_text() returns "" for every page.
+    # We achieve this by making a real PDF but monkeypatching _extract_pdf_text
+    # to simulate the image-only case — this tests the tool's branching, not pypdf.
+    pdf = _make_pdf_bytes(["real text"])
+    _patch_make_client(monkeypatch, lambda req: _ok_response(pdf))
+    monkeypatch.setattr(scraping, "_extract_pdf_text", lambda raw: ("", 1))
+
+    result = fetch_pdf_text("https://example.com/scanned.pdf")
+
+    assert result["error"] == "no_text"
+    assert result["content"] == ""
+    assert result["pages"] == 1
+    info_calls = [c for c in mock_log.call_args_list if c.args[0] == "info"]
+    assert any("no_text" in c.args[2] for c in info_calls)
+
+
+def test_fetch_pdf_text_propagates_fetch_error(monkeypatch):
+    handler = _counting_handler([httpx.Response(404)])
+    _patch_make_client(monkeypatch, handler)
+
+    result = fetch_pdf_text("https://example.com/missing.pdf")
+
+    assert result["error"] == "http_404"
+    assert result["content"] == ""
+    assert result["pages"] == 0
+    assert handler.calls["i"] == 1
+
+
+def test_fetch_pdf_text_propagates_retry_exhaustion(monkeypatch):
+    def raise_connect(req):
+        raise httpx.ConnectError("timeout")
+
+    handler = _counting_handler([raise_connect])
+    _patch_make_client(monkeypatch, handler)
+
+    result = fetch_pdf_text("https://example.com/slow.pdf")
+
+    assert result["content"] == ""
+    assert "error" in result
+    # Must not raise
+    assert isinstance(result, dict)
+
+
+def test_fetch_pdf_text_rejects_unsafe_url(monkeypatch, mock_log):
+    monkeypatch.setattr(scraping, "_validate_url", _REAL_VALIDATE_URL)
+    handler = _counting_handler([_ok_response(b"%PDF")])
+    _patch_make_client(monkeypatch, handler)
+
+    result = fetch_pdf_text("http://127.0.0.1/admin.pdf")
+
+    assert result["error"].startswith("unsafe_url")
+    assert result["content"] == ""
+    assert result["pages"] == 0
+    assert handler.calls["i"] == 0  # never reached the network
+
+
+def test_fetch_pdf_text_truncates_very_long_content(monkeypatch, mock_log):
+    """Content exceeding _PDF_MAX_CHARS must be truncated and a warn logged."""
+    # Build a pdf; then monkeypatch _extract_pdf_text to return a very long string.
+    pdf = _make_pdf_bytes(["x"])
+    _patch_make_client(monkeypatch, lambda req: _ok_response(pdf))
+    long_text = "A" * (210_000)
+    monkeypatch.setattr(scraping, "_extract_pdf_text", lambda raw: (long_text, 1))
+
+    result = fetch_pdf_text("https://example.com/long.pdf")
+
+    assert len(result["content"]) <= scraping._PDF_MAX_CHARS
+    warn_calls = [c for c in mock_log.call_args_list if c.args[0] == "warn"]
+    assert any("truncat" in c.args[2].lower() for c in warn_calls)
+
+
+# ---------------------------------------------------------------------------
+# Integration — real PDF fetch (host-only)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.integration
+def test_fetch_pdf_text_against_real_pdf():
+    """Fetch a stable, small public PDF and assert non-empty text extraction."""
+    # W3C spec PDF — stable, small, text-layer present.
+    result = fetch_pdf_text(
+        "https://www.w3.org/WAI/WCAG21/Techniques/pdf/PDF1.pdf"
+    )
+    assert "error" not in result
+    assert result["pages"] >= 1
+    assert len(result["content"]) > 50

--- a/tests/test_scraping_tools.py
+++ b/tests/test_scraping_tools.py
@@ -13,7 +13,12 @@ import pytest
 
 from news_digest.tools import scraping
 from news_digest.tools.scraping import _validate_url as _REAL_VALIDATE_URL
-from news_digest.tools.scraping import fetch_html, fetch_pdf_text, fetch_rss, parse_article
+from news_digest.tools.scraping import (
+    fetch_html,
+    fetch_pdf_text,
+    fetch_rss,
+    parse_article,
+)
 
 # ---------------------------------------------------------------------------
 # Synthetic feed XML helpers
@@ -1104,9 +1109,7 @@ def test_fetch_pdf_text_truncates_very_long_content(monkeypatch, mock_log):
 def test_fetch_pdf_text_against_real_pdf():
     """Fetch a stable, small public PDF and assert non-empty text extraction."""
     # W3C spec PDF — stable, small, text-layer present.
-    result = fetch_pdf_text(
-        "https://www.w3.org/WAI/WCAG21/Techniques/pdf/PDF1.pdf"
-    )
+    result = fetch_pdf_text("https://www.w3.org/WAI/WCAG21/Techniques/pdf/PDF1.pdf")
     assert "error" not in result
     assert result["pages"] >= 1
     assert len(result["content"]) > 50

--- a/tests/test_scraping_tools.py
+++ b/tests/test_scraping_tools.py
@@ -2,7 +2,6 @@
 (fetch_html, parse_article) and #18 (fetch_pdf_text)."""
 
 import hashlib
-import io
 from collections import Counter
 from datetime import UTC, datetime, timedelta
 from email.utils import format_datetime
@@ -944,31 +943,109 @@ def test_parse_article_against_real_page():
 
 
 def _make_pdf_bytes(pages: list[str]) -> bytes:
-    """Build a minimal valid PDF with text layers using pypdf's PdfWriter.
+    """Build a minimal hand-rolled PDF with text-layer content for each page.
 
-    Each element of `pages` becomes the visible text on one page.  The output
-    is a real PDF that PdfReader can parse and extract_text() can read back —
-    no third-party fixture files needed.
+    Uses raw PDF syntax (no pypdf writer internals) so the output is stable
+    across pypdf versions.  pypdf's extract_text() reliably recovers ASCII text
+    from the Tj operator in a BT/ET block — this is the same pattern pypdf's
+    own test suite uses for synthetic PDFs.
+
+    Each element of `pages` becomes the ASCII text on one page.  Stick to
+    plain ASCII — no parens, no backslash — in test strings.
     """
-    from pypdf import PdfWriter
+    # We build a single-page or multi-page PDF by hand.  The structure is:
+    #   header, N content streams, N page objects, pages tree, catalog, xref, trailer.
+    parts: list[bytes] = []
+    offsets: list[int] = []
+    pos = 0
 
-    writer = PdfWriter()
-    for text in pages:
-        page = writer.add_blank_page(width=612, height=792)
-        page.compress_content_streams()
-        # Add a raw content stream with a simple text object.
-        stream = f"BT /F1 12 Tf 72 720 Td ({text}) Tj ET".encode()
-        # PdfWriter doesn't have a high-level add_text API, so we inject the
-        # stream directly; /F1 may not resolve but extract_text still returns
-        # the string from the Tj operand.
-        from pypdf.generic import DecodedStreamObject, NameObject
+    header = b"%PDF-1.4\n"
+    parts.append(header)
+    pos += len(header)
 
-        content_obj = DecodedStreamObject()
-        content_obj.set_data(stream)
-        page[NameObject("/Contents")] = writer._add_object(content_obj)
-    buf = io.BytesIO()
-    writer.write(buf)
-    return buf.getvalue()
+    # Object numbering: 1=catalog, 2=pages, 3..N+2=page objects, N+3..2N+2=streams
+    n = len(pages)
+    catalog_obj_id = 1
+    pages_obj_id = 2
+    first_page_obj_id = 3
+    first_stream_obj_id = 3 + n
+
+    # Content stream objects (one per page).
+    stream_obj_ids: list[int] = []
+    for i, text in enumerate(pages):
+        obj_id = first_stream_obj_id + i
+        stream_obj_ids.append(obj_id)
+        content = f"BT /F1 12 Tf 72 720 Td ({text}) Tj ET\n".encode()
+        obj_bytes = (
+            (f"{obj_id} 0 obj\n<< /Length {len(content)} >>\nstream\n").encode()
+            + content
+            + b"endstream\nendobj\n"
+        )
+        offsets.append(pos)
+        parts.append(obj_bytes)
+        pos += len(obj_bytes)
+
+    # Page objects.
+    page_obj_ids: list[int] = []
+    for i in range(n):
+        obj_id = first_page_obj_id + i
+        page_obj_ids.append(obj_id)
+        obj_bytes = (
+            f"{obj_id} 0 obj\n"
+            f"<< /Type /Page /Parent {pages_obj_id} 0 R "
+            f"/MediaBox [0 0 612 792] "
+            f"/Contents {stream_obj_ids[i]} 0 R "
+            f"/Resources << /Font << /F1 << /Type /Font /Subtype /Type1 "
+            f"/BaseFont /Helvetica >> >> >> >>\n"
+            f">>\nendobj\n"
+        ).encode()
+        offsets.append(pos)
+        parts.append(obj_bytes)
+        pos += len(obj_bytes)
+
+    # Pages dictionary.
+    kids = " ".join(f"{oid} 0 R" for oid in page_obj_ids)
+    pages_bytes = (
+        f"{pages_obj_id} 0 obj\n<< /Type /Pages /Kids [{kids}] /Count {n} >>\nendobj\n"
+    ).encode()
+    offsets.append(pos)
+    parts.append(pages_bytes)
+    pos += len(pages_bytes)
+
+    # Catalog.
+    catalog_bytes = (
+        f"{catalog_obj_id} 0 obj\n"
+        f"<< /Type /Catalog /Pages {pages_obj_id} 0 R >>\n"
+        f"endobj\n"
+    ).encode()
+    offsets.append(pos)
+    parts.append(catalog_bytes)
+    pos += len(catalog_bytes)
+
+    # xref + trailer.
+    total_objects = 2 * n + 2  # streams + pages + pages_dict + catalog
+    xref_offset = pos
+    # Build a lookup: obj_id -> byte offset.
+    # Order: stream objects, page objects, pages, catalog.
+    id_to_offset: dict[int, int] = {}
+    for i, obj_id in enumerate(stream_obj_ids):
+        id_to_offset[obj_id] = offsets[i]
+    for i, obj_id in enumerate(page_obj_ids):
+        id_to_offset[obj_id] = offsets[n + i]
+    id_to_offset[pages_obj_id] = offsets[2 * n]
+    id_to_offset[catalog_obj_id] = offsets[2 * n + 1]
+
+    xref = f"xref\n0 {total_objects + 1}\n"
+    xref += "0000000000 65535 f \n"
+    for obj_id in range(1, total_objects + 1):
+        xref += f"{id_to_offset[obj_id]:010d} 00000 n \n"
+    trailer = (
+        f"trailer\n<< /Size {total_objects + 1} /Root {catalog_obj_id} 0 R >>\n"
+        f"startxref\n{xref_offset}\n%%EOF\n"
+    )
+    parts.append(xref.encode() + trailer.encode())
+
+    return b"".join(parts)
 
 
 def test_fetch_pdf_text_is_tool_with_doc_preserved():


### PR DESCRIPTION
Closes #18

## Summary
- Adds `fetch_pdf_text(url)` `@tool` to `scraping.py`: downloads a PDF, extracts text via `pypdf.PdfReader`, returns `{title, content, url, fetched_at, pages}`. Reuses `_fetch_document` for SSRF validation + throttling + retries. Mirrors `parse_article`'s never-raise contract. Handles corrupt bytes, image/scanned PDFs (`no_text`), and oversized text (truncates at 200k chars with warning log).
- Adds `pypdf>=4.0,<6.0` to `pyproject.toml` dependencies.
- Seeds `local_news` topic via migration `0008` (7 sources: Bucks County Courier Times RSS + HTML, Bucks County Herald, The Free Press PA, Richland Township meetings, Quakertown Borough, Centennial SD — 7d cadence). The pre-existing stub row (id=2, empty sources) was updated via migration `0008b`.
- Adds `--pdf <url>` debug dispatch to `__main__` module entrypoint.

## Test Evidence
- **Unit:** 100 passed (11 new `fetch_pdf_text` tests: happy path, multi-page, corrupt bytes, image PDF, 4xx propagation, retry exhaustion, SSRF rejection, truncation + 1 integration test) on Strix Halo, pypdf 5.9.0 installed.
- **Build check:** `python -c "import news_digest.tools.scraping, pypdf"` clean on host.
- **Lint:** ruff check + format — clean.
- **Seed migrations:** Applied to live Supabase (`0008` + `0008b`) — row confirmed (7 sources).
- **BoardDocs:** Not confirmed for Richland Township during this run. If confirmed live, a BoardDocs-specific PDF crawler is a fast-follow using `fetch_pdf_text` as the extraction layer.
- **Real-world digest:** Deferred — same `push_to_supabase` publish-step reliability issue as #54. Verify after that fix lands; expect thin coverage with explicit "sources unavailable" logs from HTML-only local sources.