### PR TITLE
Fix digest reads for logged-in users: RLS to authenticated role

### DIFF
--- a/.github/workflows/web.yml
+++ b/.github/workflows/web.yml
@@ -21,6 +21,12 @@ jobs:
     env:
       VITE_SUPABASE_URL: ${{ secrets.VITE_SUPABASE_URL || 'https://eedfyviypptfpghyffip.supabase.co' }}
       VITE_SUPABASE_ANON_KEY: ${{ secrets.VITE_SUPABASE_ANON_KEY || 'sb_publishable_CCE4uRqvWCAonhnDis0BZQ_ixrd0jl2' }}
+      # Live authenticated-read e2e specs (digest render, history live, playback) run
+      # only when all three are set; otherwise they skip cleanly. Reads are RLS-gated
+      # to the `authenticated` role, so they need a real test account + its TOTP secret.
+      MFA_TEST_EMAIL: ${{ secrets.MFA_TEST_EMAIL }}
+      MFA_TEST_PASSWORD: ${{ secrets.MFA_TEST_PASSWORD }}
+      MFA_TEST_TOTP_SECRET: ${{ secrets.MFA_TEST_TOTP_SECRET }}
     steps:
       - uses: actions/checkout@v4
 

--- a/supabase/migrations/0006_authenticated_read_policies.sql
+++ b/supabase/migrations/0006_authenticated_read_policies.sql
@@ -1,0 +1,25 @@
+-- Read policies were scoped to the `anon` role (magic-link / public-read era).
+-- Since 0005 the app is login-gated (email + password + TOTP MFA), so browser
+-- reads run as the `authenticated` role and matched no policy -> 0 rows.
+-- Move read access to `authenticated` only (tightest posture: the publishable
+-- key ships in the bundle, so anon-read would let anyone bypass the login gate).
+-- service_role still bypasses RLS for the agent's writes.
+
+drop policy if exists digest_topics_anon_read on digest_topics;
+drop policy if exists digests_anon_read on digests;
+drop policy if exists system_logs_anon_read on system_logs;
+
+create policy digest_topics_authenticated_read
+  on digest_topics for select
+  to authenticated
+  using (enabled);
+
+create policy digests_authenticated_read
+  on digests for select
+  to authenticated
+  using (true);
+
+create policy system_logs_authenticated_read
+  on system_logs for select
+  to authenticated
+  using (true);

--- a/web/.env.example
+++ b/web/.env.example
@@ -1,3 +1,11 @@
 # Supabase project — browser-safe values only. NEVER put the service_role key here.
 VITE_SUPABASE_URL=https://YOUR-PROJECT.supabase.co
 VITE_SUPABASE_ANON_KEY=your-publishable-anon-key
+
+# --- e2e only (optional) -----------------------------------------------------
+# Live authenticated-read Playwright specs (digest render, history live, playback)
+# read RLS-gated data and so need a real test account at AAL2. Set all three to run
+# them; leave unset and those specs skip. NOT used by the app itself.
+#   MFA_TEST_EMAIL=test-account@example.com
+#   MFA_TEST_PASSWORD=the-account-password
+#   MFA_TEST_TOTP_SECRET=BASE32SECRETOFITSVERIFIEDTOTPFACTOR

--- a/web/README.md
+++ b/web/README.md
@@ -42,6 +42,23 @@ npm run dev            # http://localhost:5173
 | `npm run test:unit`| Vitest (pure logic: auth/MFA gate, TOTP, grouping, query) |
 | `npm run test:e2e` | Playwright against the built app (real Supabase)      |
 
+### e2e and authenticated reads
+
+Reads are RLS-gated to the **`authenticated`** role (`supabase/migrations/0006`), so any
+spec that reads real digests needs a genuine signed-in session at **AAL2**. Those specs
+(`digest-render`, the live `history` test, `playback`, and `mfa`) run only when a test
+account is provided, and **skip cleanly otherwise**:
+
+| Var                    | Purpose                                              |
+| ---------------------- | ---------------------------------------------------- |
+| `MFA_TEST_EMAIL`       | Test account email                                   |
+| `MFA_TEST_PASSWORD`    | Test account password                                |
+| `MFA_TEST_TOTP_SECRET` | Base32 secret of the account's verified TOTP factor  |
+
+Set them locally in `web/.env`, or as repo secrets for CI (`.github/workflows/web.yml`
+passes them through). The fixture-mode `history` specs and the unauthenticated-gate
+specs need no credentials — they don't read live data.
+
 ## Architecture & extension points
 
 The app is intentionally split so issues **#11 (TTS)** and **#12 (history)** can be built
@@ -86,7 +103,8 @@ pre-existing account can ever log in.
 
 `src/lib/auth.ts` holds all wrappers (sign-in, MFA enroll, challenge, change-password) and
 the pure gate predicates (`hasValidSession`, `isMfaSatisfied`, `nextGateStep`). Data access
-is RLS-gated with the anon key regardless of auth state.
+is RLS-gated to the **`authenticated`** role: reads require a signed-in session, and the
+publishable key alone (anon role) sees nothing.
 
 ### Login flow
 

--- a/web/tests/e2e/digest-render.spec.ts
+++ b/web/tests/e2e/digest-render.spec.ts
@@ -1,34 +1,40 @@
 import { expect, test } from "@playwright/test";
-import { seedSession } from "./session";
+import { LIVE_AUTH, LIVE_AUTH_SKIP, signInAal2 } from "./live-auth";
 
-const SUPABASE_URL = process.env.VITE_SUPABASE_URL ?? "https://eedfyviypptfpghyffip.supabase.co";
-const ANON_KEY = process.env.VITE_SUPABASE_ANON_KEY ?? "sb_publishable_CCE4uRqvWCAonhnDis0BZQ_ixrd0jl2";
+// Reads real digests from Supabase, so it needs a genuine authenticated (AAL2)
+// session — RLS gates reads to the `authenticated` role.
+test.describe("digest render (live authenticated reads)", () => {
+  test.skip(!LIVE_AUTH, LIVE_AUTH_SKIP);
 
-// AC: Digests render grouped by topic and date when a session exists.
-test("authenticated user sees digests grouped by topic and date", async ({ page }) => {
-  await seedSession(page, SUPABASE_URL, ANON_KEY);
-  await page.goto("/");
+  test.beforeEach(async ({ page }) => {
+    await signInAal2(page);
+  });
 
-  // Digest content region renders (not the auth gate).
-  await expect(page.getByTestId("digest-content")).toBeVisible();
-  await expect(page.getByTestId("auth-gate")).toHaveCount(0);
+  // AC: Digests render grouped by topic and date when authenticated.
+  test("authenticated user sees digests grouped by topic and date", async ({ page }) => {
+    await page.goto("/");
 
-  // At least one topic group with a topic heading and a date heading.
-  const groups = page.locator(".topic-group");
-  await expect(groups.first()).toBeVisible({ timeout: 15_000 });
-  expect(await groups.count()).toBeGreaterThan(0);
+    // Digest content region renders (not the auth gate).
+    await expect(page.getByTestId("digest-content")).toBeVisible();
+    await expect(page.getByTestId("auth-gate")).toHaveCount(0);
 
-  await expect(page.locator(".topic-heading").first()).toBeVisible();
-  await expect(page.locator(".date-heading").first()).toBeVisible();
-  await expect(page.locator(".digest-card").first()).toBeVisible();
+    // At least one topic group with a topic heading and a date heading.
+    const groups = page.locator(".topic-group");
+    await expect(groups.first()).toBeVisible({ timeout: 15_000 });
+    expect(await groups.count()).toBeGreaterThan(0);
 
-  // Grouping invariant: each topic-group carries a slug, and date headings carry
-  // dates that are sorted descending within the group.
-  const firstGroupDates = await page
-    .locator(".topic-group")
-    .first()
-    .locator(".date-heading")
-    .evaluateAll((els) => els.map((el) => el.getAttribute("data-date") ?? ""));
-  const sortedDesc = [...firstGroupDates].sort().reverse();
-  expect(firstGroupDates).toEqual(sortedDesc);
+    await expect(page.locator(".topic-heading").first()).toBeVisible();
+    await expect(page.locator(".date-heading").first()).toBeVisible();
+    await expect(page.locator(".digest-card").first()).toBeVisible();
+
+    // Grouping invariant: each topic-group carries a slug, and date headings carry
+    // dates that are sorted descending within the group.
+    const firstGroupDates = await page
+      .locator(".topic-group")
+      .first()
+      .locator(".date-heading")
+      .evaluateAll((els) => els.map((el) => el.getAttribute("data-date") ?? ""));
+    const sortedDesc = [...firstGroupDates].sort().reverse();
+    expect(firstGroupDates).toEqual(sortedDesc);
+  });
 });

--- a/web/tests/e2e/history.spec.ts
+++ b/web/tests/e2e/history.spec.ts
@@ -1,100 +1,117 @@
 import { expect, test } from "@playwright/test";
+import { LIVE_AUTH, LIVE_AUTH_SKIP, signInAal2 } from "./live-auth";
 import { seedSession } from "./session";
 
 const SUPABASE_URL = process.env.VITE_SUPABASE_URL ?? "https://eedfyviypptfpghyffip.supabase.co";
 const ANON_KEY = process.env.VITE_SUPABASE_ANON_KEY ?? "sb_publishable_CCE4uRqvWCAonhnDis0BZQ_ixrd0jl2";
 
-test.beforeEach(async ({ page }) => {
-  await seedSession(page, SUPABASE_URL, ANON_KEY);
+// AC1: Past digests browsable, grouped by date descending — over the LIVE data path.
+// Reads real digests from Supabase, so it needs a genuine authenticated (AAL2) session
+// (RLS gates reads to the `authenticated` role).
+test.describe("history (live authenticated reads)", () => {
+  test.skip(!LIVE_AUTH, LIVE_AUTH_SKIP);
+
+  test.beforeEach(async ({ page }) => {
+    await signInAal2(page);
+  });
+
+  test("history renders grouped by topic with date headings descending", async ({ page }) => {
+    await page.goto("/#/history");
+    await expect(page.getByTestId("history-content")).toBeVisible();
+    await expect(page.getByTestId("auth-gate")).toHaveCount(0);
+
+    const groups = page.locator(".topic-group");
+    await expect(groups.first()).toBeVisible({ timeout: 15_000 });
+
+    const dates = await page
+      .locator(".topic-group")
+      .first()
+      .locator(".date-heading")
+      .evaluateAll((els) => els.map((el) => el.getAttribute("data-date") ?? ""));
+    const sortedDesc = [...dates].sort().reverse();
+    expect(dates).toEqual(sortedDesc);
+  });
 });
 
-// AC1: Past digests browsable, grouped by date descending (live data path).
-test("history renders grouped by topic with date headings descending", async ({ page }) => {
-  await page.goto("/#/history");
-  await expect(page.getByTestId("history-content")).toBeVisible();
-  await expect(page.getByTestId("auth-gate")).toHaveCount(0);
+// The remaining specs exercise filtering/search/grouping/perf over the deterministic
+// in-app fixture (`?fixture=150`), which generates rows client-side and does NOT read
+// Supabase. They only need the auth gate to pass, so a seeded (gate-only) session is
+// sufficient and they run without live credentials.
+test.describe("history (fixture data)", () => {
+  test.beforeEach(async ({ page }) => {
+    await seedSession(page, SUPABASE_URL, ANON_KEY);
+  });
 
-  const groups = page.locator(".topic-group");
-  await expect(groups.first()).toBeVisible({ timeout: 15_000 });
+  // Per-digest metadata is shown.
+  test("each digest shows metadata (topic, date, word count, sources)", async ({ page }) => {
+    await page.goto("/?fixture=150#/history");
+    await expect(page.getByTestId("history-list")).toBeVisible();
+    const meta = page.getByTestId("digest-meta").first();
+    await expect(meta).toBeVisible();
+    await expect(meta).toContainText("words");
+    await expect(meta).toContainText("sources:");
+  });
 
-  const dates = await page
-    .locator(".topic-group")
-    .first()
-    .locator(".date-heading")
-    .evaluateAll((els) => els.map((el) => el.getAttribute("data-date") ?? ""));
-  const sortedDesc = [...dates].sort().reverse();
-  expect(dates).toEqual(sortedDesc);
-});
+  // AC4 + AC1: 150-row fixture renders all rows within a sane time budget.
+  test("renders 150 fixture rows quickly", async ({ page }) => {
+    const start = Date.now();
+    await page.goto("/?fixture=150#/history");
+    await expect(page.getByTestId("history-list")).toBeVisible();
+    // Fixture spans 30 days; with no filter the default 7-day window applies.
+    // Switch to "All topics" + clear-window by selecting a topic to force full set,
+    // then assert the full dataset can render. First measure default-view interactive.
+    await expect(page.locator(".topic-group").first()).toBeVisible();
+    const interactive = Date.now() - start;
+    expect(interactive).toBeLessThan(1000);
 
-// Per-digest metadata is shown.
-test("each digest shows metadata (topic, date, word count, sources)", async ({ page }) => {
-  await page.goto("/?fixture=150#/history");
-  await expect(page.getByTestId("history-list")).toBeVisible();
-  const meta = page.getByTestId("digest-meta").first();
-  await expect(meta).toBeVisible();
-  await expect(meta).toContainText("words");
-  await expect(meta).toContainText("sources:");
-});
+    // Force the entire 150-row set via a topic filter (bypasses 7-day window) and
+    // confirm every card for that topic renders. 150 rows total / 5 topics = 30 each.
+    await page.getByTestId("filter-topic").selectOption("ai_models");
+    await expect(page.locator(".digest-card")).toHaveCount(30);
+  });
 
-// AC4 + AC1: 150-row fixture renders all rows within a sane time budget.
-test("renders 150 fixture rows quickly", async ({ page }) => {
-  const start = Date.now();
-  await page.goto("/?fixture=150#/history");
-  await expect(page.getByTestId("history-list")).toBeVisible();
-  // Fixture spans 30 days; with no filter the default 7-day window applies.
-  // Switch to "All topics" + clear-window by selecting a topic to force full set,
-  // then assert the full dataset can render. First measure default-view interactive.
-  await expect(page.locator(".topic-group").first()).toBeVisible();
-  const interactive = Date.now() - start;
-  expect(interactive).toBeLessThan(1000);
+  // AC2: Topic filter narrows results and URL state reflects the selection.
+  test("topic filter narrows results and updates the URL", async ({ page }) => {
+    await page.goto("/?fixture=150#/history");
+    await expect(page.getByTestId("history-list")).toBeVisible();
 
-  // Force the entire 150-row set via a topic filter (bypasses 7-day window) and
-  // confirm every card for that topic renders. 150 rows total / 5 topics = 30 each.
-  await page.getByTestId("filter-topic").selectOption("ai_models");
-  await expect(page.locator(".digest-card")).toHaveCount(30);
-});
+    await page.getByTestId("filter-topic").selectOption("penguins");
+    // Only the penguins group remains.
+    await expect(page.locator(".topic-group")).toHaveCount(1);
+    await expect(page.locator(".topic-group").first()).toHaveAttribute(
+      "data-topic-slug",
+      "penguins",
+    );
+    // URL search reflects the selection (shareable).
+    await expect.poll(() => new URL(page.url()).search).toContain("topic=penguins");
+  });
 
-// AC2: Topic filter narrows results and URL state reflects the selection.
-test("topic filter narrows results and updates the URL", async ({ page }) => {
-  await page.goto("/?fixture=150#/history");
-  await expect(page.getByTestId("history-list")).toBeVisible();
+  // AC2: A shareable URL with ?topic= yields the pre-filtered view on load.
+  test("shareable ?topic= URL loads pre-filtered", async ({ page }) => {
+    await page.goto("/?fixture=150&topic=ai_models#/history");
+    await expect(page.getByTestId("history-list")).toBeVisible();
+    await expect(page.locator(".topic-group")).toHaveCount(1);
+    await expect(page.locator(".topic-group").first()).toHaveAttribute(
+      "data-topic-slug",
+      "ai_models",
+    );
+    // The topic control reflects the URL state.
+    await expect(page.getByTestId("filter-topic")).toHaveValue("ai_models");
+  });
 
-  await page.getByTestId("filter-topic").selectOption("penguins");
-  // Only the penguins group remains.
-  await expect(page.locator(".topic-group")).toHaveCount(1);
-  await expect(page.locator(".topic-group").first()).toHaveAttribute(
-    "data-topic-slug",
-    "penguins",
-  );
-  // URL search reflects the selection (shareable).
-  await expect.poll(() => new URL(page.url()).search).toContain("topic=penguins");
-});
+  // AC3: Client-side search returns relevant results across digest content.
+  test("search narrows to matching digests", async ({ page }) => {
+    await page.goto("/?fixture=150#/history");
+    await expect(page.getByTestId("history-list")).toBeVisible();
 
-// AC2: A shareable URL with ?topic= yields the pre-filtered view on load.
-test("shareable ?topic= URL loads pre-filtered", async ({ page }) => {
-  await page.goto("/?fixture=150&topic=ai_models#/history");
-  await expect(page.getByTestId("history-list")).toBeVisible();
-  await expect(page.locator(".topic-group")).toHaveCount(1);
-  await expect(page.locator(".topic-group").first()).toHaveAttribute(
-    "data-topic-slug",
-    "ai_models",
-  );
-  // The topic control reflects the URL state.
-  await expect(page.getByTestId("filter-topic")).toHaveValue("ai_models");
-});
+    await page.getByTestId("filter-search").fill("township");
+    // At least one match, and every rendered card contains the term.
+    await expect(page.locator(".digest-card").first()).toBeVisible();
+    const bodies = await page.locator(".digest-body").allTextContents();
+    expect(bodies.length).toBeGreaterThan(0);
+    expect(bodies.every((t) => t.toLowerCase().includes("township"))).toBe(true);
 
-// AC3: Client-side search returns relevant results across digest content.
-test("search narrows to matching digests", async ({ page }) => {
-  await page.goto("/?fixture=150#/history");
-  await expect(page.getByTestId("history-list")).toBeVisible();
-
-  await page.getByTestId("filter-search").fill("township");
-  // At least one match, and every rendered card contains the term.
-  await expect(page.locator(".digest-card").first()).toBeVisible();
-  const bodies = await page.locator(".digest-body").allTextContents();
-  expect(bodies.length).toBeGreaterThan(0);
-  expect(bodies.every((t) => t.toLowerCase().includes("township"))).toBe(true);
-
-  // URL reflects the query.
-  await expect.poll(() => new URL(page.url()).search).toContain("q=township");
+    // URL reflects the query.
+    await expect.poll(() => new URL(page.url()).search).toContain("q=township");
+  });
 });

--- a/web/tests/e2e/live-auth.ts
+++ b/web/tests/e2e/live-auth.ts
@@ -1,0 +1,98 @@
+import { expect, type Page } from "@playwright/test";
+import { base32Decode, generateTotp } from "../../src/lib/totp";
+
+// Helper for specs that read REAL data from Supabase. Reads are RLS-gated to the
+// `authenticated` role (see supabase/migrations/0006), so these specs need a genuine
+// authenticated session at AAL2 — the same bar the app's gate enforces. That requires
+// a dedicated test account with an enrolled TOTP factor:
+//
+//   MFA_TEST_EMAIL        the account's email
+//   MFA_TEST_PASSWORD     its password
+//   MFA_TEST_TOTP_SECRET  the base32 secret of its (already verified) TOTP factor
+//
+// Without all three the live specs skip — exactly like mfa.spec.ts. The fixture-mode
+// history specs do NOT use this; they only need the auth gate to pass (seedSession).
+
+const EMAIL = process.env.MFA_TEST_EMAIL;
+const PASSWORD = process.env.MFA_TEST_PASSWORD;
+const TOTP_SECRET = process.env.MFA_TEST_TOTP_SECRET;
+
+export const LIVE_AUTH = Boolean(EMAIL && PASSWORD && TOTP_SECRET);
+export const LIVE_AUTH_SKIP =
+  "set MFA_TEST_EMAIL / MFA_TEST_PASSWORD / MFA_TEST_TOTP_SECRET to run live authenticated-read specs";
+
+interface ClientWindow {
+  __supabase: import("@supabase/supabase-js").SupabaseClient;
+}
+
+/**
+ * Establish a real authenticated AAL2 session in the page's Supabase client:
+ * sign in with password (factor 1), then challenge + verify the account's TOTP
+ * factor (factor 2) using a code computed from the stored secret. supabase-js
+ * persists the session to localStorage, so a subsequent `page.goto` boots the app
+ * already authenticated and digest reads succeed under RLS.
+ */
+export async function signInAal2(page: Page): Promise<void> {
+  await page.goto("/");
+  await page.waitForFunction(() => !!(window as unknown as { __supabase?: unknown }).__supabase, {
+    timeout: 15_000,
+  });
+
+  const signInErr = await page.evaluate(async ([email, password]) => {
+    const client = (window as unknown as ClientWindow).__supabase;
+    const { error } = await client.auth.signInWithPassword({ email, password });
+    return error?.message ?? null;
+  }, [EMAIL!, PASSWORD!] as const);
+  expect(signInErr, "password sign-in (factor 1)").toBeNull();
+
+  const factorId = await page.evaluate(async () => {
+    const client = (window as unknown as ClientWindow).__supabase;
+    const { data } = await client.auth.mfa.listFactors();
+    return data?.totp?.find((f) => f.status === "verified")?.id ?? null;
+  });
+  expect(
+    factorId,
+    "the test account must have a verified TOTP factor matching MFA_TEST_TOTP_SECRET",
+  ).not.toBeNull();
+
+  // Step the session up to AAL2. Retry once in case the code lands right on a 30s
+  // window boundary.
+  let verifyErr = await challengeAndVerify(page, factorId!);
+  if (verifyErr) {
+    verifyErr = await challengeAndVerify(page, factorId!);
+  }
+  expect(verifyErr, "TOTP challenge + verify (factor 2)").toBeNull();
+
+  // supabase-js persists the new AAL2 session to localStorage on the auth state
+  // change. Wait for it to land before returning so callers can re-navigate and boot
+  // the app already authenticated (a re-render is what surfaces digest content).
+  await page.waitForFunction(
+    () => {
+      for (let i = 0; i < window.localStorage.length; i++) {
+        if (window.localStorage.key(i)?.endsWith("-auth-token")) return true;
+      }
+      return false;
+    },
+    { timeout: 5_000 },
+  );
+}
+
+async function challengeAndVerify(page: Page, factorId: string): Promise<string | null> {
+  // Create the challenge first (a Supabase round-trip), THEN compute the code right
+  // before verify — so the code and the verify share the same 30s window with minimal
+  // skew, rather than spending the code's lifetime on the challenge round-trip.
+  const challenge = await page.evaluate(async (fid) => {
+    const client = (window as unknown as ClientWindow).__supabase;
+    const res = await client.auth.mfa.challenge({ factorId: fid });
+    if (res.error || !res.data) return { error: res.error?.message ?? "no challenge" } as const;
+    return { challengeId: res.data.id } as const;
+  }, factorId);
+  if ("error" in challenge) return challenge.error ?? "no challenge";
+
+  const code = await generateTotp(base32Decode(TOTP_SECRET!));
+  return page.evaluate(async ([fid, challengeId, otp]) => {
+    const client = (window as unknown as ClientWindow).__supabase;
+    const verify = await client.auth.mfa.verify({ factorId: fid, challengeId, code: otp });
+    return verify.error?.message ?? null;
+  }, [factorId, challenge.challengeId, code] as const);
+}

--- a/web/tests/e2e/playback.spec.ts
+++ b/web/tests/e2e/playback.spec.ts
@@ -1,8 +1,9 @@
 import { expect, test, type Page } from "@playwright/test";
-import { seedSession } from "./session";
+import { LIVE_AUTH, LIVE_AUTH_SKIP, signInAal2 } from "./live-auth";
 
-const SUPABASE_URL = process.env.VITE_SUPABASE_URL ?? "https://eedfyviypptfpghyffip.supabase.co";
-const ANON_KEY = process.env.VITE_SUPABASE_ANON_KEY ?? "sb_publishable_CCE4uRqvWCAonhnDis0BZQ_ixrd0jl2";
+// Playback renders over real digests read from Supabase, so it needs a genuine
+// authenticated (AAL2) session — RLS gates reads to the `authenticated` role.
+test.skip(!LIVE_AUTH, LIVE_AUTH_SKIP);
 
 // Stub the Web Speech API before any app code runs. Headless chromium emits no
 // audio, so we record speak/pause/cancel calls and let tests fire `onend` to
@@ -78,7 +79,7 @@ async function stubSpeech(page: Page): Promise<void> {
 
 async function gotoApp(page: Page): Promise<void> {
   await stubSpeech(page);
-  await seedSession(page, SUPABASE_URL, ANON_KEY);
+  await signInAal2(page);
   await page.goto("/");
   await expect(page.locator(".digest-card").first()).toBeVisible({ timeout: 15_000 });
 }

--- a/web/tests/e2e/session.ts
+++ b/web/tests/e2e/session.ts
@@ -1,14 +1,16 @@
 import type { Page } from "@playwright/test";
 
-// Supabase-js v2 persists the session in localStorage under
-// `sb-<projectRef>-auth-token`. The home page guard only checks that a
-// structurally-valid, non-expired session exists (hasValidSession).
+// GATE-ONLY seeded session. Supabase-js v2 persists the session in localStorage
+// under `sb-<projectRef>-auth-token`; the app's gate treats a structurally-valid,
+// non-expired session whose access_token can't be decoded as a JWT as "MFA satisfied"
+// (see src/lib/auth.ts getAalState), so this is enough to pass the auth gate.
 //
-// We set the session's access_token to the project's PUBLISHABLE/ANON key. When a
-// session is present, supabase-js sends access_token as the Bearer; PostgREST
-// accepts the publishable key and resolves to the anon role, so RLS-gated reads
-// (anon SELECT on digests/topics) succeed against REAL Supabase — no mocks, no
-// forged JWT. This exercises the authenticated render path end-to-end.
+// IMPORTANT: the access_token here is the PUBLISHABLE/ANON key, so any actual reads
+// resolve to the `anon` role at PostgREST. Since reads are RLS-gated to the
+// `authenticated` role (supabase/migrations/0006), seeded sessions CANNOT read live
+// digests. Use this ONLY for specs that don't hit the network for data — i.e. the
+// `?fixture=` history specs and the unauthenticated-gate checks. Specs that read real
+// data must use signInAal2() from ./live-auth instead.
 
 function projectRef(supabaseUrl: string): string {
   return new URL(supabaseUrl).host.split(".")[0];


### PR DESCRIPTION
## Symptom

After signing in (email + password + TOTP MFA), the web app shows **"No digests yet. Check back after the next run."** even though digests exist in Supabase.

## Root cause

The RLS read policies from `supabase/migrations/0001_init.sql` grant `SELECT` only to the **`anon`** role (`digests_anon_read`, `digest_topics_anon_read`, `system_logs_anon_read` → `to anon`).

Since the magic-link → password+MFA migration (#53, commit `50a3cf34`), the app is login-gated. A real login produces an **`authenticated`** JWT, so browser reads run as `authenticated` and match **none** of the policies → 0 rows. The agent writes via `service_role` (bypasses RLS), so the data was always present.

Proven at the DB level: `set role authenticated; select count(*) from digests;` returned **0** before the fix, **4** after.

## Why CI didn't catch it

The e2e specs that "read" digests faked auth via `seedSession()`, which sets the **anon publishable key** as the access token — PostgREST resolves that to the `anon` role. They never exercised a real `authenticated` session. Green-CI-but-broken-in-prod.

## Changes

- **`supabase/migrations/0006_authenticated_read_policies.sql`** — drop the three `*_anon_read` policies; grant `SELECT` to the **`authenticated`** role only on `digests`, `digest_topics`, `system_logs`. Tightest posture: the publishable key ships in the JS bundle, so anon-read would let anyone bypass the login gate. `service_role` still bypasses RLS for the agent's writes. *(Already applied to the live project.)*
- **`web/tests/e2e/live-auth.ts`** (new) — `signInAal2()`: real password (factor 1) + TOTP challenge/verify (factor 2) to reach AAL2, so reads run as `authenticated`. The TOTP code is computed *after* the challenge round-trip to minimize 30s-window skew, with one retry, and waits for session persistence before returning.
- **`digest-render.spec.ts`, `history.spec.ts` (live test), `playback.spec.ts`** — use `signInAal2`; `test.skip` when `MFA_TEST_EMAIL` / `MFA_TEST_PASSWORD` / `MFA_TEST_TOTP_SECRET` are absent (same pattern as `mfa.spec.ts`).
- **`history.spec.ts`** — fixture-mode specs (`?fixture=150`) keep `seedSession` (gate-only, no live read) and run without credentials.
- **`session.ts`** — corrected the misleading doc: a seeded session resolves to `anon` and **cannot** read live data.
- **CI / `web/.env.example` / `web/README.md`** — document and pass through the `MFA_TEST_*` vars; fixed the stale "anon key regardless of auth state" README note.

## Verification

- `npm run lint` (ESLint + `tsc`) ✅
- `npm run test:unit` → **89 passed** ✅
- `npm run build` ✅
- `npm run test:e2e` (no creds) → **9 passed / 9 skipped** — live-read specs skip cleanly; fixture/gate/RLS-write specs pass ✅
- DB role check: `authenticated` → 4 rows, `anon` → 0 rows ✅

> Note: the live-read specs require a dedicated test account (email + password + the verified TOTP factor's base32 secret) to run green in CI; without those secrets they skip. I don't have such an account, so they were verified to skip cleanly and are built from already-proven pieces (TOTP unit tests, the `mfa.spec` challenge/verify pattern, and the SQL-level authenticated-read check).