### PR TITLE
Structured digest output: summary-first with expandable per-item detail

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -59,7 +59,7 @@ All tools are module-level functions decorated with `@gaia.agents.base.tools.too
 - `scraping.fetch_html(url, selector=None) -> dict` (#6)
 - `scraping.parse_article(url) -> dict` (#6, uses `trafilatura`)
 - `publishing.fetch_topic_config(slug) -> dict` (#8)
-- `publishing.push_to_supabase(topic_slug, content, sources_used, token_count) -> dict` (#8)
+- `publishing.push_to_supabase(topic_slug, summary, items, sources_used, token_count, content=None) -> dict` (#8, #58)
 - `publishing.get_last_digest_date(topic_slug) -> str | None` (#8)
 - `social.fetch_reddit(subreddit, ...) -> list[dict]` (#21, Epic 7)
 
@@ -104,7 +104,9 @@ CREATE TABLE digest_topics (
 CREATE TABLE digests (
   id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
   topic_slug text NOT NULL REFERENCES digest_topics(slug),
-  content text NOT NULL,
+  content text NOT NULL,            -- flat TTS-safe prose; derived from summary+items on #58+ rows
+  summary text,                     -- short top-level overview; null on pre-#58 rows
+  items jsonb,                      -- ranked items (see §7.1); null on pre-#58 rows
   cadence text NOT NULL,
   digest_date date NOT NULL,
   sources_used jsonb NOT NULL,
@@ -267,13 +269,35 @@ Before dispatching to any topic, the scheduler re-reads `digest_topics.enabled`.
 
 ## §7 Prompt architecture
 
-### §7.1 System prompt
-Single `SYSTEM_PROMPT` constant in `prompts.py`. Hard rules, baked in:
-- Plain prose only. No markdown, bullets, headings, URLs, parentheses.
-- Write "versus" not "vs.", "and so on" not "etc.", spell out numbers under 10.
-- Conversational tone, news-anchor cadence.
-- 500–800 words target.
-- Two good / two bad examples inline.
+### §7.1 System prompt and output contract
+Single `SYSTEM_PROMPT` constant in `prompts.py`. The LLM assembles a
+**structured digest** — a short top-level `summary` plus a ranked `items` array —
+and calls `push_to_supabase(topic_slug, summary, items, sources_used, token_count)`.
+
+Canonical item shape (Python dict keys and TypeScript `DigestItem` interface match verbatim):
+```jsonc
+{
+  "headline": "one-line description",
+  "blurb":    "1–2 sentences — what happened (shown collapsed)",
+  "detail":   "fuller prose — why it matters, specifics/numbers (expandable)",
+  "metadata": {
+    "sources": [{"title": "Source Name", "url": "https://…"}],
+    "tags":    ["optional", "tags"]
+  }
+}
+```
+
+`content` (the `text NOT NULL` column) is **derived** by `flatten_digest(summary, items)`
+inside `push_to_supabase`. It is plain prose, no URLs or markdown — kept as the TTS
+source (#11) and the backward-compat fallback for pre-#58 rows where `summary`/`items`
+are null. Source links live only in `metadata.sources`.
+
+Hard rules for the output:
+- `summary` and `blurb`: clean prose, no raw URLs.
+- `metadata.sources`: machine-readable source links (rendered as `<a>` in the web app,
+  guarded to http(s) only against XSS via LLM-injected `javascript:` / `data:` schemes).
+- Rank items by significance; explain why each item matters in `detail`.
+- Aim for one to two sentences of `summary` and three to seven items.
 
 ### §7.2 Per-topic prompt hint
 `digest_topics.prompt_hint` contains topic-specific steering: what to emphasize, what to exclude. Concatenated after `SYSTEM_PROMPT` at run time.
@@ -285,7 +309,12 @@ When running a topic that overlaps with another (e.g., `ai_updates` after `ai_mo
 At generation time, compute `sha256(SYSTEM_PROMPT + '\n' + prompt_hint)[:12]` and store on `digests.prompt_version`. A history of prompt changes lives in git; `prompt_version` ties any published digest to its exact prompt text.
 
 ### §7.5 Length enforcement
-Post-generation: word count. If outside 500–800 × ±20 %, re-prompt once with a length-correction hint. Accept the second attempt regardless.
+Post-generation: `enforce_length(summary, items, regenerate)` measures word count over
+`flatten_digest(summary, items)` — the flattened structured text, not the raw LLM
+output. If the word count is outside the 500–800 ± 20 % band (400–960), re-prompt
+once with a length-correction hint. Accept the second attempt regardless. Returns a
+`(summary, items)` tuple. `enforce_length` is a pure function and is not currently
+wired into the agent loop; it is available for future integration.
 
 ---
 

--- a/src/news_digest/__main__.py
+++ b/src/news_digest/__main__.py
@@ -16,7 +16,7 @@ def main(argv: list[str]) -> int:
 
     query = argv[1]
     agent = NewsDigestAgent()
-    result = agent.process_query(query)
+    result = agent.generate_and_publish(query)
     print(result)
     return 0
 

--- a/src/news_digest/agent.py
+++ b/src/news_digest/agent.py
@@ -168,9 +168,11 @@ class NewsDigestAgent(Agent, DatabaseMixin):
         self.init_db(settings.sqlite_path)
 
     def _force_no_thinking(self) -> None:
-        """Inject chat_template_kwargs={'enable_thinking': False} on every LLM
-        call by wrapping the chat SDK send methods (process_query passes no extra
-        kwargs, so this is the single safe seam)."""
+        """Wrap the chat SDK send methods to (1) disable model "thinking" output
+        (it emits empty content and breaks GAIA's JSON-in-content tool parsing)
+        and (2) raise max_tokens to 4096. The chat SDK default is 512 (gaia
+        chat/sdk.py), which truncates a structured digest mid-JSON. process_query
+        passes no extra kwargs, so this wrap is the single safe seam for both."""
 
         def _wrap(method):
             def _inner(messages, system_prompt=None, **kw):
@@ -178,6 +180,9 @@ class NewsDigestAgent(Agent, DatabaseMixin):
                 # can never silently drop enable_thinking.
                 ctk = kw.setdefault("chat_template_kwargs", {})
                 ctk.setdefault("enable_thinking", False)
+                # Structured digests exceed the SDK's 512-token default; give the
+                # model room to emit the full summary + items JSON.
+                kw.setdefault("max_tokens", 4096)
                 return method(messages, system_prompt=system_prompt, **kw)
 
             return _inner

--- a/src/news_digest/agent.py
+++ b/src/news_digest/agent.py
@@ -116,9 +116,20 @@ def _publish_from_result(result: dict[str, Any]) -> dict[str, Any]:
         )
         return {"success": False, "error": "bad_answer_shape"}
 
-    # The model may nest the digest under "answer" or place it at the top level.
+    # The model may nest the digest under "answer" — as an object, or as a JSON
+    # string / fenced code block (models that return the answer as text) — or it
+    # may place the fields at the top level.
     answer = parsed.get("answer")
-    digest = answer if isinstance(answer, dict) else parsed
+    if isinstance(answer, dict):
+        digest = answer
+    elif isinstance(answer, str):
+        try:
+            inner = json.loads(_strip_code_fences(answer))
+        except (ValueError, TypeError):
+            inner = None
+        digest = inner if isinstance(inner, dict) else parsed
+    else:
+        digest = parsed
 
     summary = digest.get("summary")
     items = digest.get("items")

--- a/src/news_digest/agent.py
+++ b/src/news_digest/agent.py
@@ -1,23 +1,151 @@
 """NewsDigestAgent — the GAIA agent that produces news digests.
 
 The agent reads a topic's config from Supabase, scrapes the configured sources,
-summarizes with the local Lemonade LLM (its own reasoning IS the summarizer, see
-CLAUDE.md), publishes the digest back to Supabase, and logs the run to
-system_logs. DatabaseMixin adds local SQLite state (run log / article cache);
-Supabase remains the primary store.
+and summarizes with the local Lemonade LLM (its own reasoning IS the summarizer,
+see CLAUDE.md). The model returns the finished digest as its final answer (a JSON
+object); Python parses that answer and persists it deterministically via
+push_to_supabase. Local models do not reliably emit a final publish tool call, so
+the publish step is driven from Python rather than the LLM. DatabaseMixin adds
+local SQLite state (run log / article cache); Supabase remains the primary store.
 """
 
+import json
 from typing import Any
 
 from gaia.agents.base.agent import Agent
 from gaia.database import DatabaseMixin
 
 from news_digest.config import get_settings
+from news_digest.logging import log
 from news_digest.prompts import SYSTEM_PROMPT
 
 # Importing the tool modules registers their @tool functions into GAIA's global
 # tool registry at import time; the agent then advertises them to the model.
 from news_digest.tools import publishing, scraping  # noqa: F401
+from news_digest.tools.publishing import push_to_supabase
+
+
+def _strip_code_fences(text: str) -> str:
+    """Strip leading/trailing markdown code fences from a model answer.
+
+    Handles ```json ... ``` and bare ``` ... ``` wrappers, with or without a
+    trailing newline. Returns the inner text stripped of surrounding whitespace.
+    """
+    stripped = text.strip()
+    if not stripped.startswith("```"):
+        return stripped
+    # Drop the opening fence line (``` or ```json) and the trailing fence.
+    lines = stripped.splitlines()
+    if lines and lines[0].startswith("```"):
+        lines = lines[1:]
+    if lines and lines[-1].strip() == "```":
+        lines = lines[:-1]
+    return "\n".join(lines).strip()
+
+
+def _topic_slug_from_conversation(conversation: list[dict] | None) -> str | None:
+    """Recover the topic slug from the last fetch_topic_config tool call.
+
+    The slug passed to fetch_topic_config is authoritative — it is the slug the
+    model actually resolved against digest_topics. Used as a fallback when the
+    final-answer JSON omits topic_slug.
+    """
+    if not conversation:
+        return None
+    for msg in reversed(conversation):
+        if msg.get("name") == "fetch_topic_config":
+            args = msg.get("tool_args") or {}
+            slug = args.get("slug")
+            if slug:
+                return slug
+    return None
+
+
+def _publish_from_result(result: dict[str, Any]) -> dict[str, Any]:
+    """Parse a process_query result and persist the structured digest.
+
+    Extracts the model's final answer (``result['result']``), strips any markdown
+    fences, JSON-decodes it, and unwraps a nested ``answer`` dict when present.
+    Resolves topic_slug from the answer or, failing that, from the last
+    fetch_topic_config call in the conversation. Persists via push_to_supabase.
+
+    Never raises: on parse failure or missing required fields it logs an error and
+    returns ``{"success": False, "error": <reason>}``.
+
+    Args:
+        result: The dict returned by ``NewsDigestAgent.process_query``.
+
+    Returns:
+        The push_to_supabase result dict, or an error dict.
+    """
+    raw = result.get("result")
+    if not isinstance(raw, str) or not raw.strip():
+        log(
+            "error",
+            "publish",
+            "generate_and_publish: model returned no final answer string",
+            metadata={"status": result.get("status")},
+        )
+        return {"success": False, "error": "no_answer"}
+
+    try:
+        parsed = json.loads(_strip_code_fences(raw))
+    except (ValueError, TypeError) as exc:
+        log(
+            "error",
+            "publish",
+            f"generate_and_publish: could not parse final answer: "
+            f"{exc.__class__.__name__}",
+            metadata={"error": str(exc), "raw": raw[:500]},
+        )
+        return {"success": False, "error": "parse_error"}
+
+    if not isinstance(parsed, dict):
+        log(
+            "error",
+            "publish",
+            "generate_and_publish: final answer was not a JSON object",
+            metadata={"type": type(parsed).__name__},
+        )
+        return {"success": False, "error": "bad_answer_shape"}
+
+    # The model may nest the digest under "answer" or place it at the top level.
+    answer = parsed.get("answer")
+    digest = answer if isinstance(answer, dict) else parsed
+
+    summary = digest.get("summary")
+    items = digest.get("items")
+    sources_used = digest.get("sources_used", [])
+    topic_slug = digest.get("topic_slug") or _topic_slug_from_conversation(
+        result.get("conversation")
+    )
+
+    missing = [
+        name
+        for name, value in (
+            ("topic_slug", topic_slug),
+            ("summary", summary),
+            ("items", items),
+        )
+        if value is None
+    ]
+    if missing:
+        log(
+            "error",
+            "publish",
+            f"generate_and_publish: missing required field(s): {', '.join(missing)}",
+            topic_slug=topic_slug,
+            metadata={"missing": missing},
+        )
+        return {"success": False, "error": "missing_fields"}
+
+    return push_to_supabase(
+        topic_slug,
+        summary=summary,
+        items=items,
+        sources_used=sources_used,
+        token_count=result.get("output_tokens", 0),
+    )
 
 
 class NewsDigestAgent(Agent, DatabaseMixin):
@@ -57,6 +185,26 @@ class NewsDigestAgent(Agent, DatabaseMixin):
         self.chat.send_messages = _wrap(self.chat.send_messages)
         if hasattr(self.chat, "send_messages_stream"):
             self.chat.send_messages_stream = _wrap(self.chat.send_messages_stream)
+
+    def generate_and_publish(self, query: str) -> dict[str, Any]:
+        """Run a digest query and persist the structured result.
+
+        Drives the full topic run: the model reads/scrapes via tools and returns
+        the finished digest as its final answer (a JSON object). This method then
+        parses that answer and writes it to Supabase via push_to_supabase — the
+        "assemble structured digest" step, kept in Python because local models do
+        not reliably emit a final publish tool call.
+
+        Args:
+            query: The natural-language request, e.g.
+                "Generate the AI model releases digest for today".
+
+        Returns:
+            The push_to_supabase result dict on success, or
+            ``{"success": False, "error": <reason>}`` on any failure. Never raises.
+        """
+        result = self.process_query(query)
+        return _publish_from_result(result)
 
     def _get_system_prompt(self) -> str:
         return SYSTEM_PROMPT

--- a/src/news_digest/agent.py
+++ b/src/news_digest/agent.py
@@ -14,6 +14,7 @@ from typing import Any
 
 from gaia.agents.base.agent import Agent
 from gaia.database import DatabaseMixin
+from gaia.llm.lemonade_client import LemonadeClient
 
 from news_digest.config import get_settings
 from news_digest.logging import log
@@ -23,6 +24,12 @@ from news_digest.prompts import SYSTEM_PROMPT
 # tool registry at import time; the agent then advertises them to the model.
 from news_digest.tools import publishing, scraping  # noqa: F401
 from news_digest.tools.publishing import push_to_supabase
+
+# Lemonade serves models with a 4096-token context by default, which the agent's
+# accumulated scraped conversation overflows after a few sources (the prompt then
+# exceeds n_ctx and the completion is rejected). The digest models support up to
+# 131072; 32768 leaves ample headroom for a multi-source run.
+_HEAVY_CTX_SIZE = 32768
 
 
 def _strip_code_fences(text: str) -> str:
@@ -164,15 +171,16 @@ class NewsDigestAgent(Agent, DatabaseMixin):
         # chat models otherwise emit "thinking" output with empty content, which
         # breaks tool parsing — force thinking off on every completion.
         self._force_no_thinking()
+        # Serve the model with enough context for the accumulated scraped content;
+        # Lemonade's 4096 default overflows partway through a multi-source run.
+        self._ensure_context_window(model_id, settings.lemonade_base_url)
         # Local SQLite state (run log / article cache); Supabase stays primary.
         self.init_db(settings.sqlite_path)
 
     def _force_no_thinking(self) -> None:
-        """Wrap the chat SDK send methods to (1) disable model "thinking" output
-        (it emits empty content and breaks GAIA's JSON-in-content tool parsing)
-        and (2) raise max_tokens to 4096. The chat SDK default is 512 (gaia
-        chat/sdk.py), which truncates a structured digest mid-JSON. process_query
-        passes no extra kwargs, so this wrap is the single safe seam for both."""
+        """Inject chat_template_kwargs={'enable_thinking': False} on every LLM
+        call by wrapping the chat SDK send methods (process_query passes no extra
+        kwargs, so this is the single safe seam)."""
 
         def _wrap(method):
             def _inner(messages, system_prompt=None, **kw):
@@ -180,9 +188,6 @@ class NewsDigestAgent(Agent, DatabaseMixin):
                 # can never silently drop enable_thinking.
                 ctk = kw.setdefault("chat_template_kwargs", {})
                 ctk.setdefault("enable_thinking", False)
-                # Structured digests exceed the SDK's 512-token default; give the
-                # model room to emit the full summary + items JSON.
-                kw.setdefault("max_tokens", 4096)
                 return method(messages, system_prompt=system_prompt, **kw)
 
             return _inner
@@ -190,6 +195,28 @@ class NewsDigestAgent(Agent, DatabaseMixin):
         self.chat.send_messages = _wrap(self.chat.send_messages)
         if hasattr(self.chat, "send_messages_stream"):
             self.chat.send_messages_stream = _wrap(self.chat.send_messages_stream)
+
+    def _ensure_context_window(self, model_id: str | None, base_url: str) -> None:
+        """Load the model with a context window large enough for the run.
+
+        Lemonade serves models with a 4096-token context by default. The agent
+        accumulates the system prompt plus every scraped feed and article body in
+        the conversation, so after a few sources the prompt exceeds 4096 and the
+        completion request is rejected (n_ctx exceeded). Request _HEAVY_CTX_SIZE
+        tokens and persist it so scheduled runs inherit it. Best-effort: a failure
+        here must never block agent startup.
+        """
+        if not model_id:
+            return
+        try:
+            LemonadeClient(base_url=base_url).load_model(
+                model_id,
+                ctx_size=_HEAVY_CTX_SIZE,
+                save_options=True,
+                prompt=False,
+            )
+        except Exception as exc:  # noqa: BLE001 - startup must survive this
+            log("warn", "system", f"could not set context window: {exc!r}")
 
     def generate_and_publish(self, query: str) -> dict[str, Any]:
         """Run a digest query and persist the structured result.

--- a/src/news_digest/prompts.py
+++ b/src/news_digest/prompts.py
@@ -4,17 +4,18 @@ The system prompt defines the agent's overall behavior. Per-topic prompt_hints
 come from the Supabase digest_topics table and are injected at runtime.
 
 The agent IS the summarizer (see CLAUDE.md): its native reasoning, steered by
-SYSTEM_PROMPT plus the topic prompt_hint, produces the digest. enforce_length
-keeps the output within a target word range. Output is plain text; the delivery
-and formatting concern is intentionally deferred (CLAUDE.md), so the prompt does
+SYSTEM_PROMPT plus the topic prompt_hint, produces the structured digest.
+enforce_length keeps the output within a target word range, measuring over the
+flattened prose representation. Output is plain text; the delivery and
+formatting concern is intentionally deferred (CLAUDE.md), so the prompt does
 not optimize for any particular medium.
 """
 
 import hashlib
 from collections.abc import Callable
 
-SYSTEM_PROMPT = """You are a news digest agent. You produce a concise, readable \
-news digest from a set of curated sources.
+SYSTEM_PROMPT = """You are a news digest agent. You produce a structured, \
+readable news digest from a set of curated sources.
 
 How to work:
 1. Call list_topics to see the available topics, choose the one whose name best \
@@ -28,17 +29,29 @@ Do not repeat items already covered there.
    - A specific article page: call parse_article — it returns clean body text \
 with the navigation, ads, and footers already removed, which is what you want.
    - A listing or index page, or when you need the links on a page: call fetch_html.
-4. Read the gathered material and write one coherent digest in your own words.
-5. Call push_to_supabase to publish the finished digest, then log the result.
+4. Read the gathered material and compose a structured digest:
+   - A short top-level summary: one or two sentences capturing the most important \
+theme or development across all items.
+   - A ranked list of items. Each item must have:
+     - "headline": a single descriptive line.
+     - "blurb": one or two sentences describing what happened (shown to the reader \
+in the collapsed view).
+     - "detail": a fuller paragraph explaining why it matters, with specifics and \
+numbers where available (shown when the reader expands the item).
+     - "metadata": an object with a "sources" array of objects, each with a "title" \
+and a "url" (for example: [{"title": "AI Blog", "url": "https://example.com"}]). \
+Put source links only here — keep summary, blurb, and detail as clean prose with \
+no raw URLs. You may also include an optional "tags" array of short strings.
+   Rank items by significance. Explain why each item matters in the detail field. \
+Stay factual and grounded in the gathered material. Never invent facts that \
+were not in the sources. Skip dead sources and continue with the others.
+5. Call push_to_supabase(topic_slug, summary, items, sources_used, token_count) \
+to publish the finished digest, then log the result.
 
 Writing guidelines:
-- Write in clear, well-organized prose.
-- Lead with the most significant item, then move to the next most important. For \
-each item, explain what happened and why it matters. Do not try to cover \
-everything; choose the items worth the reader's time.
-- Stay factual and grounded in the gathered material. Never invent facts that \
-were not in the sources.
-- Aim for roughly 500 to 800 words.
+- Lead with the most significant item.
+- Aim for a summary of one to two sentences and roughly three to seven items.
+- Keep blurb concise (one to two sentences); use detail for context and numbers.
 - If a source is unreachable or returns nothing useful, skip it and continue with \
 the others."""
 
@@ -51,37 +64,71 @@ def count_words(text: str) -> int:
     return len(text.split())
 
 
+def flatten_digest(summary: str, items: list[dict]) -> str:
+    """Produce a flat TTS-safe prose string from structured digest data.
+
+    Generates the summary paragraph followed by one short paragraph per item
+    (headline and blurb, with detail appended where present). Plain prose only —
+    no URLs, no markdown. This is the canonical source of the ``content`` column.
+
+    Args:
+        summary: The top-level overview sentence(s).
+        items: Ranked list of digest item dicts, each optionally containing
+            ``headline``, ``blurb``, and ``detail`` keys.
+
+    Returns:
+        A single plain-prose string suitable for TTS consumption.
+    """
+    parts: list[str] = []
+    if summary:
+        parts.append(summary.strip())
+    for item in items:
+        headline = item.get("headline", "")
+        blurb = item.get("blurb", "")
+        detail = item.get("detail", "")
+        segments = [s.strip() for s in (headline, blurb, detail) if s and s.strip()]
+        if segments:
+            parts.append(" ".join(segments))
+    return "\n\n".join(parts)
+
+
 def enforce_length(
-    text: str,
-    regenerate: Callable[[str], str],
+    summary: str,
+    items: list[dict],
+    regenerate: Callable[[str], dict],
     *,
     min_words: int = 400,
     max_words: int = 960,
     target_low: int = 500,
     target_high: int = 800,
-) -> str:
+) -> tuple[str, list[dict]]:
     """Enforce the digest word-count target with a single corrective re-prompt.
 
-    The target is roughly 500-800 words; the accepted band is 400-960 (±20%).
-    If text is within band, it is returned unchanged. Otherwise regenerate is
-    called exactly once with a short feedback instruction (never looping), and
-    its result is returned as-is.
+    Measures word count over the flattened prose (``flatten_digest``) so the
+    threshold applies to the reader-facing text. The target is roughly 500-800
+    words; the accepted band is 400-960 (±20%). If the flattened text is within
+    band it is returned unchanged. Otherwise ``regenerate`` is called exactly once
+    with a short feedback instruction (never looping), and its result is returned.
 
     Args:
-        text: The generated digest.
-        regenerate: Callable taking a feedback string and returning new text
-            (e.g. a closure that re-invokes the LLM with the feedback appended).
+        summary: The top-level overview from the LLM.
+        items: The ranked item list from the LLM.
+        regenerate: Callable taking a feedback string and returning a dict with
+            ``summary`` and ``items`` keys (e.g. a closure that re-invokes the
+            LLM with the feedback appended).
         min_words: Lower bound of the accepted band.
         max_words: Upper bound of the accepted band.
         target_low: Lower bound named in the re-prompt feedback.
         target_high: Upper bound named in the re-prompt feedback.
 
     Returns:
-        The original text when in band, otherwise the single regenerated result.
+        A ``(summary, items)`` tuple — original when in band, otherwise from the
+        single regenerated result.
     """
-    n = count_words(text)
+    flat = flatten_digest(summary, items)
+    n = count_words(flat)
     if min_words <= n <= max_words:
-        return text
+        return summary, items
     if n > max_words:
         feedback = (
             f"The previous digest was too long at {n} words. Rewrite it as "
@@ -94,4 +141,5 @@ def enforce_length(
             f"clear prose of roughly {target_low} to {target_high} words, "
             f"adding more context on why each item matters."
         )
-    return regenerate(feedback)
+    result = regenerate(feedback)
+    return result.get("summary", ""), result.get("items", [])

--- a/src/news_digest/prompts.py
+++ b/src/news_digest/prompts.py
@@ -45,14 +45,17 @@ no raw URLs. You may also include an optional "tags" array of short strings.
    Rank items by significance. Explain why each item matters in the detail field. \
 Stay factual and grounded in the gathered material. Never invent facts that \
 were not in the sources. Skip dead sources and continue with the others.
-5. When the digest is composed, return it as your FINAL ANSWER — a single JSON \
+5. When the digest is composed, return it as your FINAL ANSWER, written as a \
+single fenced ```json code block (open with three backticks and "json", close \
+with three backticks) so your answer is text. Inside the block put one JSON \
 object with exactly these keys:
    - "topic_slug": the slug from fetch_topic_config.
    - "summary": the short top-level overview.
    - "items": the ranked list of items, using the same item shape described above \
 (headline, blurb, detail, metadata.sources).
    - "sources_used": the list of source URLs you actually used.
-   Do NOT call any tool to publish — just return that JSON object as your answer.
+   Do NOT call any tool to publish — put the whole digest in that code block as \
+your answer.
 
 Writing guidelines:
 - Lead with the most significant item.

--- a/src/news_digest/prompts.py
+++ b/src/news_digest/prompts.py
@@ -45,8 +45,14 @@ no raw URLs. You may also include an optional "tags" array of short strings.
    Rank items by significance. Explain why each item matters in the detail field. \
 Stay factual and grounded in the gathered material. Never invent facts that \
 were not in the sources. Skip dead sources and continue with the others.
-5. Call push_to_supabase(topic_slug, summary, items, sources_used, token_count) \
-to publish the finished digest, then log the result.
+5. When the digest is composed, return it as your FINAL ANSWER — a single JSON \
+object with exactly these keys:
+   - "topic_slug": the slug from fetch_topic_config.
+   - "summary": the short top-level overview.
+   - "items": the ranked list of items, using the same item shape described above \
+(headline, blurb, detail, metadata.sources).
+   - "sources_used": the list of source URLs you actually used.
+   Do NOT call any tool to publish — just return that JSON object as your answer.
 
 Writing guidelines:
 - Lead with the most significant item.

--- a/src/news_digest/scheduler.py
+++ b/src/news_digest/scheduler.py
@@ -1,7 +1,7 @@
 """Scheduler for the News Digest Agent.
 
-Wraps APScheduler to trigger agent.process_query() on configured intervals.
-Designed to run as a long-lived daemon via systemd.
+Wraps APScheduler to trigger agent.generate_and_publish() on configured
+intervals. Designed to run as a long-lived daemon via systemd.
 """
 
 # TODO: Phase 2 implementation
@@ -33,7 +33,7 @@ Designed to run as a long-lived daemon via systemd.
 #     )
 #
 #     # TODO: Query digest_topics for enabled topics, check cadence vs last run,
-#     # and call agent.process_query() for each due topic.
+#     # and call agent.generate_and_publish() for each due topic.
 #     logger.info("Checking for due topics...")
 #
 #

--- a/src/news_digest/tools/publishing.py
+++ b/src/news_digest/tools/publishing.py
@@ -21,7 +21,7 @@ from gaia.agents.base.tools import tool
 
 from news_digest.config import get_settings
 from news_digest.logging import log
-from news_digest.prompts import PROMPT_VERSION
+from news_digest.prompts import PROMPT_VERSION, flatten_digest
 from supabase import Client, create_client
 
 _CONFIG_CACHE_TTL: float = 300.0  # 5 minutes (issue #8)
@@ -141,22 +141,43 @@ def list_topics() -> dict:
 @tool
 def push_to_supabase(
     topic_slug: str,
-    content: str,
+    summary: str,
+    items: list[dict],
     sources_used: list[str],
     token_count: int,
+    content: str | None = None,
 ) -> dict:
-    """Publish a finished digest to the Supabase digests table.
+    """Publish a finished structured digest to the Supabase digests table.
 
     Idempotent per topic per day: upserts on the unique (topic_slug, digest_date)
     pair, so re-running the same day updates the existing row instead of creating
     a duplicate. The digest date is today in UTC; cadence is taken from the topic
     config; prompt_version records which system prompt produced the text.
 
+    The ``content`` column is derived via ``flatten_digest(summary, items)`` when
+    not explicitly provided. It is kept as the flat TTS-safe fallback and
+    deduplication source.
+
+    Each element of ``items`` must follow the canonical item shape::
+
+        {
+            "headline": "one-line description",
+            "blurb":    "1-2 sentences — what happened",
+            "detail":   "fuller prose — why it matters, specifics/numbers",
+            "metadata": {
+                "sources": [{"title": "Source Name", "url": "https://..."}],
+                "tags":    ["optional", "tags"],
+            }
+        }
+
     Args:
         topic_slug: The topic slug, for example 'ai_models'.
-        content: The finished digest text.
+        summary: Short top-level overview (one or two sentences).
+        items: Ranked list of digest items (canonical shape above).
         sources_used: URLs that were scraped for this digest.
         token_count: Approximate token count of the generated digest.
+        content: Flat prose override. When omitted, derived from summary+items
+            via ``flatten_digest`` (no raw URLs, TTS-safe).
 
     Returns:
         {'success': True, 'id': <row id>, 'digest_date': <iso date>} on success,
@@ -176,9 +197,13 @@ def push_to_supabase(
         )
         return {"success": False, "error": "unknown_topic"}
 
+    derived_content = content or flatten_digest(summary, items)
+
     row = {
         "topic_slug": topic_slug,
-        "content": content,
+        "summary": summary,
+        "items": items,
+        "content": derived_content,
         "cadence": cadence,
         "digest_date": digest_date,
         "sources_used": sources_used,

--- a/supabase/migrations/0009_digest_structured_output.sql
+++ b/supabase/migrations/0009_digest_structured_output.sql
@@ -1,0 +1,9 @@
+-- Structured digest output: summary + ranked items (issue #58)
+-- Adds two nullable columns to digests.  Pre-#58 rows keep content and leave
+-- these null; new rows carry summary + items while content is derived from them
+-- via flatten_digest() (docs/architecture.md §7.1).  No RLS changes: the
+-- existing authenticated-read policy (migration 0006) already covers new
+-- columns, and service_role bypasses RLS for agent writes.
+
+alter table digests add column summary text;   -- short top-level overview; null on pre-#58 rows
+alter table digests add column items jsonb;     -- ranked items (see docs/architecture.md §7.1)

--- a/tests/test_agent_e2e.py
+++ b/tests/test_agent_e2e.py
@@ -65,7 +65,9 @@ def test_ensure_context_window_loads_model_with_large_ctx(monkeypatch):
         def __init__(self, base_url=None, **kw):
             captured["base_url"] = base_url
 
-        def load_model(self, model_name, ctx_size=None, save_options=False, prompt=True):
+        def load_model(
+            self, model_name, ctx_size=None, save_options=False, prompt=True
+        ):
             captured.update(
                 model_name=model_name,
                 ctx_size=ctx_size,

--- a/tests/test_agent_e2e.py
+++ b/tests/test_agent_e2e.py
@@ -47,3 +47,73 @@ def test_agent_uses_system_prompt():
     # the prompt does not require live Lemonade/Supabase settings.
     agent = NewsDigestAgent.__new__(NewsDigestAgent)
     assert agent._get_system_prompt() == SYSTEM_PROMPT
+
+
+# ---------------------------------------------------------------------------
+# _ensure_context_window — agent requests a large context window on startup
+# (Lemonade's 4096 default overflows a multi-source run)
+# ---------------------------------------------------------------------------
+
+
+def test_ensure_context_window_loads_model_with_large_ctx(monkeypatch):
+    from news_digest import agent as agent_mod
+    from news_digest.agent import NewsDigestAgent
+
+    captured = {}
+
+    class FakeClient:
+        def __init__(self, base_url=None, **kw):
+            captured["base_url"] = base_url
+
+        def load_model(self, model_name, ctx_size=None, save_options=False, prompt=True):
+            captured.update(
+                model_name=model_name,
+                ctx_size=ctx_size,
+                save_options=save_options,
+                prompt=prompt,
+            )
+            return {}
+
+    monkeypatch.setattr(agent_mod, "LemonadeClient", FakeClient)
+    agent = NewsDigestAgent.__new__(NewsDigestAgent)
+    agent._ensure_context_window("Qwen3.5-35B-A3B-GGUF", "http://host:13305/api/v1")
+
+    assert captured["base_url"] == "http://host:13305/api/v1"
+    assert captured["model_name"] == "Qwen3.5-35B-A3B-GGUF"
+    assert captured["ctx_size"] == agent_mod._HEAVY_CTX_SIZE == 32768
+    assert captured["save_options"] is True
+    assert captured["prompt"] is False  # headless: never prompt for input
+
+
+def test_ensure_context_window_noops_without_model(monkeypatch):
+    from news_digest import agent as agent_mod
+    from news_digest.agent import NewsDigestAgent
+
+    calls = {"n": 0}
+
+    class FakeClient:
+        def __init__(self, **kw):
+            calls["n"] += 1
+
+    monkeypatch.setattr(agent_mod, "LemonadeClient", FakeClient)
+    agent = NewsDigestAgent.__new__(NewsDigestAgent)
+    agent._ensure_context_window(None, "http://host/api/v1")
+    assert calls["n"] == 0  # no model -> no client built
+
+
+def test_ensure_context_window_never_raises(monkeypatch):
+    from news_digest import agent as agent_mod
+    from news_digest.agent import NewsDigestAgent
+
+    class BoomClient:
+        def __init__(self, **kw):
+            pass
+
+        def load_model(self, *a, **k):
+            raise RuntimeError("lemonade unreachable")
+
+    monkeypatch.setattr(agent_mod, "LemonadeClient", BoomClient)
+    monkeypatch.setattr(agent_mod, "log", lambda *a, **k: None)
+    agent = NewsDigestAgent.__new__(NewsDigestAgent)
+    # Best-effort: a load failure must not propagate out of startup.
+    agent._ensure_context_window("some-model", "http://host/api/v1")

--- a/tests/test_generate_and_publish.py
+++ b/tests/test_generate_and_publish.py
@@ -271,3 +271,28 @@ def test_generate_and_publish_calls_process_query_then_publishes(
     assert out["success"] is True
     assert _capture_push[0]["topic_slug"] == "ai_models"
     assert _capture_push[0]["token_count"] == 321
+
+
+# ---------------------------------------------------------------------------
+# Answer returned as a fenced ```json string (Qwen shape; also avoids GAIA's
+# planning-guard, which calls .lower() on a bare-dict answer and crashes)
+# ---------------------------------------------------------------------------
+
+
+def test_publish_answer_is_fenced_json_string(_capture_push):
+    inner = "```json\n" + json.dumps(_answer_payload()) + "\n```"
+    raw = json.dumps({"thought": "done", "answer": inner})
+    result = {
+        "status": "success",
+        "result": raw,
+        "conversation": [],
+        "output_tokens": 7,
+    }
+
+    out = _publish_from_result(result)
+
+    assert out["success"] is True
+    assert len(_capture_push) == 1
+    assert _capture_push[0]["topic_slug"] == "ai_models"
+    assert _capture_push[0]["summary"] == "Top AI news today."
+    assert _capture_push[0]["token_count"] == 7

--- a/tests/test_generate_and_publish.py
+++ b/tests/test_generate_and_publish.py
@@ -1,0 +1,273 @@
+"""Tests for the Python-side publish path — issue #58 design change.
+
+Local models do not reliably emit a final push_to_supabase tool call, so the
+model returns the structured digest as its final answer and Python parses it.
+``_publish_from_result`` is the unit-testable parser+publisher; these tests drive
+it with synthetic process_query results matching the live Gemma shape.
+"""
+
+import json
+
+import pytest
+
+from news_digest import agent as agent_module
+from news_digest.agent import _publish_from_result
+
+
+@pytest.fixture(autouse=True)
+def _capture_push(monkeypatch):
+    """Replace push_to_supabase with a recorder; return the call log."""
+    calls = []
+
+    def _fake_push(topic_slug, *, summary, items, sources_used, token_count):
+        calls.append(
+            {
+                "topic_slug": topic_slug,
+                "summary": summary,
+                "items": items,
+                "sources_used": sources_used,
+                "token_count": token_count,
+            }
+        )
+        return {"success": True, "id": "row-1", "digest_date": "2026-06-10"}
+
+    monkeypatch.setattr(agent_module, "push_to_supabase", _fake_push)
+    return calls
+
+
+@pytest.fixture(autouse=True)
+def _silence_log(monkeypatch):
+    """Keep the parser's error logging from touching Supabase/SQLite in tests."""
+    monkeypatch.setattr(agent_module, "log", lambda *a, **k: None)
+
+
+_ITEMS = [
+    {
+        "headline": "AI Corp ships Model X",
+        "blurb": "A new frontier model. Beats prior baselines.",
+        "detail": "Scores 95 on MMLU after six months of training.",
+        "metadata": {"sources": [{"title": "Blog", "url": "https://example.com"}]},
+    }
+]
+
+
+def _answer_payload(include_slug: bool = True) -> dict:
+    digest = {
+        "summary": "Top AI news today.",
+        "items": _ITEMS,
+        "sources_used": ["https://example.com"],
+    }
+    if include_slug:
+        digest["topic_slug"] = "ai_models"
+    return digest
+
+
+# ---------------------------------------------------------------------------
+# Clean answer (digest nested under "answer", topic_slug present)
+# ---------------------------------------------------------------------------
+
+
+def test_publish_clean_nested_answer(_capture_push):
+    raw = json.dumps(
+        {
+            "thought": "done",
+            "goal": "digest",
+            "answer": _answer_payload(),
+        }
+    )
+    result = {
+        "status": "success",
+        "result": raw,
+        "conversation": [],
+        "output_tokens": 742,
+    }
+    out = _publish_from_result(result)
+    assert out["success"] is True
+    assert len(_capture_push) == 1
+    call = _capture_push[0]
+    assert call["topic_slug"] == "ai_models"
+    assert call["summary"] == "Top AI news today."
+    assert call["items"] == _ITEMS
+    assert call["sources_used"] == ["https://example.com"]
+    assert call["token_count"] == 742
+
+
+# ---------------------------------------------------------------------------
+# Top-level digest (no "answer" wrapper)
+# ---------------------------------------------------------------------------
+
+
+def test_publish_top_level_digest(_capture_push):
+    raw = json.dumps(_answer_payload())
+    result = {"status": "success", "result": raw, "output_tokens": 10}
+    out = _publish_from_result(result)
+    assert out["success"] is True
+    assert _capture_push[0]["topic_slug"] == "ai_models"
+    assert _capture_push[0]["token_count"] == 10
+
+
+# ---------------------------------------------------------------------------
+# Markdown-fenced answer (```json ... ```)
+# ---------------------------------------------------------------------------
+
+
+def test_publish_json_fenced_answer(_capture_push):
+    inner = json.dumps({"answer": _answer_payload()})
+    raw = f"```json\n{inner}\n```"
+    result = {"status": "success", "result": raw, "output_tokens": 5}
+    out = _publish_from_result(result)
+    assert out["success"] is True
+    assert _capture_push[0]["summary"] == "Top AI news today."
+
+
+def test_publish_bare_fenced_answer(_capture_push):
+    inner = json.dumps(_answer_payload())
+    raw = f"```\n{inner}\n```"
+    result = {"status": "success", "result": raw, "output_tokens": 0}
+    out = _publish_from_result(result)
+    assert out["success"] is True
+    assert _capture_push[0]["topic_slug"] == "ai_models"
+
+
+# ---------------------------------------------------------------------------
+# topic_slug missing from JSON → recovered from fetch_topic_config call
+# ---------------------------------------------------------------------------
+
+
+def test_publish_recovers_slug_from_conversation(_capture_push):
+    raw = json.dumps({"answer": _answer_payload(include_slug=False)})
+    result = {
+        "status": "success",
+        "result": raw,
+        "conversation": [
+            {"role": "user", "content": "Generate the AI digest"},
+            {
+                "role": "tool",
+                "name": "fetch_topic_config",
+                "tool_args": {"slug": "ai_models"},
+                "content": {"slug": "ai_models", "cadence": "24h"},
+            },
+            {"role": "assistant", "content": raw},
+        ],
+        "output_tokens": 99,
+    }
+    out = _publish_from_result(result)
+    assert out["success"] is True
+    assert _capture_push[0]["topic_slug"] == "ai_models"
+
+
+def test_publish_uses_last_fetch_topic_config_when_multiple(_capture_push):
+    raw = json.dumps(_answer_payload(include_slug=False))
+    result = {
+        "status": "success",
+        "result": raw,
+        "conversation": [
+            {
+                "role": "tool",
+                "name": "fetch_topic_config",
+                "tool_args": {"slug": "old"},
+            },
+            {
+                "role": "tool",
+                "name": "fetch_topic_config",
+                "tool_args": {"slug": "ai_models"},
+            },
+        ],
+        "output_tokens": 1,
+    }
+    out = _publish_from_result(result)
+    assert out["success"] is True
+    assert _capture_push[0]["topic_slug"] == "ai_models"
+
+
+# ---------------------------------------------------------------------------
+# Failure paths → error dict, push never called, never raises
+# ---------------------------------------------------------------------------
+
+
+def test_publish_malformed_json_returns_error(_capture_push):
+    result = {"status": "success", "result": "not json {{{", "output_tokens": 0}
+    out = _publish_from_result(result)
+    assert out["success"] is False
+    assert out["error"] == "parse_error"
+    assert _capture_push == []
+
+
+def test_publish_missing_summary_returns_error(_capture_push):
+    raw = json.dumps({"topic_slug": "ai_models", "items": _ITEMS})
+    result = {"status": "success", "result": raw, "output_tokens": 0}
+    out = _publish_from_result(result)
+    assert out["success"] is False
+    assert out["error"] == "missing_fields"
+    assert _capture_push == []
+
+
+def test_publish_missing_slug_everywhere_returns_error(_capture_push):
+    raw = json.dumps(_answer_payload(include_slug=False))
+    result = {
+        "status": "success",
+        "result": raw,
+        "conversation": [],
+        "output_tokens": 0,
+    }
+    out = _publish_from_result(result)
+    assert out["success"] is False
+    assert out["error"] == "missing_fields"
+    assert _capture_push == []
+
+
+def test_publish_no_answer_string_returns_error(_capture_push):
+    result = {"status": "failed", "result": "", "output_tokens": 0}
+    out = _publish_from_result(result)
+    assert out["success"] is False
+    assert out["error"] == "no_answer"
+    assert _capture_push == []
+
+
+def test_publish_non_object_answer_returns_error(_capture_push):
+    raw = json.dumps(["not", "an", "object"])
+    result = {"status": "success", "result": raw, "output_tokens": 0}
+    out = _publish_from_result(result)
+    assert out["success"] is False
+    assert out["error"] == "bad_answer_shape"
+    assert _capture_push == []
+
+
+def test_publish_defaults_sources_used_to_empty_list(_capture_push):
+    raw = json.dumps({"topic_slug": "ai_models", "summary": "S", "items": _ITEMS})
+    result = {"status": "success", "result": raw, "output_tokens": 0}
+    out = _publish_from_result(result)
+    assert out["success"] is True
+    assert _capture_push[0]["sources_used"] == []
+
+
+# ---------------------------------------------------------------------------
+# generate_and_publish wires process_query -> _publish_from_result
+# ---------------------------------------------------------------------------
+
+
+def test_generate_and_publish_calls_process_query_then_publishes(
+    monkeypatch, _capture_push
+):
+    from news_digest.agent import NewsDigestAgent
+
+    raw = json.dumps({"answer": _answer_payload()})
+    fake_result = {
+        "status": "success",
+        "result": raw,
+        "conversation": [],
+        "output_tokens": 321,
+    }
+
+    # Uninitialized instance avoids needing live Lemonade/Supabase settings.
+    agent = NewsDigestAgent.__new__(NewsDigestAgent)
+    monkeypatch.setattr(
+        NewsDigestAgent,
+        "process_query",
+        lambda self, query: fake_result,
+    )
+
+    out = agent.generate_and_publish("Generate the AI digest")
+    assert out["success"] is True
+    assert _capture_push[0]["topic_slug"] == "ai_models"
+    assert _capture_push[0]["token_count"] == 321

--- a/tests/test_prompts.py
+++ b/tests/test_prompts.py
@@ -151,6 +151,7 @@ def test_enforce_length_reprompts_once_when_too_short():
     result = enforce_length(summary, items, regen)
     assert len(calls) == 1
     assert "short" in calls[0].lower()
+    assert result[0] == "a much longer result"
 
 
 def test_enforce_length_reprompts_at_most_once_even_if_still_out_of_range():

--- a/tests/test_prompts.py
+++ b/tests/test_prompts.py
@@ -1,4 +1,4 @@
-"""Tests for src/news_digest/prompts.py — issue #7 (audio-first prompts)."""
+"""Tests for src/news_digest/prompts.py — issue #7 (audio-first prompts), #58 (structured output)."""
 
 import hashlib
 
@@ -7,6 +7,7 @@ from news_digest.prompts import (
     SYSTEM_PROMPT,
     count_words,
     enforce_length,
+    flatten_digest,
 )
 
 # ---------------------------------------------------------------------------
@@ -22,61 +23,148 @@ def test_count_words_counts_whitespace_separated_tokens():
 
 
 # ---------------------------------------------------------------------------
-# enforce_length — one re-prompt on out-of-range (500-800 words ±20% → 400-960)
+# flatten_digest — issue #58
 # ---------------------------------------------------------------------------
 
 
+def _sample_items() -> list[dict]:
+    return [
+        {
+            "headline": "AI Corp releases Model X",
+            "blurb": "AI Corp announced Model X today. It beats previous benchmarks.",
+            "detail": "Model X scores 95 on MMLU. The team trained for six months.",
+            "metadata": {
+                "sources": [{"title": "AI Blog", "url": "https://example.com/blog"}],
+            },
+        },
+        {
+            "headline": "Open Source rival emerges",
+            "blurb": "A new open-source model matches commercial offerings.",
+            "detail": "Released under Apache 2. Fine-tuning kits ship next week.",
+            "metadata": {
+                "sources": [{"title": "GitHub", "url": "https://github.com/org/repo"}],
+                "tags": ["open-source"],
+            },
+        },
+    ]
+
+
+def test_flatten_digest_includes_headlines_and_blurbs():
+    items = _sample_items()
+    result = flatten_digest("Top summary here.", items)
+    assert "AI Corp releases Model X" in result
+    assert "beats previous benchmarks" in result
+    assert "open-source model matches" in result
+
+
+def test_flatten_digest_contains_no_urls():
+    items = _sample_items()
+    result = flatten_digest("Summary.", items)
+    assert "http" not in result
+    assert "https" not in result
+
+
+def test_flatten_digest_is_deterministic():
+    items = _sample_items()
+    assert flatten_digest("S", items) == flatten_digest("S", items)
+
+
+def test_flatten_digest_empty_items_returns_summary():
+    result = flatten_digest("Only summary text.", [])
+    assert "Only summary text" in result
+
+
+def test_flatten_digest_handles_missing_optional_keys():
+    # item with no 'detail', no 'metadata'
+    items = [{"headline": "A thing happened", "blurb": "It was notable."}]
+    result = flatten_digest("Summary.", items)
+    assert "A thing happened" in result
+    assert "It was notable." in result
+
+
+def test_flatten_digest_contains_no_markdown():
+    items = _sample_items()
+    result = flatten_digest("Summary.", items)
+    assert "**" not in result
+    assert "#" not in result
+    assert "[" not in result
+
+
+# ---------------------------------------------------------------------------
+# enforce_length — adapted for structured shape (issue #58)
+# ---------------------------------------------------------------------------
+
+
+def _make_items(total_blurb_words: int) -> list[dict]:
+    """Build a list of items whose flattened blurb fills roughly total_blurb_words words."""
+    word = "word"
+    blurb = " ".join([word] * (total_blurb_words // 2))
+    detail = " ".join([word] * (total_blurb_words // 2))
+    return [
+        {
+            "headline": "Headline",
+            "blurb": blurb,
+            "detail": detail,
+            "metadata": {"sources": []},
+        }
+    ]
+
+
 def test_enforce_length_returns_original_within_range_without_reprompt():
-    text = " ".join(["word"] * 600)
+    # summary (~50 words) + items (~550 words) = ~600 total, in range
+    summary = " ".join(["word"] * 50)
+    items = _make_items(550)
     calls = []
 
     def regen(feedback):
         calls.append(feedback)
-        return "REGENERATED"
+        return {"summary": "REGENERATED", "items": []}
 
-    assert enforce_length(text, regen) == text
-    assert calls == []  # in range → no re-prompt
+    assert enforce_length(summary, items, regen) == (summary, items)
+    assert calls == []
 
 
 def test_enforce_length_reprompts_once_when_too_long():
-    text = " ".join(["word"] * 1000)  # > 960
+    summary = " ".join(["word"] * 100)
+    items = _make_items(900)  # together > 960
     calls = []
 
     def regen(feedback):
         calls.append(feedback)
-        return "shorter result"
+        return {"summary": "shorter", "items": []}
 
-    result = enforce_length(text, regen)
+    result = enforce_length(summary, items, regen)
     assert len(calls) == 1
     assert "long" in calls[0].lower()
-    assert result == "shorter result"
+    assert result == ("shorter", [])
 
 
 def test_enforce_length_reprompts_once_when_too_short():
-    text = " ".join(["word"] * 100)  # < 400
+    summary = " ".join(["word"] * 10)
+    items = _make_items(50)  # together < 400
     calls = []
 
     def regen(feedback):
         calls.append(feedback)
-        return "a much longer result"
+        return {"summary": "a much longer result", "items": _make_items(400)}
 
-    result = enforce_length(text, regen)
+    result = enforce_length(summary, items, regen)
     assert len(calls) == 1
     assert "short" in calls[0].lower()
-    assert result == "a much longer result"
 
 
 def test_enforce_length_reprompts_at_most_once_even_if_still_out_of_range():
-    text = " ".join(["word"] * 50)
+    summary = " ".join(["word"] * 5)
+    items = _make_items(20)  # < 400
     calls = []
 
     def regen(feedback):
         calls.append(feedback)
-        return "still short"  # 2 words, still out of range
+        return {"summary": "still", "items": []}  # still short
 
-    result = enforce_length(text, regen)
+    result = enforce_length(summary, items, regen)
     assert len(calls) == 1  # exactly one re-prompt — never loops
-    assert result == "still short"
+    assert result == ("still", [])
 
 
 # ---------------------------------------------------------------------------
@@ -91,7 +179,7 @@ def test_prompt_version_is_deterministic_identity_of_system_prompt():
 
 
 # ---------------------------------------------------------------------------
-# SYSTEM_PROMPT — describes the tool workflow; audio layer fully removed
+# SYSTEM_PROMPT — describes structured output contract; audio layer fully removed
 # ---------------------------------------------------------------------------
 
 
@@ -107,3 +195,16 @@ def test_system_prompt_describes_workflow_without_audio_layer():
     assert "audio" not in sp
     assert "read aloud" not in sp
     assert "news anchor" not in sp
+
+
+def test_system_prompt_describes_structured_output_contract():
+    sp = SYSTEM_PROMPT
+    # structured output keywords must be present
+    assert "summary" in sp
+    assert "items" in sp
+    assert "headline" in sp
+    assert "blurb" in sp
+    assert "detail" in sp
+    assert "sources" in sp
+    # push_to_supabase call with correct args
+    assert "push_to_supabase" in sp

--- a/tests/test_prompts.py
+++ b/tests/test_prompts.py
@@ -207,5 +207,14 @@ def test_system_prompt_describes_structured_output_contract():
     assert "blurb" in sp
     assert "detail" in sp
     assert "sources" in sp
-    # push_to_supabase call with correct args
-    assert "push_to_supabase" in sp
+
+
+def test_system_prompt_instructs_final_answer_json_not_publish_tool():
+    sp = SYSTEM_PROMPT
+    sp_lower = sp.lower()
+    # The model returns the digest as its FINAL ANSWER (JSON), not via a tool call.
+    assert "final answer" in sp_lower
+    assert "topic_slug" in sp
+    assert "sources_used" in sp
+    # It must NOT instruct the model to publish via push_to_supabase anymore.
+    assert "push_to_supabase" not in sp

--- a/tests/test_publishing_tools.py
+++ b/tests/test_publishing_tools.py
@@ -248,7 +248,9 @@ def test_push_to_supabase_items_persisted_unchanged(monkeypatch):
 
 def test_push_to_supabase_unknown_topic_returns_failure(monkeypatch):
     _install_client(monkeypatch, {"rows": {"digest_topics": []}})
-    result = push_to_supabase("ghost", summary="x", items=[], sources_used=[], token_count=0)
+    result = push_to_supabase(
+        "ghost", summary="x", items=[], sources_used=[], token_count=0
+    )
     assert result["success"] is False
     assert "error" in result
 
@@ -260,7 +262,9 @@ def test_push_to_supabase_handles_db_failure_gracefully(monkeypatch):
         {"slug": "ai_models", "cadence": "24h"},
     )
     _install_client(monkeypatch, {"raise": RuntimeError("db down")})
-    result = push_to_supabase("ai_models", summary="x", items=[], sources_used=[], token_count=0)
+    result = push_to_supabase(
+        "ai_models", summary="x", items=[], sources_used=[], token_count=0
+    )
     assert result["success"] is False
     assert "error" in result
 

--- a/tests/test_publishing_tools.py
+++ b/tests/test_publishing_tools.py
@@ -1,4 +1,4 @@
-"""Tests for src/news_digest/tools/publishing.py — issue #8.
+"""Tests for src/news_digest/tools/publishing.py — issue #8, #58.
 
 These use a lightweight fake Supabase client. Per the project's testing policy
 the real pass gate is the live-Supabase integration run on the host; these
@@ -172,14 +172,29 @@ def test_fetch_topic_config_handles_exception_without_raising(monkeypatch):
 
 
 # ---------------------------------------------------------------------------
-# push_to_supabase
+# push_to_supabase — issue #58: structured output (summary + items + derived content)
 # ---------------------------------------------------------------------------
+
+_SAMPLE_ITEMS = [
+    {
+        "headline": "AI Corp ships Model X",
+        "blurb": "A new frontier model. Beats previous baselines.",
+        "detail": "Scores 95 on MMLU. Six months of training.",
+        "metadata": {"sources": [{"title": "Blog", "url": "https://example.com"}]},
+    }
+]
 
 
 def test_push_to_supabase_upserts_expected_row_and_returns_id(monkeypatch):
     state = {"rows": {"digest_topics": [{"slug": "ai_models", "cadence": "24h"}]}}
     _install_client(monkeypatch, state)
-    result = push_to_supabase("ai_models", "Hello digest", ["https://a"], 123)
+    result = push_to_supabase(
+        "ai_models",
+        summary="Top AI news today.",
+        items=_SAMPLE_ITEMS,
+        sources_used=["https://example.com"],
+        token_count=123,
+    )
 
     assert result["success"] is True
     assert result["id"] == "fake-uuid-123"
@@ -189,17 +204,51 @@ def test_push_to_supabase_upserts_expected_row_and_returns_id(monkeypatch):
     assert up["on_conflict"] == "topic_slug,digest_date"
     row = up["row"]
     assert row["topic_slug"] == "ai_models"
-    assert row["content"] == "Hello digest"
-    assert row["sources_used"] == ["https://a"]
+    assert row["summary"] == "Top AI news today."
+    assert row["items"] == _SAMPLE_ITEMS
+    # content is derived, not empty, and contains no raw URLs
+    assert isinstance(row["content"], str) and len(row["content"]) > 0
+    assert "http" not in row["content"]
+    assert row["sources_used"] == ["https://example.com"]
     assert row["token_count"] == 123
-    assert row["cadence"] == "24h"  # sourced from topic config
+    assert row["cadence"] == "24h"
     assert row["prompt_version"] == publishing.PROMPT_VERSION
     assert row["digest_date"] == datetime.now(UTC).date().isoformat()
 
 
+def test_push_to_supabase_explicit_content_is_honored(monkeypatch):
+    state = {"rows": {"digest_topics": [{"slug": "ai_models", "cadence": "24h"}]}}
+    _install_client(monkeypatch, state)
+    result = push_to_supabase(
+        "ai_models",
+        summary="Summary here.",
+        items=_SAMPLE_ITEMS,
+        sources_used=[],
+        token_count=0,
+        content="Explicitly provided content, no override.",
+    )
+    assert result["success"] is True
+    row = state["upserts"][-1]["row"]
+    assert row["content"] == "Explicitly provided content, no override."
+
+
+def test_push_to_supabase_items_persisted_unchanged(monkeypatch):
+    state = {"rows": {"digest_topics": [{"slug": "ai_models", "cadence": "24h"}]}}
+    _install_client(monkeypatch, state)
+    push_to_supabase(
+        "ai_models",
+        summary="S",
+        items=_SAMPLE_ITEMS,
+        sources_used=[],
+        token_count=0,
+    )
+    row = state["upserts"][-1]["row"]
+    assert row["items"] == _SAMPLE_ITEMS
+
+
 def test_push_to_supabase_unknown_topic_returns_failure(monkeypatch):
     _install_client(monkeypatch, {"rows": {"digest_topics": []}})
-    result = push_to_supabase("ghost", "x", [], 0)
+    result = push_to_supabase("ghost", summary="x", items=[], sources_used=[], token_count=0)
     assert result["success"] is False
     assert "error" in result
 
@@ -211,7 +260,7 @@ def test_push_to_supabase_handles_db_failure_gracefully(monkeypatch):
         {"slug": "ai_models", "cadence": "24h"},
     )
     _install_client(monkeypatch, {"raise": RuntimeError("db down")})
-    result = push_to_supabase("ai_models", "x", [], 0)
+    result = push_to_supabase("ai_models", summary="x", items=[], sources_used=[], token_count=0)
     assert result["success"] is False
     assert "error" in result
 

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -151,8 +151,282 @@
         "node": ">=18"
       }
     },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.21.5.tgz",
+      "integrity": "sha512-1SDgH6ZSPTlggy1yI6+Dbkiz8xzpHJEVAlF/AM1tHPLsf5STom9rwtjE4hKAF20FfXXNTFqEYXyJNWh1GiZedQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.21.5.tgz",
+      "integrity": "sha512-vCPvzSjpPHEi1siZdlvAlsPxXl7WbOVUBBAowWug4rJHb68Ox8KualB+1ocNvT5fjv6wpkX6o/iEpbDrf68zcg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.21.5.tgz",
+      "integrity": "sha512-c0uX9VAUBQ7dTDCjq+wdyGLowMdtR/GoC2U5IYk/7D1H1JYC0qseD7+11iMP2mRLN9RcCMRcjC4YMclCzGwS/A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.21.5.tgz",
+      "integrity": "sha512-D7aPRUUNHRBwHxzxRvp856rjUHRFW1SdQATKXH2hqA0kAZb1hKmi02OpYRacl0TxIGz/ZmXWlbZgjwWYaCakTA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.21.5.tgz",
+      "integrity": "sha512-DwqXqZyuk5AiWWf3UfLiRDJ5EDd49zg6O9wclZ7kUMv2WRFr4HKjXp/5t8JZ11QbQfUS6/cRCKGwYhtNAY88kQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.21.5.tgz",
+      "integrity": "sha512-se/JjF8NlmKVG4kNIuyWMV/22ZaerB+qaSi5MdrXtd6R08kvs2qCN4C09miupktDitvh8jRFflwGFBQcxZRjbw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.21.5.tgz",
+      "integrity": "sha512-5JcRxxRDUJLX8JXp/wcBCy3pENnCgBR9bN6JsY4OmhfUtIHe3ZW0mawA7+RDAcMLrMIZaf03NlQiX9DGyB8h4g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.21.5.tgz",
+      "integrity": "sha512-J95kNBj1zkbMXtHVH29bBriQygMXqoVQOQYA+ISs0/2l3T9/kj42ow2mpqerRBxDJnmkUDCaQT/dfNXWX/ZZCQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.21.5.tgz",
+      "integrity": "sha512-bPb5AHZtbeNGjCKVZ9UGqGwo8EUu4cLq68E95A53KlxAPRmUyYv2D6F0uUI65XisGOL1hBP5mTronbgo+0bFcA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.21.5.tgz",
+      "integrity": "sha512-ibKvmyYzKsBeX8d8I7MH/TMfWDXBF3db4qM6sy+7re0YXya+K1cem3on9XgdT2EQGMu4hQyZhan7TeQ8XkGp4Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.21.5.tgz",
+      "integrity": "sha512-YvjXDqLRqPDl2dvRODYmmhz4rPeVKYvppfGYKSNGdyZkA01046pLWyRKKI3ax8fbJoK5QbxblURkwK/MWY18Tg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.21.5.tgz",
+      "integrity": "sha512-uHf1BmMG8qEvzdrzAqg2SIG/02+4/DHB6a9Kbya0XDvwDEKCoC8ZRWI5JJvNdUjtciBGFQ5PuBlpEOXQj+JQSg==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.21.5.tgz",
+      "integrity": "sha512-IajOmO+KJK23bj52dFSNCMsz1QP1DqM6cwLUv3W1QwyxkyIWecfafnI555fvSGqEKwjMXVLokcV5ygHW5b3Jbg==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.21.5.tgz",
+      "integrity": "sha512-1hHV/Z4OEfMwpLO8rp7CvlhBDnjsC3CttJXIhBi+5Aj5r+MBvy4egg7wCbe//hSsT+RvDAG7s81tAvpL2XAE4w==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.21.5.tgz",
+      "integrity": "sha512-2HdXDMd9GMgTGrPWnJzP2ALSokE/0O5HhTUvWIbD3YdjME8JwvSCnNGBnTThKGEB91OZhzrJ4qIIxk/SBmyDDA==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.21.5.tgz",
+      "integrity": "sha512-zus5sxzqBJD3eXxwvjN1yQkRepANgxE9lgOW2qLnmr8ikMTphkjgXu1HR01K4FJg8h1kEEDAqDcZQtbrRnB41A==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/@esbuild/linux-x64": {
       "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.21.5.tgz",
+      "integrity": "sha512-1rYdTpyv03iycF1+BhzrzQJCdOuAOtaqHTWJZCWvijKD2N5Xu0TtVC8/+1faWqcP9iBCWOmjmhoH94dH82BxPQ==",
       "cpu": [
         "x64"
       ],
@@ -166,8 +440,112 @@
         "node": ">=12"
       }
     },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.21.5.tgz",
+      "integrity": "sha512-Woi2MXzXjMULccIwMnLciyZH4nCIMpWQAs049KEeMvOcNADVxo0UBIQPfSmxB3CWKedngg7sWZdLvLczpe0tLg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.21.5.tgz",
+      "integrity": "sha512-HLNNw99xsvx12lFBUwoT8EVCsSvRNDVxNpjZ7bPn947b8gJPzeHWyNVhFsaerc0n3TsbOINvRP2byTZ5LKezow==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.21.5.tgz",
+      "integrity": "sha512-6+gjmFpfy0BHU5Tpptkuh8+uw3mnrvgs+dSPQXQOv3ekbordwnzTVEb4qnIvQcYXq6gzkyTnoZ9dZG+D4garKg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.21.5.tgz",
+      "integrity": "sha512-Z0gOTd75VvXqyq7nsl93zwahcTROgqvuAcYDUr+vOv8uHhNSKROyU961kgtCD1e95IqPKSQKH7tBTslnS3tA8A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.21.5.tgz",
+      "integrity": "sha512-SWXFF1CL2RVNMaVs+BBClwtfZSvDgtL//G/smwAc5oVK/UPu2Gu9tIaRgFmYFFKrmg3SyAjSrElf0TiJ1v8fYA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.21.5.tgz",
+      "integrity": "sha512-tQd/1efJuzPC6rCFwEvLtci/xNFcTZknmXs98FYDfGE4wP9ClFV98nyKrzJKVPMhdDnjzLhdUyMX4PsQAPjwIw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/@eslint-community/eslint-utils": {
       "version": "4.9.1",
+      "resolved": "https://registry.npmjs.org/@eslint-community/eslint-utils/-/eslint-utils-4.9.1.tgz",
+      "integrity": "sha512-phrYmNiYppR7znFEdqgfWHXR6NCkZEK7hwWDHZUjit/2/U0r6XvkDl0SYnoM51Hq7FhCGdLDT6zxCCOY1hexsQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -185,6 +563,8 @@
     },
     "node_modules/@eslint-community/regexpp": {
       "version": "4.12.2",
+      "resolved": "https://registry.npmjs.org/@eslint-community/regexpp/-/regexpp-4.12.2.tgz",
+      "integrity": "sha512-EriSTlt5OC9/7SXkRSCAhfSxxoSUgBm33OH+IkwbdpgoqsSsUg7y3uh+IICI/Qg4BBWr3U2i39RpmycbxMq4ew==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -193,6 +573,8 @@
     },
     "node_modules/@eslint/config-array": {
       "version": "0.21.2",
+      "resolved": "https://registry.npmjs.org/@eslint/config-array/-/config-array-0.21.2.tgz",
+      "integrity": "sha512-nJl2KGTlrf9GjLimgIru+V/mzgSK0ABCDQRvxw5BjURL7WfH5uoWmizbH7QB6MmnMBd8cIC9uceWnezL1VZWWw==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -206,11 +588,15 @@
     },
     "node_modules/@eslint/config-array/node_modules/balanced-match": {
       "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/@eslint/config-array/node_modules/brace-expansion": {
       "version": "1.1.15",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.15.tgz",
+      "integrity": "sha512-EwOCDEex4quD37XhqM3omwtMoJjr//isUZz1JopUNWms+4Z2ViyM/k1YIRePpoVNnQhENnxtFjLaxNHrT7xIUg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -220,6 +606,8 @@
     },
     "node_modules/@eslint/config-array/node_modules/minimatch": {
       "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+      "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
       "dev": true,
       "license": "ISC",
       "dependencies": {
@@ -231,6 +619,8 @@
     },
     "node_modules/@eslint/config-helpers": {
       "version": "0.4.2",
+      "resolved": "https://registry.npmjs.org/@eslint/config-helpers/-/config-helpers-0.4.2.tgz",
+      "integrity": "sha512-gBrxN88gOIf3R7ja5K9slwNayVcZgK6SOUORm2uBzTeIEfeVaIhOpCtTox3P6R7o2jLFwLFTLnC7kU/RGcYEgw==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -242,6 +632,8 @@
     },
     "node_modules/@eslint/core": {
       "version": "0.17.0",
+      "resolved": "https://registry.npmjs.org/@eslint/core/-/core-0.17.0.tgz",
+      "integrity": "sha512-yL/sLrpmtDaFEiUj1osRP4TI2MDz1AddJL+jZ7KSqvBuliN4xqYY54IfdN8qD8Toa6g1iloph1fxQNkjOxrrpQ==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -253,6 +645,8 @@
     },
     "node_modules/@eslint/eslintrc": {
       "version": "3.3.5",
+      "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-3.3.5.tgz",
+      "integrity": "sha512-4IlJx0X0qftVsN5E+/vGujTRIFtwuLbNsVUe7TO6zYPDR1O6nFwvwhIKEKSrl6dZchmYBITazxKoUYOjdtjlRg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -275,11 +669,15 @@
     },
     "node_modules/@eslint/eslintrc/node_modules/balanced-match": {
       "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/@eslint/eslintrc/node_modules/brace-expansion": {
       "version": "1.1.15",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.15.tgz",
+      "integrity": "sha512-EwOCDEex4quD37XhqM3omwtMoJjr//isUZz1JopUNWms+4Z2ViyM/k1YIRePpoVNnQhENnxtFjLaxNHrT7xIUg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -289,6 +687,8 @@
     },
     "node_modules/@eslint/eslintrc/node_modules/ignore": {
       "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.2.tgz",
+      "integrity": "sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -297,6 +697,8 @@
     },
     "node_modules/@eslint/eslintrc/node_modules/minimatch": {
       "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+      "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
       "dev": true,
       "license": "ISC",
       "dependencies": {
@@ -308,6 +710,8 @@
     },
     "node_modules/@eslint/js": {
       "version": "9.39.4",
+      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-9.39.4.tgz",
+      "integrity": "sha512-nE7DEIchvtiFTwBw4Lfbu59PG+kCofhjsKaCWzxTpt4lfRjRMqG6uMBzKXuEcyXhOHoUp9riAm7/aWYGhXZ9cw==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -319,6 +723,8 @@
     },
     "node_modules/@eslint/object-schema": {
       "version": "2.1.7",
+      "resolved": "https://registry.npmjs.org/@eslint/object-schema/-/object-schema-2.1.7.tgz",
+      "integrity": "sha512-VtAOaymWVfZcmZbp6E2mympDIHvyjXs/12LqWYjVw6qjrfF+VK+fyG33kChz3nnK+SU5/NeHOqrTEHS8sXO3OA==",
       "dev": true,
       "license": "Apache-2.0",
       "engines": {
@@ -327,6 +733,8 @@
     },
     "node_modules/@eslint/plugin-kit": {
       "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/@eslint/plugin-kit/-/plugin-kit-0.4.1.tgz",
+      "integrity": "sha512-43/qtrDUokr7LJqoF2c3+RInu/t4zfrpYdoSDfYyhg52rwLV6TnOvdG4fXm7IkSB3wErkcmJS9iEhjVtOSEjjA==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -339,6 +747,8 @@
     },
     "node_modules/@humanfs/core": {
       "version": "0.19.2",
+      "resolved": "https://registry.npmjs.org/@humanfs/core/-/core-0.19.2.tgz",
+      "integrity": "sha512-UhXNm+CFMWcbChXywFwkmhqjs3PRCmcSa/hfBgLIb7oQ5HNb1wS0icWsGtSAUNgefHeI+eBrA8I1fxmbHsGdvA==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -350,6 +760,8 @@
     },
     "node_modules/@humanfs/node": {
       "version": "0.16.8",
+      "resolved": "https://registry.npmjs.org/@humanfs/node/-/node-0.16.8.tgz",
+      "integrity": "sha512-gE1eQNZ3R++kTzFUpdGlpmy8kDZD/MLyHqDwqjkVQI0JMdI1D51sy1H958PNXYkM2rAac7e5/CnIKZrHtPh3BQ==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -363,6 +775,8 @@
     },
     "node_modules/@humanfs/types": {
       "version": "0.15.0",
+      "resolved": "https://registry.npmjs.org/@humanfs/types/-/types-0.15.0.tgz",
+      "integrity": "sha512-ZZ1w0aoQkwuUuC7Yf+7sdeaNfqQiiLcSRbfI08oAxqLtpXQr9AIVX7Ay7HLDuiLYAaFPu8oBYNq/QIi9URHJ3Q==",
       "dev": true,
       "license": "Apache-2.0",
       "engines": {
@@ -371,6 +785,8 @@
     },
     "node_modules/@humanwhocodes/module-importer": {
       "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@humanwhocodes/module-importer/-/module-importer-1.0.1.tgz",
+      "integrity": "sha512-bxveV4V8v5Yb4ncFTT3rPSgZBOpCkjfK0y4oVVVJwIuDVBRMDXrPyXRL988i5ap9m9bnyEEjWfm5WkBmtffLfA==",
       "dev": true,
       "license": "Apache-2.0",
       "engines": {
@@ -383,6 +799,8 @@
     },
     "node_modules/@humanwhocodes/retry": {
       "version": "0.4.3",
+      "resolved": "https://registry.npmjs.org/@humanwhocodes/retry/-/retry-0.4.3.tgz",
+      "integrity": "sha512-bV0Tgo9K4hfPCek+aMAn81RppFKv2ySDQeMoSZuvTASywNTnVJCArCZE2FWqpvIatKu7VMRLWlR1EazvVhDyhQ==",
       "dev": true,
       "license": "Apache-2.0",
       "engines": {
@@ -395,11 +813,15 @@
     },
     "node_modules/@jridgewell/sourcemap-codec": {
       "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/@playwright/test": {
       "version": "1.60.0",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.60.0.tgz",
+      "integrity": "sha512-O71yZIbAh/PxDMNGns37GHBIfrVkEVyn+AXyIa5dOTfb4/xNvRWV+Vv/NMbNCtODB/pO7vLlF2OTmMVLhmr7Ag==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -412,8 +834,248 @@
         "node": ">=18"
       }
     },
+    "node_modules/@rollup/rollup-android-arm-eabi": {
+      "version": "4.61.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.61.1.tgz",
+      "integrity": "sha512-JnBB8MdXj45cajvTuO5FmPlvFVJRQgvrz1uSEl3NwqFnReAPGwb8EanbGi4z2nRaqLzjJSv5/JmycoTKlRZxHA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-android-arm64": {
+      "version": "4.61.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.61.1.tgz",
+      "integrity": "sha512-Jx2g7iSjw4AOT0HDPHM9RV3GNjRXwybWtSFZiZAYUTjUwjVrYIwq3kBf+LnhqJlzXFAqTAh2F7IGI+O568exPw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-arm64": {
+      "version": "4.61.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.61.1.tgz",
+      "integrity": "sha512-0F1L/Z3Eqv8mT2n3dCpeO8GcTvHvVqkP5/t6DMsn0KzhYVcg+s7Ncl5DS8qjKYEeio6Az0Gt6nyBORay5qIlCA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-x64": {
+      "version": "4.61.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.61.1.tgz",
+      "integrity": "sha512-qLttcH871ujY4YcVfUSShhOw+CsoTatYz8gRbHO7Bb92QH059/P0y5do1KMs41fY0BpD2x4AJH/gID0zFiqVKQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-arm64": {
+      "version": "4.61.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.61.1.tgz",
+      "integrity": "sha512-fUI4RapGE0Oh3mb8mgfvC1O2nU1RpDZUKnDQm3xB1Ipg7C2wTs5Kstz7G2uWK99a8S2yTMq8/P4uycwNa0nJyw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-x64": {
+      "version": "4.61.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.61.1.tgz",
+      "integrity": "sha512-H5YrdvJaDtI/U9/emrD4b++xkvp3y/JvOe4rizHbxvkyMfRS/CiRYdji+Pl8D0brEaNFWUh1drQxgAGIl6Xudw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
+      "version": "4.61.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.61.1.tgz",
+      "integrity": "sha512-Q8CBCCQtDFrYtXoeUXSrnFXKOnyUhx6bz+SkL6A0E7V8kAiCJ5pamq1WtbfpVGhR5TSpXY6ak3avmDc5fHTyJA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-musleabihf": {
+      "version": "4.61.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.61.1.tgz",
+      "integrity": "sha512-nwnhk1581l0FBVellGcVCAT0Oi06onEA3WB53sf01VO3I0UPBkMH9sXONYME2K0ovXcNayJfNtHfm6mpJElatQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-gnu": {
+      "version": "4.61.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.61.1.tgz",
+      "integrity": "sha512-x5Xr49hwt3hdW75UOZm3395YwwzPyauktslv29KpWL/T+vVAzoT3azLcTWv0eMciBNrx+DYjH4paehHoLpPvpg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-musl": {
+      "version": "4.61.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.61.1.tgz",
+      "integrity": "sha512-unMS3H73DpaoPyyEVPjGKleM/s0mkmsauTENpw4INQY8y4+IuLNjkueQ5QCtC0D3N38Y38yhAU8OoZ20S2Tm6w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-gnu": {
+      "version": "4.61.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.61.1.tgz",
+      "integrity": "sha512-zNZzGRnAhwjFEYmvphJRV5XaQGjs62cCmeYYHUT//NbvEnHauw+I85nGG+SiVg5ld4GX8D1IbKIX+ozITQnhMQ==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-musl": {
+      "version": "4.61.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.61.1.tgz",
+      "integrity": "sha512-LdpWGL8X209B2SIvWjqlc8VZgM6PKfontSerGepuldQmHYrAOtnMCXeJkxXGbC+PPZVOuu5czJo7fNV6aeW8rQ==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-gnu": {
+      "version": "4.61.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.61.1.tgz",
+      "integrity": "sha512-EC5kTtNaNGOmbMGqar8dvJy6y/hg99GAwjfBz++pxZhQATXGcRjd6c5en5wcbru0vkRmiMGsQKdMJOOf6sza4g==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-musl": {
+      "version": "4.61.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.61.1.tgz",
+      "integrity": "sha512-8hiwp6D4acEcNK78I4rP0/XtS1sknWIAMJBPdR4l6zUtyTm5KiTDr5bXmWt4foY7nAN7AThDHgkLIEZOWKbzWw==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-gnu": {
+      "version": "4.61.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.61.1.tgz",
+      "integrity": "sha512-10dh/h/BqA7DuMPWSxkR8uks18FRwnwOEqr5zOTEl+NOwP/OMzKX8OFR/Of9xxDA7D5qef1Nzar5WDD2kCCr1g==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-musl": {
+      "version": "4.61.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.61.1.tgz",
+      "integrity": "sha512-YKJ5lg35DP17gcAOggnihe+APw9HLyj1Xn7gsmGumBJAUDa6NGXNixJzmkWLhcK9TOuuyQjdamzvJefkO7qHZQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-s390x-gnu": {
+      "version": "4.61.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.61.1.tgz",
+      "integrity": "sha512-Mlil5G2Jj6a7B3LWGctg+XPL9vdXYuzCtNXfxOQ0nPjc2m6ueUktocPGH9bnAM0bNRKb/bAWTujUU7IJQdQA+g==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
     "node_modules/@rollup/rollup-linux-x64-gnu": {
-      "version": "4.61.0",
+      "version": "4.61.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.61.1.tgz",
+      "integrity": "sha512-bVWIOIk6pV01p4CdUbPP7CJ/434z+OooYjDuFcR+44N35YvKUC66G8MGnvcWx5mWKW3g61J+t74l3Kj15Kwn2Q==",
       "cpu": [
         "x64"
       ],
@@ -424,8 +1086,108 @@
         "linux"
       ]
     },
+    "node_modules/@rollup/rollup-linux-x64-musl": {
+      "version": "4.61.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.61.1.tgz",
+      "integrity": "sha512-qy5pBvZbqNFheBz61R1rzsezjm0J7O2oNGoWtGoY89SZYLUfxAJTBAqDChqAIdB4rCiIbi9nF7yZ83GnNiLwSw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-openbsd-x64": {
+      "version": "4.61.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.61.1.tgz",
+      "integrity": "sha512-E83TXjI4zm0+5f2qO+UOudaCYIhYwpJ5jq6YCZNIZ+6CbfhKrkAGezeiASBL9ElxAxFsRS9ZhESv8mfnj6TKeg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-openharmony-arm64": {
+      "version": "4.61.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.61.1.tgz",
+      "integrity": "sha512-fbWnKqVkjrJN38vNe3ahkbk6iejS/3b0Nt7EEtPpE6RBacZcGXNKbzfHN3GUUlXOPghUg0j6XUGrtjX9z1sIvA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-arm64-msvc": {
+      "version": "4.61.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.61.1.tgz",
+      "integrity": "sha512-ArMl38iVAbk0New1ogihQNY6iphLi4ZaRsa037gUzv5yeKPY8TD3Dmy4x2RNC1VztU/uqm+G+/RwFrSka3Oy2g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-ia32-msvc": {
+      "version": "4.61.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.61.1.tgz",
+      "integrity": "sha512-0mYtjHS9ucAbcATycCNK9IGBk/cCe/ma7EmSLGZdsxnOA8cjRIyU04wDpVAD9NiOfLUR9KTxdiO53uOkherqjQ==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-gnu": {
+      "version": "4.61.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.61.1.tgz",
+      "integrity": "sha512-gK1iCEPfpoSG9wfBihXxvBMi8ZfcWffYkEsC/Eih+iFENTaewvNcrEQ69lIOWYO5pePHKLHHO7nq5AILGO/HQQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-msvc": {
+      "version": "4.61.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.61.1.tgz",
+      "integrity": "sha512-X+zaP2x+j4RXGfbp/seSoRHWnPxzApilDszisZxbYH5C/jTxFhCtDNdPGZb9lJyYPs24wGxruPF7Y+sIXt9Gzw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
     "node_modules/@supabase/auth-js": {
-      "version": "2.106.2",
+      "version": "2.108.1",
+      "resolved": "https://registry.npmjs.org/@supabase/auth-js/-/auth-js-2.108.1.tgz",
+      "integrity": "sha512-Lle5rKU8f9LF3K5dDd8Or8mkkG+ptzRZZWKPVMm9B9UuovH65Ss2+iFnQqRsCqaGouvJEcTWyl0cj2riNrrDLQ==",
       "license": "MIT",
       "dependencies": {
         "tslib": "2.8.1"
@@ -435,7 +1197,9 @@
       }
     },
     "node_modules/@supabase/functions-js": {
-      "version": "2.106.2",
+      "version": "2.108.1",
+      "resolved": "https://registry.npmjs.org/@supabase/functions-js/-/functions-js-2.108.1.tgz",
+      "integrity": "sha512-fxBRW/A4IG7ADQztVt0NaEy5ysiO1WJ2pbldsnBchrkHuyepX0Krek9qA9T4gUQBVVTCE9Ea4pdsM5hfn3nc4A==",
       "license": "MIT",
       "dependencies": {
         "tslib": "2.8.1"
@@ -446,10 +1210,14 @@
     },
     "node_modules/@supabase/phoenix": {
       "version": "0.4.2",
+      "resolved": "https://registry.npmjs.org/@supabase/phoenix/-/phoenix-0.4.2.tgz",
+      "integrity": "sha512-YSAGnmDAfuleFCVt3CeurQZAhxRfXWeZIIkwp7NhYzQ1UwW6ePSnzsFAiUm/mbCkfoCf70QQHKW/K6RKh52a4A==",
       "license": "MIT"
     },
     "node_modules/@supabase/postgrest-js": {
-      "version": "2.106.2",
+      "version": "2.108.1",
+      "resolved": "https://registry.npmjs.org/@supabase/postgrest-js/-/postgrest-js-2.108.1.tgz",
+      "integrity": "sha512-9lj2MCPPMgSTaJ5y+amnhb3TWPtMFVlbDn2hmX/VV91xQU4j0AauwfMaBErHBJ+zzsSwjc0jLU+zLIZFLQzfig==",
       "license": "MIT",
       "dependencies": {
         "tslib": "2.8.1"
@@ -459,7 +1227,9 @@
       }
     },
     "node_modules/@supabase/realtime-js": {
-      "version": "2.106.2",
+      "version": "2.108.1",
+      "resolved": "https://registry.npmjs.org/@supabase/realtime-js/-/realtime-js-2.108.1.tgz",
+      "integrity": "sha512-mHGGqOjwd1XTydcoffUqEMsbFQHUi6A3uhQ0EXr3iqzpLqItxKA9nbN6gIQxrZ7JRRnuUe/iOFPUkYV9Tdc5lg==",
       "license": "MIT",
       "dependencies": {
         "@supabase/phoenix": "^0.4.2",
@@ -470,7 +1240,9 @@
       }
     },
     "node_modules/@supabase/storage-js": {
-      "version": "2.106.2",
+      "version": "2.108.1",
+      "resolved": "https://registry.npmjs.org/@supabase/storage-js/-/storage-js-2.108.1.tgz",
+      "integrity": "sha512-Er0SGGt85iT6ye+SSh98Az6L2CesoZJuyzEZYH2oBOAnIxa9Nn4CtwUC3veGxYggoT56X+3tVuuQeDBP8kR8sg==",
       "license": "MIT",
       "dependencies": {
         "iceberg-js": "^0.8.1",
@@ -481,14 +1253,16 @@
       }
     },
     "node_modules/@supabase/supabase-js": {
-      "version": "2.106.2",
+      "version": "2.108.1",
+      "resolved": "https://registry.npmjs.org/@supabase/supabase-js/-/supabase-js-2.108.1.tgz",
+      "integrity": "sha512-V/1hRKLSCJ0zEL+9QFRBUtivvePfOsaAYQmC0HhFNSHC2F3xFs4jSF3YhkLmzex6E4V4FGvmBDOP72D/53NnZA==",
       "license": "MIT",
       "dependencies": {
-        "@supabase/auth-js": "2.106.2",
-        "@supabase/functions-js": "2.106.2",
-        "@supabase/postgrest-js": "2.106.2",
-        "@supabase/realtime-js": "2.106.2",
-        "@supabase/storage-js": "2.106.2"
+        "@supabase/auth-js": "2.108.1",
+        "@supabase/functions-js": "2.108.1",
+        "@supabase/postgrest-js": "2.108.1",
+        "@supabase/realtime-js": "2.108.1",
+        "@supabase/storage-js": "2.108.1"
       },
       "engines": {
         "node": ">=20.0.0"
@@ -496,18 +1270,22 @@
     },
     "node_modules/@types/estree": {
       "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.9.tgz",
+      "integrity": "sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/json-schema": {
       "version": "7.0.15",
+      "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz",
+      "integrity": "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/node": {
-      "version": "20.19.41",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.41.tgz",
-      "integrity": "sha512-ECymXOukMnOoVkC2bb1Vc/w/836DXncOg5m8Xj1RH7xSHZJWNYY6Zh7EH477vcnD5egKNNfy2RpNOmuChhFPgQ==",
+      "version": "20.19.42",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.42.tgz",
+      "integrity": "sha512-5L7SUaFC1RyDraj2yRhyBzHTobyXHmohD100CChNtyPyleoq37Mqab5Gn8XEKI04dfN/oqPdpHk38MgcQWHbZg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -515,15 +1293,17 @@
       }
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
-      "version": "8.60.1",
+      "version": "8.61.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.61.0.tgz",
+      "integrity": "sha512-bFNvl9ZczlVb+wR2Akszf3gHfKVj/8WanXaGJ3UstTA7brNKg0cNdk6X1Psu5V7MZ2oQtzZKOEzIUehaoxbDGw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@eslint-community/regexpp": "^4.12.2",
-        "@typescript-eslint/scope-manager": "8.60.1",
-        "@typescript-eslint/type-utils": "8.60.1",
-        "@typescript-eslint/utils": "8.60.1",
-        "@typescript-eslint/visitor-keys": "8.60.1",
+        "@typescript-eslint/scope-manager": "8.61.0",
+        "@typescript-eslint/type-utils": "8.61.0",
+        "@typescript-eslint/utils": "8.61.0",
+        "@typescript-eslint/visitor-keys": "8.61.0",
         "ignore": "^7.0.5",
         "natural-compare": "^1.4.0",
         "ts-api-utils": "^2.5.0"
@@ -536,20 +1316,22 @@
         "url": "https://opencollective.com/typescript-eslint"
       },
       "peerDependencies": {
-        "@typescript-eslint/parser": "^8.60.1",
+        "@typescript-eslint/parser": "^8.61.0",
         "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
         "typescript": ">=4.8.4 <6.1.0"
       }
     },
     "node_modules/@typescript-eslint/parser": {
-      "version": "8.60.1",
+      "version": "8.61.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.61.0.tgz",
+      "integrity": "sha512-5B7PfA2e1NQGCnDHd/0lW7W3gvp3d59Ryw54FYO8Uswxo9f6ikw3AZV+Xj/TvpImmpsiYyUqAfhC6kJID1jF6w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/scope-manager": "8.60.1",
-        "@typescript-eslint/types": "8.60.1",
-        "@typescript-eslint/typescript-estree": "8.60.1",
-        "@typescript-eslint/visitor-keys": "8.60.1",
+        "@typescript-eslint/scope-manager": "8.61.0",
+        "@typescript-eslint/types": "8.61.0",
+        "@typescript-eslint/typescript-estree": "8.61.0",
+        "@typescript-eslint/visitor-keys": "8.61.0",
         "debug": "^4.4.3"
       },
       "engines": {
@@ -565,12 +1347,14 @@
       }
     },
     "node_modules/@typescript-eslint/project-service": {
-      "version": "8.60.1",
+      "version": "8.61.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.61.0.tgz",
+      "integrity": "sha512-DV42F7MLJO6Rax7SK1yg43tcnEfGUrurSpSxKuVX+a3RCTzBlH3fuxprrOJXKCJGAaw82xXocikJ0uQaqwXgGA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/tsconfig-utils": "^8.60.1",
-        "@typescript-eslint/types": "^8.60.1",
+        "@typescript-eslint/tsconfig-utils": "^8.61.0",
+        "@typescript-eslint/types": "^8.61.0",
         "debug": "^4.4.3"
       },
       "engines": {
@@ -585,12 +1369,14 @@
       }
     },
     "node_modules/@typescript-eslint/scope-manager": {
-      "version": "8.60.1",
+      "version": "8.61.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.61.0.tgz",
+      "integrity": "sha512-IWdXFHFSb6mlC3HPc7QsLDm5zYEbUla6trDEHf32D3/dnuUyXd87plScSNXSbm0/RxMvObpI17sv/EDTGrGZkA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/types": "8.60.1",
-        "@typescript-eslint/visitor-keys": "8.60.1"
+        "@typescript-eslint/types": "8.61.0",
+        "@typescript-eslint/visitor-keys": "8.61.0"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -601,7 +1387,9 @@
       }
     },
     "node_modules/@typescript-eslint/tsconfig-utils": {
-      "version": "8.60.1",
+      "version": "8.61.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.61.0.tgz",
+      "integrity": "sha512-O5Amvdv9ztMpxpf+vmFULGG78IE6Qwdr3bCGvqwG4nwc9H2qXkOYJJnRbRHyMkQTjv1d03olqwwwzHLMqpFePQ==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -616,13 +1404,15 @@
       }
     },
     "node_modules/@typescript-eslint/type-utils": {
-      "version": "8.60.1",
+      "version": "8.61.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.61.0.tgz",
+      "integrity": "sha512-TuBiQYIkd97yBfInHCTKVYMbX4kvEmpOEuixIuzCU9p8BGT1SfyyO0d0IfDMbPIHcjn/hWnusUX5e8v5Xg+X8A==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/types": "8.60.1",
-        "@typescript-eslint/typescript-estree": "8.60.1",
-        "@typescript-eslint/utils": "8.60.1",
+        "@typescript-eslint/types": "8.61.0",
+        "@typescript-eslint/typescript-estree": "8.61.0",
+        "@typescript-eslint/utils": "8.61.0",
         "debug": "^4.4.3",
         "ts-api-utils": "^2.5.0"
       },
@@ -639,7 +1429,9 @@
       }
     },
     "node_modules/@typescript-eslint/types": {
-      "version": "8.60.1",
+      "version": "8.61.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.61.0.tgz",
+      "integrity": "sha512-9QTQpZ5Iin4CdIodfbDQFSeiSJKidgYJYug1P9CC2xWgUTvlmixViqDZNciMjwLBZyJnG4tGmPl97rVAFb1AJg==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -651,14 +1443,16 @@
       }
     },
     "node_modules/@typescript-eslint/typescript-estree": {
-      "version": "8.60.1",
+      "version": "8.61.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.61.0.tgz",
+      "integrity": "sha512-42zatd5qSvvcV1JdDBCLxYRznvP4eIHpPoZXdkPFnAmanA4FuZ5dibSnCBggY8hQnqajPpoGjXFdZ7fIJKQnlA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/project-service": "8.60.1",
-        "@typescript-eslint/tsconfig-utils": "8.60.1",
-        "@typescript-eslint/types": "8.60.1",
-        "@typescript-eslint/visitor-keys": "8.60.1",
+        "@typescript-eslint/project-service": "8.61.0",
+        "@typescript-eslint/tsconfig-utils": "8.61.0",
+        "@typescript-eslint/types": "8.61.0",
+        "@typescript-eslint/visitor-keys": "8.61.0",
         "debug": "^4.4.3",
         "minimatch": "^10.2.2",
         "semver": "^7.7.3",
@@ -677,14 +1471,16 @@
       }
     },
     "node_modules/@typescript-eslint/utils": {
-      "version": "8.60.1",
+      "version": "8.61.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.61.0.tgz",
+      "integrity": "sha512-3bzFt7ImFMW/jVYwJamDoe/dMOdFLSC6pom6rRjdh4SZJEYupyMzem8e7vKZLclLfpHjlwSAXOUxtKxGXUiLqA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.9.1",
-        "@typescript-eslint/scope-manager": "8.60.1",
-        "@typescript-eslint/types": "8.60.1",
-        "@typescript-eslint/typescript-estree": "8.60.1"
+        "@typescript-eslint/scope-manager": "8.61.0",
+        "@typescript-eslint/types": "8.61.0",
+        "@typescript-eslint/typescript-estree": "8.61.0"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -699,11 +1495,13 @@
       }
     },
     "node_modules/@typescript-eslint/visitor-keys": {
-      "version": "8.60.1",
+      "version": "8.61.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.61.0.tgz",
+      "integrity": "sha512-QVLZu3ZPQEE+HICQyAMZ2yLQhxf0meY/wx6Hx14YcTNj13JB3qHlX3lJ02L3fLGHgERRH71kvYDwiXIguT3AjQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/types": "8.60.1",
+        "@typescript-eslint/types": "8.61.0",
         "eslint-visitor-keys": "^5.0.0"
       },
       "engines": {
@@ -716,6 +1514,8 @@
     },
     "node_modules/@typescript-eslint/visitor-keys/node_modules/eslint-visitor-keys": {
       "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-5.0.1.tgz",
+      "integrity": "sha512-tD40eHxA35h0PEIZNeIjkHoDR4YjjJp34biM0mDvplBe//mB+IHCqHDGV7pxF+7MklTvighcCPPZC7ynWyjdTA==",
       "dev": true,
       "license": "Apache-2.0",
       "engines": {
@@ -727,6 +1527,8 @@
     },
     "node_modules/@vitest/expect": {
       "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-2.1.9.tgz",
+      "integrity": "sha512-UJCIkTBenHeKT1TTlKMJWy1laZewsRIzYighyYiJKZreqtdxSos/S1t+ktRMQWu2CKqaarrkeszJx1cgC5tGZw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -741,6 +1543,8 @@
     },
     "node_modules/@vitest/mocker": {
       "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-2.1.9.tgz",
+      "integrity": "sha512-tVL6uJgoUdi6icpxmdrn5YNo3g3Dxv+IHJBr0GXHaEdTcw3F+cPKnsXFhli6nO+f/6SDKPHEK1UN+k+TQv0Ehg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -766,6 +1570,8 @@
     },
     "node_modules/@vitest/pretty-format": {
       "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-2.1.9.tgz",
+      "integrity": "sha512-KhRIdGV2U9HOUzxfiHmY8IFHTdqtOhIzCpd8WRdJiE7D/HUcZVD0EgQCVjm+Q9gkUXWgBvMmTtZgIG48wq7sOQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -777,6 +1583,8 @@
     },
     "node_modules/@vitest/runner": {
       "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-2.1.9.tgz",
+      "integrity": "sha512-ZXSSqTFIrzduD63btIfEyOmNcBmQvgOVsPNPe0jYtESiXkhd8u2erDLnMxmGrDCwHCCHE7hxwRDCT3pt0esT4g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -789,6 +1597,8 @@
     },
     "node_modules/@vitest/snapshot": {
       "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-2.1.9.tgz",
+      "integrity": "sha512-oBO82rEjsxLNJincVhLhaxxZdEtV0EFHMK5Kmx5sJ6H9L183dHECjiefOAdnqpIgT5eZwT04PoggUnW88vOBNQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -802,6 +1612,8 @@
     },
     "node_modules/@vitest/spy": {
       "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-2.1.9.tgz",
+      "integrity": "sha512-E1B35FwzXXTs9FHNK6bDszs7mtydNi5MIfUWpceJ8Xbfb1gBMscAnwLbEu+B44ed6W3XjL9/ehLPHR1fkf1KLQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -813,6 +1625,8 @@
     },
     "node_modules/@vitest/utils": {
       "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-2.1.9.tgz",
+      "integrity": "sha512-v0psaMSkNJ3A2NMrUEHFRzJtDPFn+/VWZ5WxImB21T9fjucJRmS7xCS3ppEnARb9y11OAzaD+P2Ps+b+BGX5iQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -826,6 +1640,8 @@
     },
     "node_modules/acorn": {
       "version": "8.16.0",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.16.0.tgz",
+      "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
       "dev": true,
       "license": "MIT",
       "bin": {
@@ -837,6 +1653,8 @@
     },
     "node_modules/acorn-jsx": {
       "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.2.tgz",
+      "integrity": "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==",
       "dev": true,
       "license": "MIT",
       "peerDependencies": {
@@ -855,6 +1673,8 @@
     },
     "node_modules/ajv": {
       "version": "6.15.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.15.0.tgz",
+      "integrity": "sha512-fgFx7Hfoq60ytK2c7DhnF8jIvzYgOMxfugjLOSMHjLIPgenqa7S7oaagATUq99mV6IYvN2tRmC0wnTYX6iPbMw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -870,6 +1690,8 @@
     },
     "node_modules/ansi-styles": {
       "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -884,11 +1706,15 @@
     },
     "node_modules/argparse": {
       "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
       "dev": true,
       "license": "Python-2.0"
     },
     "node_modules/assertion-error": {
       "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -904,6 +1730,8 @@
     },
     "node_modules/balanced-match": {
       "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
+      "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -912,6 +1740,8 @@
     },
     "node_modules/brace-expansion": {
       "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
+      "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -923,6 +1753,8 @@
     },
     "node_modules/cac": {
       "version": "6.7.14",
+      "resolved": "https://registry.npmjs.org/cac/-/cac-6.7.14.tgz",
+      "integrity": "sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -945,6 +1777,8 @@
     },
     "node_modules/callsites": {
       "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
+      "integrity": "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -953,6 +1787,8 @@
     },
     "node_modules/chai": {
       "version": "5.3.3",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-5.3.3.tgz",
+      "integrity": "sha512-4zNhdJD/iOjSH0A05ea+Ke6MU5mmpQcbQsSOkgdaUMJ9zTlDTD/GYlwohmIE2u0gaxHYiVHEn1Fw9mZ/ktJWgw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -968,6 +1804,8 @@
     },
     "node_modules/chalk": {
       "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -983,6 +1821,8 @@
     },
     "node_modules/check-error": {
       "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/check-error/-/check-error-2.1.3.tgz",
+      "integrity": "sha512-PAJdDJusoxnwm1VwW07VWwUN1sl7smmC3OKggvndJFadxxDRyFJBX/ggnu/KE4kQAB7a3Dp8f/YXC1FlUprWmA==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -991,6 +1831,8 @@
     },
     "node_modules/color-convert": {
       "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1002,6 +1844,8 @@
     },
     "node_modules/color-name": {
       "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
       "dev": true,
       "license": "MIT"
     },
@@ -1020,11 +1864,15 @@
     },
     "node_modules/concat-map": {
       "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+      "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/cross-spawn": {
       "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1073,6 +1921,8 @@
     },
     "node_modules/debug": {
       "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1096,6 +1946,8 @@
     },
     "node_modules/deep-eql": {
       "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-5.0.2.tgz",
+      "integrity": "sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -1104,6 +1956,8 @@
     },
     "node_modules/deep-is": {
       "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz",
+      "integrity": "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==",
       "dev": true,
       "license": "MIT"
     },
@@ -1167,6 +2021,8 @@
     },
     "node_modules/es-module-lexer": {
       "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-1.7.0.tgz",
+      "integrity": "sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==",
       "dev": true,
       "license": "MIT"
     },
@@ -1201,6 +2057,8 @@
     },
     "node_modules/esbuild": {
       "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.21.5.tgz",
+      "integrity": "sha512-mg3OPMV4hXywwpoDxu3Qda5xCKQi+vCTZq8S9J/EpkhB2HzKXq4SNFZE3+NK93JYxc8VMSep+lOUSC/RVKaBqw==",
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
@@ -1238,6 +2096,8 @@
     },
     "node_modules/escape-string-regexp": {
       "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
+      "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -1249,6 +2109,8 @@
     },
     "node_modules/eslint": {
       "version": "9.39.4",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-9.39.4.tgz",
+      "integrity": "sha512-XoMjdBOwe/esVgEvLmNsD3IRHkm7fbKIUGvrleloJXUZgDHig2IPWNniv+GwjyJXzuNqVjlr5+4yVUZjycJwfQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1307,6 +2169,8 @@
     },
     "node_modules/eslint-scope": {
       "version": "8.4.0",
+      "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-8.4.0.tgz",
+      "integrity": "sha512-sNXOfKCn74rt8RICKMvJS7XKV/Xk9kA7DyJr8mJik3S7Cwgy3qlkkmyS2uQB3jiJg6VNdZd/pDBJu0nvG2NlTg==",
       "dev": true,
       "license": "BSD-2-Clause",
       "dependencies": {
@@ -1322,6 +2186,8 @@
     },
     "node_modules/eslint-visitor-keys": {
       "version": "3.4.3",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.4.3.tgz",
+      "integrity": "sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag==",
       "dev": true,
       "license": "Apache-2.0",
       "engines": {
@@ -1333,11 +2199,15 @@
     },
     "node_modules/eslint/node_modules/balanced-match": {
       "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/eslint/node_modules/brace-expansion": {
       "version": "1.1.15",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.15.tgz",
+      "integrity": "sha512-EwOCDEex4quD37XhqM3omwtMoJjr//isUZz1JopUNWms+4Z2ViyM/k1YIRePpoVNnQhENnxtFjLaxNHrT7xIUg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1347,6 +2217,8 @@
     },
     "node_modules/eslint/node_modules/eslint-visitor-keys": {
       "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-4.2.1.tgz",
+      "integrity": "sha512-Uhdk5sfqcee/9H/rCOJikYz67o0a2Tw2hGRPOG2Y1R2dg7brRe1uG0yaNQDHu+TO/uQPF/5eCapvYSmHUjt7JQ==",
       "dev": true,
       "license": "Apache-2.0",
       "engines": {
@@ -1358,6 +2230,8 @@
     },
     "node_modules/eslint/node_modules/ignore": {
       "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.2.tgz",
+      "integrity": "sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -1366,6 +2240,8 @@
     },
     "node_modules/eslint/node_modules/minimatch": {
       "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+      "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
       "dev": true,
       "license": "ISC",
       "dependencies": {
@@ -1377,6 +2253,8 @@
     },
     "node_modules/espree": {
       "version": "10.4.0",
+      "resolved": "https://registry.npmjs.org/espree/-/espree-10.4.0.tgz",
+      "integrity": "sha512-j6PAQ2uUr79PZhBjP5C5fhl8e39FmRnOjsD5lGnWrFU8i2G776tBK7+nP8KuQUTTyAZUwfQqXAgrVH5MbH9CYQ==",
       "dev": true,
       "license": "BSD-2-Clause",
       "dependencies": {
@@ -1393,6 +2271,8 @@
     },
     "node_modules/espree/node_modules/eslint-visitor-keys": {
       "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-4.2.1.tgz",
+      "integrity": "sha512-Uhdk5sfqcee/9H/rCOJikYz67o0a2Tw2hGRPOG2Y1R2dg7brRe1uG0yaNQDHu+TO/uQPF/5eCapvYSmHUjt7JQ==",
       "dev": true,
       "license": "Apache-2.0",
       "engines": {
@@ -1404,6 +2284,8 @@
     },
     "node_modules/esquery": {
       "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/esquery/-/esquery-1.7.0.tgz",
+      "integrity": "sha512-Ap6G0WQwcU/LHsvLwON1fAQX9Zp0A2Y6Y/cJBl9r/JbW90Zyg4/zbG6zzKa2OTALELarYHmKu0GhpM5EO+7T0g==",
       "dev": true,
       "license": "BSD-3-Clause",
       "dependencies": {
@@ -1415,6 +2297,8 @@
     },
     "node_modules/esrecurse": {
       "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/esrecurse/-/esrecurse-4.3.0.tgz",
+      "integrity": "sha512-KmfKL3b6G+RXvP8N1vr3Tq1kL/oCFgn2NYXEtqP8/L3pKapUA4G8cFVaoF3SU323CD4XypR/ffioHmkti6/Tag==",
       "dev": true,
       "license": "BSD-2-Clause",
       "dependencies": {
@@ -1426,6 +2310,8 @@
     },
     "node_modules/estraverse": {
       "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
+      "integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
       "dev": true,
       "license": "BSD-2-Clause",
       "engines": {
@@ -1434,6 +2320,8 @@
     },
     "node_modules/estree-walker": {
       "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1442,6 +2330,8 @@
     },
     "node_modules/esutils": {
       "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
+      "integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==",
       "dev": true,
       "license": "BSD-2-Clause",
       "engines": {
@@ -1450,6 +2340,8 @@
     },
     "node_modules/expect-type": {
       "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.3.0.tgz",
+      "integrity": "sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==",
       "dev": true,
       "license": "Apache-2.0",
       "engines": {
@@ -1458,21 +2350,29 @@
     },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/fast-json-stable-stringify": {
       "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
+      "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/fast-levenshtein": {
       "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
+      "integrity": "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/fdir": {
       "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
+      "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -1489,6 +2389,8 @@
     },
     "node_modules/file-entry-cache": {
       "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-8.0.0.tgz",
+      "integrity": "sha512-XXTUwCvisa5oacNGRP9SfNtYBNAMi+RPwBFmblZEF7N7swHYQS6/Zfk7SRwx4D5j3CH211YNRco1DEMNVfZCnQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1500,6 +2402,8 @@
     },
     "node_modules/find-up": {
       "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/find-up/-/find-up-5.0.0.tgz",
+      "integrity": "sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1515,6 +2419,8 @@
     },
     "node_modules/flat-cache": {
       "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-4.0.1.tgz",
+      "integrity": "sha512-f7ccFPK3SXFHpx15UIGyRJ/FJQctuKZ0zVuN3frBo4HnK3cay9VEW0R6yPYFHC0AgqhukPzKjq22t5DmAyqGyw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1527,6 +2433,8 @@
     },
     "node_modules/flatted": {
       "version": "3.4.2",
+      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.4.2.tgz",
+      "integrity": "sha512-PjDse7RzhcPkIJwy5t7KPWQSZ9cAbzQXcafsetQoD7sOJRQlGikNbx7yZp2OotDnJyrDcbyRq3Ttb18iYOqkxA==",
       "dev": true,
       "license": "ISC"
     },
@@ -1545,6 +2453,21 @@
       },
       "engines": {
         "node": ">= 6"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
     "node_modules/function-bind": {
@@ -1598,6 +2521,8 @@
     },
     "node_modules/glob-parent": {
       "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-6.0.2.tgz",
+      "integrity": "sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==",
       "dev": true,
       "license": "ISC",
       "dependencies": {
@@ -1609,6 +2534,8 @@
     },
     "node_modules/globals": {
       "version": "14.0.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-14.0.0.tgz",
+      "integrity": "sha512-oahGvuMGQlPw/ivIYBjVSrWAfWLBeku5tpPE2fOPLi+WHffIWbuh2tCjhyQhTBPMf5E9jDEH4FOmTYgYwbKwtQ==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -1633,6 +2560,8 @@
     },
     "node_modules/has-flag": {
       "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -1724,6 +2653,8 @@
     },
     "node_modules/iceberg-js": {
       "version": "0.8.1",
+      "resolved": "https://registry.npmjs.org/iceberg-js/-/iceberg-js-0.8.1.tgz",
+      "integrity": "sha512-1dhVQZXhcHje7798IVM+xoo/1ZdVfzOMIc8/rgVSijRK38EDqOJoGula9N/8ZI5RD8QTxNQtK/Gozpr+qUqRRA==",
       "license": "MIT",
       "engines": {
         "node": ">=20.0.0"
@@ -1744,6 +2675,8 @@
     },
     "node_modules/ignore": {
       "version": "7.0.5",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-7.0.5.tgz",
+      "integrity": "sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -1752,6 +2685,8 @@
     },
     "node_modules/import-fresh": {
       "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.1.tgz",
+      "integrity": "sha512-TR3KfrTZTYLPB6jUjfx6MF9WcWrHL9su5TObK4ZkYgBdWKPOFoSoQIdEuTuR82pmtxH2spWG9h6etwfr1pLBqQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1767,6 +2702,8 @@
     },
     "node_modules/imurmurhash": {
       "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
+      "integrity": "sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -1775,6 +2712,8 @@
     },
     "node_modules/is-extglob": {
       "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
+      "integrity": "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -1783,6 +2722,8 @@
     },
     "node_modules/is-glob": {
       "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
+      "integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1801,11 +2742,15 @@
     },
     "node_modules/isexe": {
       "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
       "dev": true,
       "license": "ISC"
     },
     "node_modules/js-yaml": {
       "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.2.0.tgz",
+      "integrity": "sha512-ePWsvanv0DWuDRsW8dnt+R4jQ31SCRCQ7hhNcPXZPsoBZiemuZNYGf7adZdqX2D86j6rvKp3RpCxVTSb8WQlOw==",
       "dev": true,
       "funding": [
         {
@@ -1868,21 +2813,29 @@
     },
     "node_modules/json-buffer": {
       "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/json-buffer/-/json-buffer-3.0.1.tgz",
+      "integrity": "sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/json-schema-traverse": {
       "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/json-stable-stringify-without-jsonify": {
       "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
+      "integrity": "sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/keyv": {
       "version": "4.5.4",
+      "resolved": "https://registry.npmjs.org/keyv/-/keyv-4.5.4.tgz",
+      "integrity": "sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1891,6 +2844,8 @@
     },
     "node_modules/levn": {
       "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/levn/-/levn-0.4.1.tgz",
+      "integrity": "sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1903,6 +2858,8 @@
     },
     "node_modules/locate-path": {
       "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz",
+      "integrity": "sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1917,11 +2874,15 @@
     },
     "node_modules/lodash.merge": {
       "version": "4.6.2",
+      "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
+      "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/loupe": {
       "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/loupe/-/loupe-3.2.1.tgz",
+      "integrity": "sha512-CdzqowRJCeLU72bHvWqwRBBlLcMEtIvGrlvef74kMnV2AolS9Y8xUv1I0U/MNAWMhBlKIoyuEgoJ0t/bbwHbLQ==",
       "dev": true,
       "license": "MIT"
     },
@@ -1934,6 +2895,8 @@
     },
     "node_modules/magic-string": {
       "version": "0.30.21",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+      "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1975,6 +2938,8 @@
     },
     "node_modules/minimatch": {
       "version": "10.2.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.5.tgz",
+      "integrity": "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==",
       "dev": true,
       "license": "BlueOak-1.0.0",
       "dependencies": {
@@ -1989,11 +2954,15 @@
     },
     "node_modules/ms": {
       "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/nanoid": {
       "version": "3.3.12",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.12.tgz",
+      "integrity": "sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ==",
       "dev": true,
       "funding": [
         {
@@ -2011,18 +2980,22 @@
     },
     "node_modules/natural-compare": {
       "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
+      "integrity": "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/nwsapi": {
-      "version": "2.2.23",
-      "resolved": "https://registry.npmjs.org/nwsapi/-/nwsapi-2.2.23.tgz",
-      "integrity": "sha512-7wfH4sLbt4M0gCDzGE6vzQBo0bfTKjU7Sfpqy/7gs1qBfYz2vEJH6vXcBKpO3+6Yu1telwd0t9HpyOoLEQQbIQ==",
+      "version": "2.2.24",
+      "resolved": "https://registry.npmjs.org/nwsapi/-/nwsapi-2.2.24.tgz",
+      "integrity": "sha512-7YRhZ3jS45LwmSCT4b2sVFHt/WuovaktDU07QrtOBY2PXskss5a9jfmR9jptyumwXST+rFjrmppMY1KT/yn35A==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/optionator": {
       "version": "0.9.4",
+      "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.9.4.tgz",
+      "integrity": "sha512-6IpQ7mKUxRcZNLIObR0hz7lxsapSSIYNZJwXPGeF0mTVqGKFIXj1DQcMoT22S3ROcLyY/rz0PWaWZ9ayWmad9g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2039,6 +3012,8 @@
     },
     "node_modules/p-limit": {
       "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
+      "integrity": "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2053,6 +3028,8 @@
     },
     "node_modules/p-locate": {
       "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-5.0.0.tgz",
+      "integrity": "sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2067,6 +3044,8 @@
     },
     "node_modules/parent-module": {
       "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
+      "integrity": "sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2091,6 +3070,8 @@
     },
     "node_modules/path-exists": {
       "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
+      "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -2099,6 +3080,8 @@
     },
     "node_modules/path-key": {
       "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+      "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -2107,11 +3090,15 @@
     },
     "node_modules/pathe": {
       "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-1.1.2.tgz",
+      "integrity": "sha512-whLdWMYL2TwI08hn8/ZqAbrVemu0LNaNNJZX73O6qaIdCTfXutsLhMkjdENX0qhsQ9uIimo4/aQOmXkoon2nDQ==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/pathval": {
       "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/pathval/-/pathval-2.0.1.tgz",
+      "integrity": "sha512-//nshmD55c46FuFw26xV/xFAaB5HF9Xdap7HJBBnrKdAd6/GxDBaNA1870O79+9ueg61cZLSVc+OaFlfmObYVQ==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -2120,11 +3107,15 @@
     },
     "node_modules/picocolors": {
       "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
       "dev": true,
       "license": "ISC"
     },
     "node_modules/picomatch": {
       "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -2136,6 +3127,8 @@
     },
     "node_modules/playwright": {
       "version": "1.60.0",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.60.0.tgz",
+      "integrity": "sha512-hheHdokM8cdqCb0lcE3s+zT4t4W+vvjpGxsZlDnikarzx8tSzMebh3UiFtgqwFwnTnjYQcsyMF8ei2mCO/tpeA==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -2153,6 +3146,8 @@
     },
     "node_modules/playwright-core": {
       "version": "1.60.0",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.60.0.tgz",
+      "integrity": "sha512-9bW6zvX/m0lEbgTKJ6YppOKx8H3VOPBMOCFh2irXFOT4BbHgrx5hPjwJYLT40Lu+4qtD36qKc/Hn56StUW57IA==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {
@@ -2164,6 +3159,8 @@
     },
     "node_modules/postcss": {
       "version": "8.5.15",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.15.tgz",
+      "integrity": "sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A==",
       "dev": true,
       "funding": [
         {
@@ -2191,6 +3188,8 @@
     },
     "node_modules/prelude-ls": {
       "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
+      "integrity": "sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -2199,6 +3198,8 @@
     },
     "node_modules/punycode": {
       "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
+      "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -2207,6 +3208,8 @@
     },
     "node_modules/resolve-from": {
       "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
+      "integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -2214,7 +3217,9 @@
       }
     },
     "node_modules/rollup": {
-      "version": "4.61.0",
+      "version": "4.61.1",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.61.1.tgz",
+      "integrity": "sha512-I4KW6iuRpuu2uHBLraZ1wNZe0DP7lnRha+VJ9tNaYVaVgKhW0aI3h4RYnoRPeql0flHm/Co55b7snEDcOfOJrA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2228,31 +3233,31 @@
         "npm": ">=8.0.0"
       },
       "optionalDependencies": {
-        "@rollup/rollup-android-arm-eabi": "4.61.0",
-        "@rollup/rollup-android-arm64": "4.61.0",
-        "@rollup/rollup-darwin-arm64": "4.61.0",
-        "@rollup/rollup-darwin-x64": "4.61.0",
-        "@rollup/rollup-freebsd-arm64": "4.61.0",
-        "@rollup/rollup-freebsd-x64": "4.61.0",
-        "@rollup/rollup-linux-arm-gnueabihf": "4.61.0",
-        "@rollup/rollup-linux-arm-musleabihf": "4.61.0",
-        "@rollup/rollup-linux-arm64-gnu": "4.61.0",
-        "@rollup/rollup-linux-arm64-musl": "4.61.0",
-        "@rollup/rollup-linux-loong64-gnu": "4.61.0",
-        "@rollup/rollup-linux-loong64-musl": "4.61.0",
-        "@rollup/rollup-linux-ppc64-gnu": "4.61.0",
-        "@rollup/rollup-linux-ppc64-musl": "4.61.0",
-        "@rollup/rollup-linux-riscv64-gnu": "4.61.0",
-        "@rollup/rollup-linux-riscv64-musl": "4.61.0",
-        "@rollup/rollup-linux-s390x-gnu": "4.61.0",
-        "@rollup/rollup-linux-x64-gnu": "4.61.0",
-        "@rollup/rollup-linux-x64-musl": "4.61.0",
-        "@rollup/rollup-openbsd-x64": "4.61.0",
-        "@rollup/rollup-openharmony-arm64": "4.61.0",
-        "@rollup/rollup-win32-arm64-msvc": "4.61.0",
-        "@rollup/rollup-win32-ia32-msvc": "4.61.0",
-        "@rollup/rollup-win32-x64-gnu": "4.61.0",
-        "@rollup/rollup-win32-x64-msvc": "4.61.0",
+        "@rollup/rollup-android-arm-eabi": "4.61.1",
+        "@rollup/rollup-android-arm64": "4.61.1",
+        "@rollup/rollup-darwin-arm64": "4.61.1",
+        "@rollup/rollup-darwin-x64": "4.61.1",
+        "@rollup/rollup-freebsd-arm64": "4.61.1",
+        "@rollup/rollup-freebsd-x64": "4.61.1",
+        "@rollup/rollup-linux-arm-gnueabihf": "4.61.1",
+        "@rollup/rollup-linux-arm-musleabihf": "4.61.1",
+        "@rollup/rollup-linux-arm64-gnu": "4.61.1",
+        "@rollup/rollup-linux-arm64-musl": "4.61.1",
+        "@rollup/rollup-linux-loong64-gnu": "4.61.1",
+        "@rollup/rollup-linux-loong64-musl": "4.61.1",
+        "@rollup/rollup-linux-ppc64-gnu": "4.61.1",
+        "@rollup/rollup-linux-ppc64-musl": "4.61.1",
+        "@rollup/rollup-linux-riscv64-gnu": "4.61.1",
+        "@rollup/rollup-linux-riscv64-musl": "4.61.1",
+        "@rollup/rollup-linux-s390x-gnu": "4.61.1",
+        "@rollup/rollup-linux-x64-gnu": "4.61.1",
+        "@rollup/rollup-linux-x64-musl": "4.61.1",
+        "@rollup/rollup-openbsd-x64": "4.61.1",
+        "@rollup/rollup-openharmony-arm64": "4.61.1",
+        "@rollup/rollup-win32-arm64-msvc": "4.61.1",
+        "@rollup/rollup-win32-ia32-msvc": "4.61.1",
+        "@rollup/rollup-win32-x64-gnu": "4.61.1",
+        "@rollup/rollup-win32-x64-msvc": "4.61.1",
         "fsevents": "~2.3.2"
       }
     },
@@ -2284,7 +3289,9 @@
       }
     },
     "node_modules/semver": {
-      "version": "7.8.1",
+      "version": "7.8.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.4.tgz",
+      "integrity": "sha512-rUCObTnP32Q08R2uuIrt7r9PlEonuTmtuXYcW6s5kjdlj3xbnwe+21yXptAUYcMAABLkYYTtnmzb3w3EDZfueA==",
       "dev": true,
       "license": "ISC",
       "bin": {
@@ -2296,6 +3303,8 @@
     },
     "node_modules/shebang-command": {
       "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+      "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2307,6 +3316,8 @@
     },
     "node_modules/shebang-regex": {
       "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+      "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -2315,11 +3326,15 @@
     },
     "node_modules/siginfo": {
       "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
       "dev": true,
       "license": "ISC"
     },
     "node_modules/source-map-js": {
       "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+      "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
       "dev": true,
       "license": "BSD-3-Clause",
       "engines": {
@@ -2328,16 +3343,22 @@
     },
     "node_modules/stackback": {
       "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/std-env": {
       "version": "3.10.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-3.10.0.tgz",
+      "integrity": "sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/strip-json-comments": {
       "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
+      "integrity": "sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -2349,6 +3370,8 @@
     },
     "node_modules/supports-color": {
       "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2367,16 +3390,22 @@
     },
     "node_modules/tinybench": {
       "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/tinyexec": {
       "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-0.3.2.tgz",
+      "integrity": "sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/tinyglobby": {
       "version": "0.2.17",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.17.tgz",
+      "integrity": "sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2392,6 +3421,8 @@
     },
     "node_modules/tinypool": {
       "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/tinypool/-/tinypool-1.1.1.tgz",
+      "integrity": "sha512-Zba82s87IFq9A9XmjiX5uZA/ARWDrB03OHlq+Vw1fSdt0I+4/Kutwy8BP4Y/y/aORMo61FQ0vIb5j44vSo5Pkg==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -2400,6 +3431,8 @@
     },
     "node_modules/tinyrainbow": {
       "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-1.2.0.tgz",
+      "integrity": "sha512-weEDEq7Z5eTHPDh4xjX789+fHfF+P8boiFB+0vbWzpbnbsEr/GRaohi/uMKxg8RZMXnl1ItAi/IUHWMsjDV7kQ==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -2408,6 +3441,8 @@
     },
     "node_modules/tinyspy": {
       "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/tinyspy/-/tinyspy-3.0.2.tgz",
+      "integrity": "sha512-n1cw8k1k0x4pgA2+9XrOkFydTerNcJ1zWCO5Nn9scWHTD+5tp8dghT2x1uduQePZTZgd3Tupf+x9BxJjeJi77Q==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -2462,6 +3497,8 @@
     },
     "node_modules/ts-api-utils": {
       "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-2.5.0.tgz",
+      "integrity": "sha512-OJ/ibxhPlqrMM0UiNHJ/0CKQkoKF243/AEmplt3qpRgkW8VG7IfOS41h7V8TjITqdByHzrjcS/2si+y4lIh8NA==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -2473,10 +3510,14 @@
     },
     "node_modules/tslib": {
       "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
       "license": "0BSD"
     },
     "node_modules/type-check": {
       "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.4.0.tgz",
+      "integrity": "sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2488,6 +3529,8 @@
     },
     "node_modules/typescript": {
       "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {
@@ -2507,6 +3550,8 @@
     },
     "node_modules/uri-js": {
       "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
+      "integrity": "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==",
       "dev": true,
       "license": "BSD-2-Clause",
       "dependencies": {
@@ -2515,6 +3560,8 @@
     },
     "node_modules/vite": {
       "version": "5.4.21",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-5.4.21.tgz",
+      "integrity": "sha512-o5a9xKjbtuhY6Bi5S3+HvbRERmouabWbyUcpXXUA1u+GNUKoROi9byOJ8M0nHbHYHkYICiMlqxkg1KkYmm25Sw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2573,6 +3620,8 @@
     },
     "node_modules/vite-node": {
       "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/vite-node/-/vite-node-2.1.9.tgz",
+      "integrity": "sha512-AM9aQ/IPrW/6ENLQg3AGY4K1N2TGZdR5e4gu/MmmR2xR3Ll1+dib+nook92g4TV3PXVyeyxdWwtaCAiUL0hMxA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2592,8 +3641,25 @@
         "url": "https://opencollective.com/vitest"
       }
     },
+    "node_modules/vite/node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
     "node_modules/vitest": {
       "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-2.1.9.tgz",
+      "integrity": "sha512-MSmPM9REYqDGBI8439mA4mWhV5sKmDlBKWIYbA3lRb2PTHACE0mgKwA8yQ2xq9vxDTuk4iPrECBAEW2aoFXY0Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2719,6 +3785,8 @@
     },
     "node_modules/which": {
       "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+      "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
       "dev": true,
       "license": "ISC",
       "dependencies": {
@@ -2733,6 +3801,8 @@
     },
     "node_modules/why-is-node-running": {
       "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2748,6 +3818,8 @@
     },
     "node_modules/word-wrap": {
       "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.5.tgz",
+      "integrity": "sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -2795,6 +3867,8 @@
     },
     "node_modules/yocto-queue": {
       "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
+      "integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==",
       "dev": true,
       "license": "MIT",
       "engines": {

--- a/web/src/lib/query.ts
+++ b/web/src/lib/query.ts
@@ -9,7 +9,7 @@ export interface QuerySpec {
 }
 
 const DIGEST_COLUMNS =
-  "id, topic_slug, content, cadence, digest_date, sources_used, token_count, prompt_version, created_at";
+  "id, topic_slug, content, summary, items, cadence, digest_date, sources_used, token_count, prompt_version, created_at";
 const TOPIC_COLUMNS = "id, name, slug, cadence, enabled";
 
 export function digestsQuery(opts: { limit?: number } = {}): QuerySpec {

--- a/web/src/lib/types.ts
+++ b/web/src/lib/types.ts
@@ -1,5 +1,22 @@
 // Shared data shapes. Mirrors the Supabase schema (docs/architecture.md §3.1).
 
+/** One source reference attached to a digest item. */
+export interface DigestItemSource {
+  title: string;
+  url: string;
+}
+
+/** One ranked item in a structured digest (issue #58). */
+export interface DigestItem {
+  headline: string;
+  blurb: string;
+  detail: string;
+  metadata?: {
+    sources?: DigestItemSource[];
+    tags?: string[];
+  };
+}
+
 export interface Digest {
   id: string;
   topic_slug: string;
@@ -10,6 +27,10 @@ export interface Digest {
   token_count: number | null;
   prompt_version: string;
   created_at: string;
+  /** Short top-level overview; null on pre-#58 rows. */
+  summary: string | null;
+  /** Ranked structured items; null on pre-#58 rows. */
+  items: DigestItem[] | null;
 }
 
 export interface Topic {

--- a/web/src/pages/history.ts
+++ b/web/src/pages/history.ts
@@ -175,6 +175,8 @@ export function generateFixtureDigests(count: number): Digest[] {
       token_count: 80 + (i % 50),
       prompt_version: "fixture",
       created_at: `${digestDate}T00:00:00Z`,
+      summary: null,
+      items: null,
     });
   }
   return out;

--- a/web/src/views/digest-card.ts
+++ b/web/src/views/digest-card.ts
@@ -1,4 +1,4 @@
-import type { Digest } from "../lib/types";
+import type { Digest, DigestItem } from "../lib/types";
 
 // Renders a single digest. Includes an explicit, documented mount point for
 // playback controls.
@@ -7,6 +7,10 @@ import type { Digest } from "../lib/types";
 // editing this file's core: it provides a `mountPlaybackControls` hook that this
 // renderer invokes against the slot. The slot carries `data-digest-id` so #11 can
 // wire per-digest playback.
+//
+// Rendering modes (issue #58):
+//   Structured: digest.items?.length > 0  →  summary + one <details> per item
+//   Fallback:   items null/empty           →  <p class="digest-body"> from content
 
 export type MountPlaybackControls = (slotEl: HTMLElement, digest: Digest) => void;
 
@@ -17,21 +21,115 @@ export function registerPlaybackControls(fn: MountPlaybackControls): void {
   playbackMounter = fn;
 }
 
+/**
+ * Guard a URL to allow only http(s) schemes.
+ *
+ * Returns the URL string unchanged when it starts with http:// or https://.
+ * Returns null for javascript:, data:, or any other scheme — these must never
+ * appear as an href value (LLM-generated source URLs could carry injected schemes).
+ */
+function safeHref(url: string): string | null {
+  if (url.startsWith("https://") || url.startsWith("http://")) {
+    return url;
+  }
+  return null;
+}
+
+function renderStructured(card: HTMLElement, digest: Digest): void {
+  const items = digest.items!;
+
+  if (digest.summary) {
+    const summaryEl = document.createElement("p");
+    summaryEl.className = "digest-summary";
+    summaryEl.textContent = digest.summary;
+    card.appendChild(summaryEl);
+  }
+
+  for (const item of items) {
+    card.appendChild(renderItem(item));
+  }
+}
+
+function renderItem(item: DigestItem): HTMLElement {
+  const details = document.createElement("details");
+  details.className = "digest-item";
+
+  const summaryEl = document.createElement("summary");
+  // Headline and blurb go in the collapsed header.
+  const headlineSpan = document.createElement("span");
+  headlineSpan.className = "item-headline";
+  headlineSpan.textContent = item.headline;
+  summaryEl.appendChild(headlineSpan);
+
+  if (item.blurb) {
+    const blurbSpan = document.createElement("span");
+    blurbSpan.className = "item-blurb";
+    blurbSpan.textContent = item.blurb;
+    summaryEl.appendChild(blurbSpan);
+  }
+  details.appendChild(summaryEl);
+
+  // Expanded body: detail prose.
+  if (item.detail) {
+    const detailEl = document.createElement("p");
+    detailEl.className = "item-detail";
+    detailEl.textContent = item.detail;
+    details.appendChild(detailEl);
+  }
+
+  // Source links — only http(s) URLs are emitted as anchors.
+  const sources = item.metadata?.sources ?? [];
+  if (sources.length > 0) {
+    const sourcesList = document.createElement("ul");
+    sourcesList.className = "item-sources";
+    for (const src of sources) {
+      const href = safeHref(src.url);
+      const li = document.createElement("li");
+      if (href !== null) {
+        const a = document.createElement("a");
+        a.className = "source-link";
+        a.href = href;
+        a.target = "_blank";
+        a.rel = "noopener noreferrer";
+        a.textContent = src.title;
+        li.appendChild(a);
+      } else {
+        // Non-http(s) URL: render as plain text to avoid dropping the source name.
+        li.textContent = src.title;
+      }
+      sourcesList.appendChild(li);
+    }
+    details.appendChild(sourcesList);
+  }
+
+  return details;
+}
+
+function renderFallback(card: HTMLElement, digest: Digest): void {
+  const body = document.createElement("p");
+  body.className = "digest-body";
+  body.textContent = digest.content;
+  card.appendChild(body);
+}
+
 export function renderDigestCard(digest: Digest): HTMLElement {
   const card = document.createElement("article");
   card.className = "digest-card";
   card.setAttribute("data-digest-id", digest.id);
 
-  // #11 mounts TTS controls into .playback-slot
+  // #11 mounts TTS controls into .playback-slot — always present regardless of
+  // rendering mode. TTS reads digest.content (flat prose), never the structured fields.
   const slot = document.createElement("div");
   slot.className = "playback-slot";
   slot.setAttribute("data-digest-id", digest.id);
   card.appendChild(slot);
 
-  const body = document.createElement("p");
-  body.className = "digest-body";
-  body.textContent = digest.content;
-  card.appendChild(body);
+  const hasStructuredItems = (digest.items?.length ?? 0) > 0;
+  if (hasStructuredItems) {
+    renderStructured(card, digest);
+  } else {
+    renderFallback(card, digest);
+  }
 
   if (playbackMounter) {
     playbackMounter(slot, digest);

--- a/web/tests/e2e/digest-render.spec.ts
+++ b/web/tests/e2e/digest-render.spec.ts
@@ -37,4 +37,67 @@ test.describe("digest render (live authenticated reads)", () => {
     const sortedDesc = [...firstGroupDates].sort().reverse();
     expect(firstGroupDates).toEqual(sortedDesc);
   });
+
+  // AC: structured digests render summary + expandable items; legacy cards fall back.
+  test("structured digest cards show summary and expandable items", async ({ page }) => {
+    await page.goto("/");
+    await expect(page.locator(".digest-card").first()).toBeVisible({ timeout: 15_000 });
+
+    // Tolerate data: some cards may be pre-#58 (content only), some structured.
+    // For each card, assert it shows either a structured layout or a fallback body —
+    // never neither.
+    const cards = page.locator(".digest-card");
+    const count = await cards.count();
+    for (let i = 0; i < Math.min(count, 5); i++) {
+      const card = cards.nth(i);
+      const hasStructured = (await card.locator("details.digest-item").count()) > 0;
+      const hasFallback = (await card.locator("p.digest-body").count()) > 0;
+      // At least one rendering mode must be present.
+      expect(hasStructured || hasFallback).toBe(true);
+    }
+  });
+
+  // AC: structured items are <details> elements that can be expanded.
+  test("structured digest items are expandable <details> elements", async ({ page }) => {
+    await page.goto("/");
+    await expect(page.locator(".digest-card").first()).toBeVisible({ timeout: 15_000 });
+
+    const firstStructured = page.locator("details.digest-item").first();
+    // Only assert if structured cards exist on the page — graceful when data is all legacy.
+    const hasStructured = (await firstStructured.count()) > 0;
+    if (!hasStructured) {
+      test.info().annotations.push({
+        type: "skip-reason",
+        description: "No structured digest cards found (all rows are pre-#58 content-only)",
+      });
+      return;
+    }
+
+    // The item should be a <details> that can be opened.
+    await expect(firstStructured).toBeVisible();
+    const tagName = await firstStructured.evaluate((el) => el.tagName.toLowerCase());
+    expect(tagName).toBe("details");
+
+    // Clicking the <summary> opens the item.
+    const summaryEl = firstStructured.locator("summary").first();
+    await summaryEl.click();
+    await expect(firstStructured).toHaveAttribute("open", "");
+  });
+
+  // AC: legacy (pre-#58) content-only cards still show their body text.
+  test("legacy content-only digest cards still render body text", async ({ page }) => {
+    await page.goto("/");
+    await expect(page.locator(".digest-card").first()).toBeVisible({ timeout: 15_000 });
+
+    // Find any card with a p.digest-body (fallback). If structured rows dominate,
+    // there may be none — that's fine; the test is a no-op rather than a false failure.
+    const fallbackCards = page.locator("p.digest-body");
+    const count = await fallbackCards.count();
+    if (count === 0) return;
+
+    for (let i = 0; i < Math.min(count, 3); i++) {
+      const text = await fallbackCards.nth(i).textContent();
+      expect((text ?? "").trim().length).toBeGreaterThan(0);
+    }
+  });
 });

--- a/web/tests/unit/digest-card.test.ts
+++ b/web/tests/unit/digest-card.test.ts
@@ -1,0 +1,207 @@
+// @vitest-environment jsdom
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { renderDigestCard } from "../../src/views/digest-card";
+import type { Digest, DigestItem } from "../../src/lib/types";
+
+function makeDigest(partial: Partial<Digest>): Digest {
+  return {
+    id: "test-id-1",
+    topic_slug: "ai_models",
+    content: "Fallback plain content for TTS.",
+    cadence: "24h",
+    digest_date: "2026-06-10",
+    sources_used: [],
+    token_count: 100,
+    prompt_version: "sp-abc123",
+    created_at: "2026-06-10T12:00:00Z",
+    summary: null,
+    items: null,
+    ...partial,
+  };
+}
+
+const sampleItems: DigestItem[] = [
+  {
+    headline: "AI Corp ships Model X",
+    blurb: "A new frontier model. Beats previous baselines on key benchmarks.",
+    detail: "Scores 95 on MMLU. The team trained for six months with new techniques.",
+    metadata: {
+      sources: [
+        { title: "AI Blog", url: "https://example.com/blog" },
+        { title: "GitHub", url: "https://github.com/org/repo" },
+      ],
+      tags: ["ai", "models"],
+    },
+  },
+  {
+    headline: "Open Source rival emerges",
+    blurb: "A new open-source model matches commercial offerings.",
+    detail: "Released under Apache 2. Fine-tuning kits ship next week.",
+    metadata: {
+      sources: [{ title: "HN Discussion", url: "https://news.ycombinator.com/item?id=1" }],
+    },
+  },
+];
+
+beforeEach(() => {
+  document.body.innerHTML = "";
+});
+
+afterEach(() => {
+  document.body.innerHTML = "";
+});
+
+// ---------------------------------------------------------------------------
+// Structured digest rendering
+// ---------------------------------------------------------------------------
+
+describe("renderDigestCard — structured digest (items present)", () => {
+  it("renders the top-level summary", () => {
+    const digest = makeDigest({ summary: "Top news today.", items: sampleItems });
+    const card = renderDigestCard(digest);
+    document.body.appendChild(card);
+    const summary = card.querySelector(".digest-summary");
+    expect(summary).not.toBeNull();
+    expect(summary!.textContent).toContain("Top news today.");
+  });
+
+  it("renders one <details> per item", () => {
+    const digest = makeDigest({ summary: "Summary.", items: sampleItems });
+    const card = renderDigestCard(digest);
+    document.body.appendChild(card);
+    const details = card.querySelectorAll("details.digest-item");
+    expect(details.length).toBe(sampleItems.length);
+  });
+
+  it("renders headline and blurb in the <summary> element", () => {
+    const digest = makeDigest({ summary: "S.", items: sampleItems });
+    const card = renderDigestCard(digest);
+    document.body.appendChild(card);
+    const firstDetails = card.querySelector("details.digest-item");
+    const sumEl = firstDetails?.querySelector("summary");
+    expect(sumEl?.textContent).toContain("AI Corp ships Model X");
+    expect(sumEl?.textContent).toContain("Beats previous baselines");
+  });
+
+  it("renders detail text in the expanded body", () => {
+    const digest = makeDigest({ summary: "S.", items: sampleItems });
+    const card = renderDigestCard(digest);
+    document.body.appendChild(card);
+    const firstDetails = card.querySelector("details.digest-item");
+    const detail = firstDetails?.querySelector(".item-detail");
+    expect(detail?.textContent).toContain("Scores 95 on MMLU");
+  });
+
+  it("renders source links with correct href from metadata.sources", () => {
+    const digest = makeDigest({ summary: "S.", items: sampleItems });
+    const card = renderDigestCard(digest);
+    document.body.appendChild(card);
+    const links = card.querySelectorAll<HTMLAnchorElement>("a.source-link");
+    const hrefs = Array.from(links).map((a) => a.href);
+    expect(hrefs).toContain("https://example.com/blog");
+    expect(hrefs).toContain("https://github.com/org/repo");
+    expect(hrefs).toContain("https://news.ycombinator.com/item?id=1");
+  });
+
+  it("does not render the content-only fallback <p> when items are present", () => {
+    const digest = makeDigest({ summary: "S.", items: sampleItems });
+    const card = renderDigestCard(digest);
+    document.body.appendChild(card);
+    const fallback = card.querySelector("p.digest-body");
+    expect(fallback).toBeNull();
+  });
+
+  // XSS guard: javascript: and data: URLs must not appear as href
+  it("does not emit javascript: URLs as href (XSS guard)", () => {
+    const xssItem: DigestItem = {
+      headline: "Malicious",
+      blurb: "Injected source.",
+      detail: "Details.",
+      metadata: {
+        sources: [
+          { title: "Evil", url: "javascript:alert('xss')" },
+          { title: "Good", url: "https://safe.example.com" },
+        ],
+      },
+    };
+    const digest = makeDigest({ summary: "S.", items: [xssItem] });
+    const card = renderDigestCard(digest);
+    document.body.appendChild(card);
+    const links = card.querySelectorAll<HTMLAnchorElement>("a.source-link");
+    const hrefs = Array.from(links).map((a) => a.getAttribute("href"));
+    expect(hrefs.some((h) => h?.startsWith("javascript:"))).toBe(false);
+    // the safe link is still rendered
+    expect(hrefs).toContain("https://safe.example.com");
+  });
+
+  it("does not emit data: URLs as href (XSS guard)", () => {
+    const xssItem: DigestItem = {
+      headline: "Data URI",
+      blurb: "Data URL test.",
+      detail: "Details.",
+      metadata: {
+        sources: [{ title: "Data", url: "data:text/html,<script>bad()</script>" }],
+      },
+    };
+    const digest = makeDigest({ summary: "S.", items: [xssItem] });
+    const card = renderDigestCard(digest);
+    document.body.appendChild(card);
+    const links = card.querySelectorAll<HTMLAnchorElement>("a.source-link");
+    const hrefs = Array.from(links).map((a) => a.getAttribute("href"));
+    expect(hrefs.some((h) => h?.startsWith("data:"))).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Fallback rendering (items null/empty)
+// ---------------------------------------------------------------------------
+
+describe("renderDigestCard — content-only fallback", () => {
+  it("renders <p class=digest-body> when items is null", () => {
+    const digest = makeDigest({ items: null });
+    const card = renderDigestCard(digest);
+    document.body.appendChild(card);
+    const body = card.querySelector("p.digest-body");
+    expect(body).not.toBeNull();
+    expect(body!.textContent).toContain("Fallback plain content for TTS.");
+  });
+
+  it("renders <p class=digest-body> when items is empty array", () => {
+    const digest = makeDigest({ summary: "Summary.", items: [] });
+    const card = renderDigestCard(digest);
+    document.body.appendChild(card);
+    const body = card.querySelector("p.digest-body");
+    expect(body).not.toBeNull();
+  });
+
+  it("does not render <details> elements in fallback mode", () => {
+    const digest = makeDigest({ items: null });
+    const card = renderDigestCard(digest);
+    document.body.appendChild(card);
+    expect(card.querySelectorAll("details").length).toBe(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// TTS playback slot preserved in both modes (issue #11 contract)
+// ---------------------------------------------------------------------------
+
+describe("renderDigestCard — playback slot preserved", () => {
+  it("structured mode: .playback-slot[data-digest-id] is present", () => {
+    const digest = makeDigest({ summary: "S.", items: sampleItems });
+    const card = renderDigestCard(digest);
+    document.body.appendChild(card);
+    const slot = card.querySelector<HTMLElement>(".playback-slot");
+    expect(slot).not.toBeNull();
+    expect(slot!.getAttribute("data-digest-id")).toBe("test-id-1");
+  });
+
+  it("fallback mode: .playback-slot[data-digest-id] is present", () => {
+    const digest = makeDigest({ items: null });
+    const card = renderDigestCard(digest);
+    document.body.appendChild(card);
+    const slot = card.querySelector<HTMLElement>(".playback-slot");
+    expect(slot).not.toBeNull();
+    expect(slot!.getAttribute("data-digest-id")).toBe("test-id-1");
+  });
+});

--- a/web/tests/unit/group.test.ts
+++ b/web/tests/unit/group.test.ts
@@ -11,6 +11,8 @@ function digest(partial: Partial<Digest> & { topic_slug: string; digest_date: st
     token_count: null,
     prompt_version: "v",
     created_at: "2026-06-01T00:00:00Z",
+    summary: null,
+    items: null,
     ...partial,
   };
 }

--- a/web/tests/unit/history.test.ts
+++ b/web/tests/unit/history.test.ts
@@ -22,6 +22,8 @@ function digest(
     token_count: null,
     prompt_version: "v",
     created_at: `${partial.digest_date}T00:00:00Z`,
+    summary: null,
+    items: null,
     ...partial,
   };
 }

--- a/web/tests/unit/query.test.ts
+++ b/web/tests/unit/query.test.ts
@@ -10,6 +10,12 @@ describe("digestsQuery", () => {
     expect(q.order).toEqual({ column: "digest_date", ascending: false });
   });
 
+  it("includes structured output columns summary and items", () => {
+    const q = digestsQuery();
+    expect(q.columns).toContain("summary");
+    expect(q.columns).toContain("items");
+  });
+
   it("honours a limit when provided", () => {
     expect(digestsQuery({ limit: 50 }).limit).toBe(50);
     expect(digestsQuery().limit).toBeUndefined();


### PR DESCRIPTION
Closes #58

## Summary
Replaces the single prose-blob digest with a **structured, summary-first** output: a short top-level `summary` plus a ranked list of `items` (each with `headline`, `blurb`, an expandable `detail`, and per-item `metadata` including source links). `content` is retained as the flat, TTS-safe (#11) prose fallback — now **derived** from the structured fields so it can't drift — and pre-existing content-only rows still render. This is the canonical output contract that #19 (`world_news` sentiment as per-item `metadata`) and #22 (feedback) build on.

### Changes
- **DB** — migration `0009` adds nullable `summary text` + `items jsonb` to `digests` (additive; pre-#58 rows keep `content`). No RLS change: the existing authenticated-read policy (0006) covers the new columns and `service_role` bypasses RLS for agent writes.
- **Agent / prompt** — `SYSTEM_PROMPT` now steers the LLM to emit `summary` + ranked `items` and call `push_to_supabase(topic_slug, summary, items, …)`. New `flatten_digest()` derives the flat `content` (plain prose, no URLs — TTS-safe). `enforce_length` adapted to measure the flattened text (single corrective re-prompt preserved). `agent.py` intentionally unchanged — the LLM assembles the structure and `publishing.py` derives `content`.
- **Web** — `Digest`/`DigestItem` types, `summary,items` added to the digest fetch columns, and `digest-card.ts` renders the summary + a collapsible `<details>` per item with source links, falling back to the `content` `<p>` when `items` is null/empty. The `.playback-slot` TTS mount is preserved. Source `<a href>` is restricted to `http(s)` (XSS guard on LLM-supplied URLs).
- **Docs** — architecture §3.1 / §7.1 / §7.5 document the output contract.

## Test Evidence
- **Python unit** (Strix Halo host, CI-parity): `ruff check` ✓ · `ruff format --check` ✓ · `pytest -m "not integration"` → **113 passed, 6 deselected**.
- **Web unit / build** (local): `npm run lint` ✓ · `vitest` → **103 passed** (incl. new `digest-card.test.ts`: structured render, content fallback, XSS-href guard, playback-slot preserved) · `npm run build` ✓. GitHub `web.yml` re-runs these on Linux (`npm ci` + Playwright).
- **Real-world — 4-topic in-place regeneration** (Strix Halo → prod Supabase, migration `0009` applied): performed as the gated production step; evidence appended below on completion.

## Notes
- TTS (#11) continues to read the flat `content`.
- The live-authenticated structured-render e2e runs against real data after the regeneration step.
