### PR TITLE
Agent reads via service_role (fix anon-read regression from #57)

### DIFF
--- a/src/news_digest/tools/publishing.py
+++ b/src/news_digest/tools/publishing.py
@@ -34,11 +34,16 @@ def _now() -> float:
     return time.monotonic()
 
 
-def _client(write: bool = False) -> Client:
-    """Build a Supabase client. Writes use the service-role key; reads the anon key."""
+def _client() -> Client:
+    """Build a Supabase client authenticated as service_role.
+
+    The agent is a trusted backend process; it uses the service-role key for all
+    Supabase access. Reads previously used the anon key, but anon reads return
+    zero rows since read policies moved to the ``authenticated`` role (migration
+    0006 / #57); service_role bypasses RLS. The service key never leaves the host.
+    """
     settings = get_settings()
-    key = settings.supabase_service_key if write else settings.supabase_anon_key
-    return create_client(settings.supabase_url, key)
+    return create_client(settings.supabase_url, settings.supabase_service_key)
 
 
 @tool
@@ -187,7 +192,7 @@ def push_to_supabase(
     }
     try:
         resp = (
-            _client(write=True)
+            _client()
             .table("digests")
             .upsert(row, on_conflict="topic_slug,digest_date")
             .execute()

--- a/tests/test_publishing_tools.py
+++ b/tests/test_publishing_tools.py
@@ -108,12 +108,42 @@ def _clear_cache():
 def _install_client(monkeypatch, state):
     calls = {"count": 0}
 
-    def _fake_client(write=False):
+    def _fake_client():
         calls["count"] += 1
         return FakeClient(state)
 
     monkeypatch.setattr(publishing, "_client", _fake_client)
     return calls
+
+
+# ---------------------------------------------------------------------------
+# _client — agent authenticates as service_role (issue #60)
+# ---------------------------------------------------------------------------
+
+
+def test_client_authenticates_as_service_role(monkeypatch):
+    """The agent is a trusted backend and authenticates as service_role for ALL
+    Supabase access, reads included. Anon reads return zero rows since read
+    policies moved to the `authenticated` role (#57 / migration 0006)."""
+    captured = {}
+
+    def fake_create_client(url, key):
+        captured["url"] = url
+        captured["key"] = key
+        return MagicMock()
+
+    settings = MagicMock(
+        supabase_url="https://x.supabase.co",
+        supabase_service_key="SERVICE_KEY",
+        supabase_anon_key="ANON_KEY",
+    )
+    monkeypatch.setattr(publishing, "create_client", fake_create_client)
+    monkeypatch.setattr(publishing, "get_settings", lambda: settings)
+
+    publishing._client()
+
+    assert captured["url"] == "https://x.supabase.co"
+    assert captured["key"] == "SERVICE_KEY"  # never the anon key
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Closes #60

## Summary
The agent's Supabase **read** tools authenticated with the **anon key**, which has matched no SELECT policy since #57 / migration `0006` moved read access to the `authenticated` role. As a result `list_topics` / `fetch_topic_config` / `get_recent_digests` / `get_last_digest_date` returned **0 rows**, and the agent could not publish any digest (the pipeline aborts at `fetch_topic_config` → cadence `None` → `unknown_topic`).

The agent is a trusted backend process, so it now authenticates as **service_role** (which bypasses RLS; the service key never leaves the host) for all Supabase access. No anon read policy is re-added — that would reopen the browser login-bypass that #57 deliberately closed. `logging.py` already used the service-role key, so logging was unaffected.

## Changes
- `src/news_digest/tools/publishing.py` — `_client()` now always uses `supabase_service_key`; dropped the now-meaningless `write` parameter and updated the single write call site.
- `tests/test_publishing_tools.py` — adds `test_client_authenticates_as_service_role`; simplifies the fake-client stub to match.

## Test Evidence
- Strix Halo host (CI-parity): `ruff check` ✓ · `ruff format --check` ✓ · `pytest -m "not integration"` → **105 passed, 6 deselected**.

## Notes
Prerequisite for the "regenerate in place" step of #58: with the anon key the agent reads `{'topics': []}` despite 4 enabled topics; this restores read access.
