### PR TITLE
Global settings menu for voice and speed

### DIFF
--- a/web/src/components/playback.ts
+++ b/web/src/components/playback.ts
@@ -10,7 +10,8 @@
 
 import { registerPlaybackControls as registerCardHook } from "../views/digest-card";
 import type { Digest } from "../lib/types";
-import { TtsPlayer, type TtsItem, type TtsState, loadPrefs } from "../lib/tts";
+import { TtsPlayer, type TtsItem, type TtsState } from "../lib/tts";
+import { buildSettingsControls } from "./settings";
 
 let player: TtsPlayer | null = null;
 // Ordered registry: insertion order === card render order.
@@ -56,42 +57,17 @@ function injectStyles(): void {
   style.id = "tts-styles";
   style.textContent = `
     .tts-controls { display:flex; flex-wrap:wrap; gap:0.4rem; align-items:center; margin-bottom:0.6rem; }
-    .tts-controls button { min-height:40px; padding:0.4rem 0.7rem; font-size:0.9rem; }
-    .tts-controls .tts-prefs { display:flex; gap:0.4rem; align-items:center; margin-left:auto; }
-    .tts-controls select.tts-voice { font:inherit; min-height:40px; max-width:9rem; border:1px solid var(--border); border-radius:var(--radius); background:var(--bg); color:var(--fg); padding:0 0.4rem; }
-    .tts-controls input.tts-rate { accent-color: var(--accent); }
-    .tts-rate-label { font-size:0.8rem; color:var(--muted); white-space:nowrap; }
+    .tts-controls button { min-height:44px; padding:0.4rem 0.7rem; font-size:0.9rem; }
     .tts-playall { display:flex; align-items:center; gap:0.5rem; margin:0 0 1rem; }
     .tts-playall button[aria-pressed="true"] { background: var(--card); color: var(--accent); }
     .digest-card[data-tts-state="playing"] { outline:2px solid var(--accent); outline-offset:2px; }
+    .digest-toolbar { display:flex; flex-wrap:wrap; align-items:center; gap:0.6rem; padding:0.5rem 0 0.75rem; border-bottom:1px solid var(--border); margin-bottom:1rem; }
+    .tts-settings { display:flex; flex-wrap:wrap; gap:0.4rem; align-items:center; }
+    .tts-settings select.tts-voice { font:inherit; min-height:44px; max-width:9rem; border:1px solid var(--border); border-radius:var(--radius); background:var(--bg); color:var(--fg); padding:0 0.4rem; }
+    .tts-settings input.tts-rate { accent-color: var(--accent); min-height:44px; }
+    .tts-rate-label { font-size:0.8rem; color:var(--muted); white-space:nowrap; }
   `;
   document.head.appendChild(style);
-}
-
-function populateVoices(select: HTMLSelectElement): void {
-  const synth = (globalThis as unknown as { speechSynthesis?: SpeechSynthesis }).speechSynthesis;
-  if (!synth) return;
-  const render = (): void => {
-    const voices = synth.getVoices();
-    const current = loadPrefs().voiceURI;
-    select.replaceChildren();
-    const def = document.createElement("option");
-    def.value = "";
-    def.textContent = "Default voice";
-    select.appendChild(def);
-    for (const v of voices) {
-      const opt = document.createElement("option");
-      opt.value = v.voiceURI;
-      opt.textContent = v.name;
-      if (current && (v.voiceURI === current || v.name === current)) opt.selected = true;
-      select.appendChild(opt);
-    }
-  };
-  render();
-  // Voices often load asynchronously.
-  if (typeof synth.addEventListener === "function") {
-    synth.addEventListener("voiceschanged", render);
-  }
 }
 
 function makeButton(label: string, cls: string): HTMLButtonElement {
@@ -129,6 +105,16 @@ function finalize(): void {
   document.querySelectorAll(".tts-playall").forEach((el) => el.remove());
   playAllBtn = null;
   if (firstSlot) firstSlot.prepend(buildPlayAllBar());
+
+  // Mount a single global settings toolbar above the digest list.
+  document.querySelectorAll(".digest-toolbar").forEach((el) => el.remove());
+  const digestList = document.querySelector<HTMLElement>(".digest-list");
+  if (digestList) {
+    const toolbar = document.createElement("div");
+    toolbar.className = "digest-toolbar";
+    toolbar.appendChild(buildSettingsControls(getPlayer()));
+    digestList.prepend(toolbar);
+  }
 }
 
 function scheduleFinalize(): void {
@@ -184,42 +170,6 @@ function mountControls(slot: HTMLElement, digest: Digest): void {
   skip.addEventListener("click", () => getPlayer().skip(30));
 
   controls.append(play, pause, stop, skip);
-
-  // Voice + rate prefs (shared across cards, but each card carries a copy so the
-  // controls are reachable per-card).
-  const prefs = document.createElement("div");
-  prefs.className = "tts-prefs";
-
-  const voice = document.createElement("select");
-  voice.className = "tts-voice";
-  voice.setAttribute("aria-label", "Voice");
-  populateVoices(voice);
-  voice.addEventListener("change", () => {
-    getPlayer().setVoiceURI(voice.value || null);
-  });
-
-  const rateLabel = document.createElement("label");
-  rateLabel.className = "tts-rate-label";
-  const rate = document.createElement("input");
-  rate.type = "range";
-  rate.className = "tts-rate";
-  rate.min = "0.5";
-  rate.max = "2";
-  rate.step = "0.1";
-  const stored = loadPrefs().rate;
-  rate.value = String(stored);
-  rateLabel.textContent = `Speed ${stored.toFixed(1)}x`;
-  rate.setAttribute("aria-label", "Speech rate");
-  rate.addEventListener("input", () => {
-    const r = Number(rate.value);
-    rateLabel.textContent = `Speed ${r.toFixed(1)}x`;
-    getPlayer().setRate(r);
-  });
-
-  rateLabel.appendChild(rate);
-  prefs.append(voice, rateLabel);
-  controls.appendChild(prefs);
-
   slot.appendChild(controls);
 }
 

--- a/web/src/components/settings.ts
+++ b/web/src/components/settings.ts
@@ -1,0 +1,85 @@
+// Global TTS settings controls (voice selector + speed slider).
+//
+// Mounted once at page level in a `.digest-toolbar`, not per-card. This module
+// owns the voice-list UI (including async `voiceschanged` repopulation) that was
+// previously duplicated inside every card via `populateVoices` in playback.ts.
+
+import { type TtsPlayer, loadPrefs } from "../lib/tts";
+
+function populateVoices(select: HTMLSelectElement): void {
+  const synth = (globalThis as unknown as { speechSynthesis?: SpeechSynthesis }).speechSynthesis;
+  if (!synth) return;
+  const render = (): void => {
+    const voices = synth.getVoices();
+    const current = loadPrefs().voiceURI;
+    select.replaceChildren();
+    const def = document.createElement("option");
+    def.value = "";
+    def.textContent = "Default voice";
+    select.appendChild(def);
+    for (const v of voices) {
+      const opt = document.createElement("option");
+      opt.value = v.voiceURI;
+      opt.textContent = v.name;
+      if (current && (v.voiceURI === current || v.name === current)) opt.selected = true;
+      select.appendChild(opt);
+    }
+  };
+  render();
+  // Voices often load asynchronously — re-render when the list arrives.
+  if (typeof synth.addEventListener === "function") {
+    synth.addEventListener("voiceschanged", render);
+  }
+}
+
+/**
+ * Build a `.tts-settings` element containing a global voice `<select>` and
+ * speed `<input type="range">`. Reads `loadPrefs()` to reflect stored values
+ * and delegates persistence to the player's `setRate`/`setVoiceURI` (which
+ * call `savePrefs` internally).
+ *
+ * Idempotent to mount: caller is responsible for removing any prior instance.
+ */
+export function buildSettingsControls(player: TtsPlayer): HTMLElement {
+  const group = document.createElement("div");
+  group.className = "tts-settings";
+
+  // Voice selector
+  const voice = document.createElement("select");
+  voice.className = "tts-voice";
+  voice.setAttribute("aria-label", "Voice");
+  populateVoices(voice);
+  voice.addEventListener("change", () => {
+    player.setVoiceURI(voice.value || null);
+  });
+
+  // Speed slider — use a separate <span> for the text so updating it never
+  // risks detaching the <input> from the label DOM subtree.
+  const rateLabel = document.createElement("label");
+  rateLabel.className = "tts-rate-label";
+
+  const rateLabelText = document.createElement("span");
+
+  const rate = document.createElement("input");
+  rate.type = "range";
+  rate.className = "tts-rate";
+  rate.min = "0.5";
+  rate.max = "2";
+  rate.step = "0.1";
+  rate.setAttribute("aria-label", "Speech rate");
+
+  const stored = loadPrefs().rate;
+  rate.value = String(stored);
+  rateLabelText.textContent = `Speed ${stored.toFixed(1)}x`;
+
+  rate.addEventListener("input", () => {
+    const r = Number(rate.value);
+    rateLabelText.textContent = `Speed ${r.toFixed(1)}x`;
+    player.setRate(r);
+  });
+
+  rateLabel.append(rate, rateLabelText);
+  group.append(voice, rateLabel);
+
+  return group;
+}

--- a/web/tests/e2e/playback.spec.ts
+++ b/web/tests/e2e/playback.spec.ts
@@ -161,9 +161,10 @@ test("Play all advances the queue across multiple digests", async ({ page }) => 
   expect(total).toBeGreaterThan(first);
 });
 
-test("voice and rate persist to localStorage", async ({ page }) => {
+test("voice and rate persist to localStorage via global toolbar", async ({ page }) => {
   await gotoApp(page);
-  const rate = page.locator(".digest-card").first().locator(".tts-controls input.tts-rate");
+  // Controls are now in the single global toolbar, not per-card.
+  const rate = page.locator(".digest-toolbar input.tts-rate");
   await expect(rate).toBeVisible();
   // type=range isn't fillable; set the value and fire input/change so the
   // component's listener persists it.
@@ -174,4 +175,24 @@ test("voice and rate persist to localStorage", async ({ page }) => {
   });
   const stored = await page.evaluate(() => window.localStorage.getItem("tts.rate"));
   expect(Number(stored)).toBeCloseTo(1.5);
+});
+
+test("global toolbar exists once with voice+rate controls; cards have no per-card pickers", async ({
+  page,
+}) => {
+  await gotoApp(page);
+  // Exactly one toolbar in the page.
+  await expect(page.locator(".digest-toolbar")).toHaveCount(1);
+  // Toolbar has the voice select and rate slider.
+  await expect(page.locator(".digest-toolbar .tts-voice")).toHaveCount(1);
+  await expect(page.locator(".digest-toolbar input.tts-rate")).toHaveCount(1);
+  // No per-card voice/rate pickers.
+  expect(await page.locator(".digest-card .tts-voice").count()).toBe(0);
+  expect(await page.locator(".digest-card input.tts-rate").count()).toBe(0);
+  // Toolbar is rendered above the first card.
+  const toolbarBox = await page.locator(".digest-toolbar").boundingBox();
+  const firstCardBox = await page.locator(".digest-card").first().boundingBox();
+  expect(toolbarBox).not.toBeNull();
+  expect(firstCardBox).not.toBeNull();
+  expect(toolbarBox!.y).toBeLessThan(firstCardBox!.y);
 });

--- a/web/tests/unit/settings.test.ts
+++ b/web/tests/unit/settings.test.ts
@@ -1,0 +1,205 @@
+// @vitest-environment jsdom
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { TtsPlayer, savePrefs } from "../../src/lib/tts";
+import { buildSettingsControls } from "../../src/components/settings";
+
+// --- speechSynthesis stub ---------------------------------------------------
+
+interface FakeUtterance {
+  text: string;
+  rate: number;
+  voice: SpeechSynthesisVoice | null;
+  onend: (() => void) | null;
+  onerror: (() => void) | null;
+}
+
+class FakeSynth {
+  spoken: FakeUtterance[] = [];
+  paused = false;
+  cancelled = 0;
+  private voices: SpeechSynthesisVoice[] = [];
+
+  speak(u: FakeUtterance): void {
+    this.spoken.push(u);
+  }
+  pause(): void {
+    this.paused = true;
+  }
+  resume(): void {
+    this.paused = false;
+  }
+  cancel(): void {
+    this.cancelled += 1;
+  }
+  getVoices(): SpeechSynthesisVoice[] {
+    return this.voices;
+  }
+  // expose for tests that inject voices
+  __setVoices(v: SpeechSynthesisVoice[]): void {
+    this.voices = v;
+  }
+}
+
+function fakeUtteranceFactory(text: string): FakeUtterance {
+  return { text, rate: 1, voice: null, onend: null, onerror: null };
+}
+
+function makePlayer(synth: FakeSynth): TtsPlayer {
+  return new TtsPlayer({
+    synth: synth as unknown as SpeechSynthesis,
+    createUtterance: fakeUtteranceFactory as unknown as (t: string) => SpeechSynthesisUtterance,
+  });
+}
+
+beforeEach(() => {
+  localStorage.clear();
+  // Install a minimal speechSynthesis stub on window so populateVoices doesn't crash.
+  const synth = new FakeSynth();
+  Object.defineProperty(globalThis, "speechSynthesis", {
+    value: synth,
+    configurable: true,
+    writable: true,
+  });
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+// ---------------------------------------------------------------------------
+
+describe("buildSettingsControls", () => {
+  it("returns an element with a .tts-voice select and input.tts-rate", () => {
+    const player = makePlayer(new FakeSynth());
+    const el = buildSettingsControls(player);
+    expect(el.querySelector("select.tts-voice")).toBeTruthy();
+    expect(el.querySelector("input.tts-rate")).toBeTruthy();
+  });
+
+  it("rate slider reflects loadPrefs() value and label shows it", () => {
+    savePrefs({ rate: 1.8 });
+    const player = makePlayer(new FakeSynth());
+    const el = buildSettingsControls(player);
+    const slider = el.querySelector<HTMLInputElement>("input.tts-rate");
+    expect(slider).toBeTruthy();
+    expect(Number(slider!.value)).toBeCloseTo(1.8);
+    // label text should include the rate value
+    const label = el.querySelector<HTMLElement>(".tts-rate-label");
+    expect(label?.textContent).toContain("1.8");
+  });
+
+  it("rate slider has correct aria-label, min, max, step attributes", () => {
+    const player = makePlayer(new FakeSynth());
+    const el = buildSettingsControls(player);
+    const slider = el.querySelector<HTMLInputElement>("input.tts-rate")!;
+    expect(slider.getAttribute("aria-label")).toBe("Speech rate");
+    expect(slider.min).toBe("0.5");
+    expect(slider.max).toBe("2");
+    expect(slider.step).toBe("0.1");
+  });
+
+  it("voice select has correct aria-label", () => {
+    const player = makePlayer(new FakeSynth());
+    const el = buildSettingsControls(player);
+    const select = el.querySelector<HTMLSelectElement>("select.tts-voice")!;
+    expect(select.getAttribute("aria-label")).toBe("Voice");
+  });
+
+  it("dispatching input on rate slider calls player.setRate and updates localStorage", () => {
+    const synth = new FakeSynth();
+    const player = makePlayer(synth);
+    const setRateSpy = vi.spyOn(player, "setRate");
+
+    const el = buildSettingsControls(player);
+    document.body.appendChild(el);
+
+    const slider = el.querySelector<HTMLInputElement>("input.tts-rate")!;
+    slider.value = "1.5";
+    slider.dispatchEvent(new Event("input", { bubbles: true }));
+
+    expect(setRateSpy).toHaveBeenCalledWith(1.5);
+    expect(Number(localStorage.getItem("tts.rate"))).toBeCloseTo(1.5);
+
+    document.body.removeChild(el);
+  });
+
+  it("dispatching change on voice select calls player.setVoiceURI and updates localStorage", () => {
+    const synth = new FakeSynth();
+    const player = makePlayer(synth);
+    const setVoiceSpy = vi.spyOn(player, "setVoiceURI");
+
+    const el = buildSettingsControls(player);
+    document.body.appendChild(el);
+
+    const select = el.querySelector<HTMLSelectElement>("select.tts-voice")!;
+    // Add an option with a real voiceURI value so we can select it
+    const opt = document.createElement("option");
+    opt.value = "com.example.voice.Daniel";
+    opt.textContent = "Daniel";
+    select.appendChild(opt);
+    select.value = "com.example.voice.Daniel";
+    select.dispatchEvent(new Event("change", { bubbles: true }));
+
+    expect(setVoiceSpy).toHaveBeenCalledWith("com.example.voice.Daniel");
+    expect(localStorage.getItem("tts.voiceURI")).toBe("com.example.voice.Daniel");
+
+    document.body.removeChild(el);
+  });
+
+  it("selecting empty voice value calls setVoiceURI(null)", () => {
+    const synth = new FakeSynth();
+    const player = makePlayer(synth);
+    const setVoiceSpy = vi.spyOn(player, "setVoiceURI");
+
+    const el = buildSettingsControls(player);
+    document.body.appendChild(el);
+
+    const select = el.querySelector<HTMLSelectElement>("select.tts-voice")!;
+    select.value = "";
+    select.dispatchEvent(new Event("change", { bubbles: true }));
+
+    expect(setVoiceSpy).toHaveBeenCalledWith(null);
+
+    document.body.removeChild(el);
+  });
+
+  it("rate slider input updates label text live", () => {
+    const player = makePlayer(new FakeSynth());
+    const el = buildSettingsControls(player);
+    document.body.appendChild(el);
+
+    const slider = el.querySelector<HTMLInputElement>("input.tts-rate")!;
+    const label = el.querySelector<HTMLElement>(".tts-rate-label")!;
+    slider.value = "2.0";
+    slider.dispatchEvent(new Event("input", { bubbles: true }));
+
+    expect(label.textContent).toContain("2.0");
+
+    document.body.removeChild(el);
+  });
+
+  it("reflects stored voiceURI in the select when voice list already available", () => {
+    savePrefs({ voiceURI: "com.example.Samantha" });
+    // Populate speechSynthesis with a matching voice
+    const synth = new FakeSynth();
+    const fakeVoice = {
+      voiceURI: "com.example.Samantha",
+      name: "Samantha",
+      lang: "en-US",
+      localService: true,
+      default: false,
+    } as SpeechSynthesisVoice;
+    synth.__setVoices([fakeVoice]);
+    Object.defineProperty(globalThis, "speechSynthesis", {
+      value: synth,
+      configurable: true,
+      writable: true,
+    });
+
+    const player = makePlayer(synth);
+    const el = buildSettingsControls(player);
+
+    const select = el.querySelector<HTMLSelectElement>("select.tts-voice")!;
+    expect(select.value).toBe("com.example.Samantha");
+  });
+});


### PR DESCRIPTION
Closes #62

## Summary
Voice and speed are now set in exactly one place instead of being duplicated on every card.
- New page-level toolbar (`.digest-toolbar`) mounted once at the top of the digest list, hosting the global Voice `<select>` + Speed slider (new `web/src/components/settings.ts`).
- Removed the per-card voice/rate pickers from `mountControls`; cards keep only their transport controls.
- Changes write through the shared `TtsPlayer` (`setVoiceURI` / `setRate`) so they persist (localStorage) and affect the next utterance live.
- All styling is injected via the module's existing `injectStyles()` — `styles.css` is untouched (keeps this independent of the #65 redesign).

## Test Evidence
- **Unit:** 112 (incl. new `settings.test.ts`) · **Lint** · **Build** — green.
- **Real-world** (strx-halo, authenticated): e2e confirms exactly one global toolbar with voice + rate, **cards carry no per-card pickers**, and voice/rate **persist to localStorage** via the toolbar; live `digest-render` 4/4 + `history` 6/6 passed.