### PR TITLE
Move 'Play all' to a page-level bar at the top

### DIFF
--- a/web/src/components/playback.ts
+++ b/web/src/components/playback.ts
@@ -58,10 +58,11 @@ function injectStyles(): void {
   style.textContent = `
     .tts-controls { display:flex; flex-wrap:wrap; gap:0.4rem; align-items:center; margin-bottom:0.6rem; }
     .tts-controls button { min-height:44px; padding:0.4rem 0.7rem; font-size:0.9rem; }
-    .tts-playall { display:flex; align-items:center; gap:0.5rem; margin:0 0 1rem; }
+    .tts-playall { display:flex; align-items:center; gap:0.5rem; }
     .tts-playall button[aria-pressed="true"] { background: var(--card); color: var(--accent); }
     .digest-card[data-tts-state="playing"] { outline:2px solid var(--accent); outline-offset:2px; }
     .digest-toolbar { display:flex; flex-wrap:wrap; align-items:center; gap:0.6rem; padding:0.5rem 0 0.75rem; border-bottom:1px solid var(--border); margin-bottom:1rem; }
+    .digest-toolbar .tts-settings { margin-left:auto; }
     .tts-settings { display:flex; flex-wrap:wrap; gap:0.4rem; align-items:center; }
     .tts-settings select.tts-voice { font:inherit; min-height:44px; max-width:9rem; border:1px solid var(--border); border-radius:var(--radius); background:var(--bg); color:var(--fg); padding:0 0.4rem; }
     .tts-settings input.tts-rate { accent-color: var(--accent); min-height:44px; }
@@ -101,17 +102,17 @@ function finalize(): void {
     if (!firstSlot) firstSlot = card.querySelector<HTMLElement>(".playback-slot");
   }
 
-  // Drop any stale play-all bar, then mount exactly one above the first card.
+  // Drop any stale play-all bar.
   document.querySelectorAll(".tts-playall").forEach((el) => el.remove());
   playAllBtn = null;
-  if (firstSlot) firstSlot.prepend(buildPlayAllBar());
 
-  // Mount a single global settings toolbar above the digest list.
+  // Mount a single global toolbar above the digest list: [play-all] … [settings].
   document.querySelectorAll(".digest-toolbar").forEach((el) => el.remove());
   const digestList = document.querySelector<HTMLElement>(".digest-list");
   if (digestList) {
     const toolbar = document.createElement("div");
     toolbar.className = "digest-toolbar";
+    toolbar.appendChild(buildPlayAllBar());
     toolbar.appendChild(buildSettingsControls(getPlayer()));
     digestList.prepend(toolbar);
   }

--- a/web/tests/e2e/playback.spec.ts
+++ b/web/tests/e2e/playback.spec.ts
@@ -86,8 +86,8 @@ async function gotoApp(page: Page): Promise<void> {
 
 test("each digest card renders playback controls", async ({ page }) => {
   await gotoApp(page);
-  // Scope to the per-card control group (.tts-controls) so the first card's
-  // play-all bar (which shares a Stop label) doesn't cause ambiguity.
+  // Scope to the per-card control group (.tts-controls) to avoid ambiguity with
+  // the global toolbar's Stop button.
   const controls = page.locator(".digest-card").first().locator(".tts-controls");
   await expect(controls.locator("button.tts-play")).toBeVisible();
   await expect(controls.locator("button.tts-pause")).toBeVisible();
@@ -141,6 +141,23 @@ test("skip-30s utters again from an advanced position", async ({ page }) => {
   await controls.locator("button.tts-skip").click();
   const after = await page.evaluate(() => (window as any).__tts.speaks.length);
   expect(after).toBeGreaterThan(before);
+});
+
+test("play-all control is inside .digest-toolbar at the top, not inside any card", async ({
+  page,
+}) => {
+  await gotoApp(page);
+  // Exactly one play-all button in the whole page.
+  await expect(page.locator(".tts-playall")).toHaveCount(1);
+  // It lives inside the toolbar, not inside a card's playback-slot.
+  await expect(page.locator(".digest-toolbar .tts-playall")).toHaveCount(1);
+  expect(await page.locator(".digest-card .playback-slot .tts-playall").count()).toBe(0);
+  // Toolbar (and therefore play-all) is above the first card.
+  const toolbarBox = await page.locator(".digest-toolbar").boundingBox();
+  const firstCardBox = await page.locator(".digest-card").first().boundingBox();
+  expect(toolbarBox).not.toBeNull();
+  expect(firstCardBox).not.toBeNull();
+  expect(toolbarBox!.y).toBeLessThan(firstCardBox!.y);
 });
 
 test("Play all advances the queue across multiple digests", async ({ page }) => {


### PR DESCRIPTION
Closes #66

## Summary
"Play all today" now lives once at the top of the view instead of being nested in the first card.
- `finalize()` mounts the play-all controls into the page-level `.digest-toolbar` (introduced by #62) rather than prepending them into the first card's `.playback-slot`.
- Per-card transport controls are untouched; the ordered registry (newest-first) and `aria-pressed` state are preserved.

## Test Evidence
- **Unit:** 112 · **Lint** · **Build** — green.
- **Real-world** (strx-halo, authenticated): e2e confirms play-all appears **once, inside `.digest-toolbar` at the top, and not inside any card**, and still advances the queue across multiple digests.

## Note
Stacked on #62 — base is `feat/issue-62-global-settings`. Will retarget to `main` once #62 merges.