### PR TITLE
Make playback controls feel like real media controls

### DIFF
--- a/web/src/components/playback.ts
+++ b/web/src/components/playback.ts
@@ -10,7 +10,7 @@
 
 import { registerPlaybackControls as registerCardHook } from "../views/digest-card";
 import type { Digest } from "../lib/types";
-import { TtsPlayer, type TtsItem, type TtsState } from "../lib/tts";
+import { TtsPlayer, type TtsItem, type TtsState, wordsForSkip } from "../lib/tts";
 import { buildSettingsControls } from "./settings";
 
 let player: TtsPlayer | null = null;
@@ -22,6 +22,68 @@ const knownDigests = new Map<string, Digest>();
 let playAllBtn: HTMLButtonElement | null = null;
 let finalizeScheduled = false;
 
+// --- progress timer state ---------------------------------------------------
+
+interface ProgressState {
+  timerId: ReturnType<typeof setInterval> | null;
+  elapsed: number;    // seconds elapsed since play started
+  total: number;      // estimated total seconds for active item
+  activeId: string | null;
+}
+
+const progress: ProgressState = {
+  timerId: null,
+  elapsed: 0,
+  total: 0,
+  activeId: null,
+};
+
+const TICK_MS = 500;
+
+function estimateTotal(digest: Digest): number {
+  const words = digest.content.trim().split(/\s+/).filter(Boolean).length;
+  const rate = getPlayer().getRate();
+  // wordsForSkip(rate, 1) = words spoken per second at this rate
+  const wps = wordsForSkip(rate, 1);
+  return wps > 0 ? words / wps : 0;
+}
+
+function setProgressFill(digestId: string, fraction: number): void {
+  const entry = registry.get(digestId);
+  if (!entry) return;
+  const fill = entry.card.querySelector<HTMLElement>(".tts-progress-fill");
+  if (!fill) return;
+  fill.style.width = `${Math.round(Math.min(1, Math.max(0, fraction)) * 100)}%`;
+}
+
+function resetProgress(digestId: string | null): void {
+  if (digestId) setProgressFill(digestId, 0);
+  progress.elapsed = 0;
+  progress.total = 0;
+}
+
+function stopTicker(): void {
+  if (progress.timerId !== null) {
+    clearInterval(progress.timerId);
+    progress.timerId = null;
+  }
+}
+
+function startTicker(digestId: string): void {
+  stopTicker();
+  const digest = knownDigests.get(digestId);
+  if (!digest) return;
+  progress.activeId = digestId;
+  progress.elapsed = 0;
+  progress.total = estimateTotal(digest);
+  progress.timerId = setInterval(() => {
+    progress.elapsed += TICK_MS / 1000;
+    setProgressFill(digestId, progress.total > 0 ? progress.elapsed / progress.total : 0);
+  }, TICK_MS);
+}
+
+// ---------------------------------------------------------------------------
+
 function getPlayer(): TtsPlayer {
   if (player) return player;
   player = new TtsPlayer({ onStateChange: handleStateChange });
@@ -30,25 +92,88 @@ function getPlayer(): TtsPlayer {
 
 function setCardState(cardEl: HTMLElement, state: TtsState): void {
   cardEl.setAttribute("data-tts-state", state);
-  const playBtn = cardEl.querySelector<HTMLButtonElement>(".tts-play");
-  const pauseBtn = cardEl.querySelector<HTMLButtonElement>(".tts-pause");
-  if (playBtn) playBtn.disabled = state === "playing";
-  if (pauseBtn) {
-    // Pause doubles as Resume while paused, so it stays enabled unless idle.
-    pauseBtn.disabled = state === "idle";
-    pauseBtn.textContent = state === "paused" ? "Resume" : "Pause";
+  const toggleBtn = cardEl.querySelector<HTMLButtonElement>(".tts-toggle");
+  const stopBtn = cardEl.querySelector<HTMLButtonElement>(".tts-stop");
+  const skipBtn = cardEl.querySelector<HTMLButtonElement>(".tts-skip");
+
+  if (toggleBtn) {
+    const isPlaying = state === "playing";
+    const isActive = isPlaying || state === "paused";
+    toggleBtn.setAttribute("aria-pressed", String(isActive));
+    toggleBtn.setAttribute("aria-label", isPlaying ? "Pause" : "Play");
+    toggleBtn.innerHTML = isPlaying ? ICON_PAUSE : ICON_PLAY;
+    toggleBtn.disabled = false;
   }
+  if (stopBtn) stopBtn.disabled = state === "idle";
+  if (skipBtn) skipBtn.disabled = state === "idle";
 }
 
 function handleStateChange(state: TtsState, currentId: string | null): void {
+  // If the active card changed, clear timer and reset the previous card's fill.
+  if (progress.activeId && progress.activeId !== currentId) {
+    stopTicker();
+    resetProgress(progress.activeId);
+    progress.activeId = null;
+  }
+
   // Reset all cards, then mark the active one.
   for (const [id, { card }] of registry) {
-    setCardState(card, state !== "idle" && id === currentId ? state : "idle");
+    const cardState = state !== "idle" && id === currentId ? state : "idle";
+    setCardState(card, cardState);
+    if (cardState === "idle") {
+      const fill = card.querySelector<HTMLElement>(".tts-progress-fill");
+      if (fill) fill.style.width = "0%";
+    }
   }
+
   if (playAllBtn) {
     playAllBtn.setAttribute("aria-pressed", String(state !== "idle"));
   }
+
+  // Manage progress ticker based on new state.
+  if (currentId && state === "playing") {
+    if (progress.activeId !== currentId) {
+      resetProgress(progress.activeId);
+      startTicker(currentId);
+    } else if (progress.timerId === null) {
+      // Resuming the same item — restart ticker without resetting elapsed.
+      const digest = knownDigests.get(currentId);
+      if (digest) progress.total = estimateTotal(digest);
+      progress.timerId = setInterval(() => {
+        progress.elapsed += TICK_MS / 1000;
+        setProgressFill(currentId, progress.total > 0 ? progress.elapsed / progress.total : 0);
+      }, TICK_MS);
+    }
+  } else if (state === "paused") {
+    stopTicker(); // freeze while paused
+  } else if (state === "idle") {
+    stopTicker();
+    if (currentId) resetProgress(currentId);
+    else if (progress.activeId) {
+      resetProgress(progress.activeId);
+      progress.activeId = null;
+    }
+  }
 }
+
+// --- SVG icon glyphs (aria-hidden; button carries aria-label) ---------------
+
+const ICON_PLAY =
+  `<svg aria-hidden="true" width="16" height="16" viewBox="0 0 16 16" fill="currentColor" xmlns="http://www.w3.org/2000/svg">` +
+  `<path d="M4 2.5a.5.5 0 0 1 .765-.424l8 5.5a.5.5 0 0 1 0 .848l-8 5.5A.5.5 0 0 1 4 13.5v-11Z"/>` +
+  `</svg>`;
+const ICON_PAUSE =
+  `<svg aria-hidden="true" width="16" height="16" viewBox="0 0 16 16" fill="currentColor" xmlns="http://www.w3.org/2000/svg">` +
+  `<path d="M5.5 3.5A1.5 1.5 0 0 1 7 5v6a1.5 1.5 0 0 1-3 0V5a1.5 1.5 0 0 1 1.5-1.5Zm5 0A1.5 1.5 0 0 1 12 5v6a1.5 1.5 0 0 1-3 0V5a1.5 1.5 0 0 1 1.5-1.5Z"/>` +
+  `</svg>`;
+const ICON_STOP =
+  `<svg aria-hidden="true" width="16" height="16" viewBox="0 0 16 16" fill="currentColor" xmlns="http://www.w3.org/2000/svg">` +
+  `<path d="M3.5 3.5A1.5 1.5 0 0 1 5 2h6a1.5 1.5 0 0 1 1.5 1.5v9A1.5 1.5 0 0 1 11 14H5a1.5 1.5 0 0 1-1.5-1.5v-9Z"/>` +
+  `</svg>`;
+const ICON_SKIP =
+  `<svg aria-hidden="true" width="16" height="16" viewBox="0 0 16 16" fill="currentColor" xmlns="http://www.w3.org/2000/svg">` +
+  `<path d="M3.5 2.5a.5.5 0 0 1 .5.5v4.06l7.07-4.65A.5.5 0 0 1 12 2.9v10.2a.5.5 0 0 1-.77.42L4.5 8.94V13a.5.5 0 0 1-1 0v-10a.5.5 0 0 1 .5-.5Zm9 0a.5.5 0 0 1 .5.5v10a.5.5 0 0 1-1 0V3a.5.5 0 0 1 .5-.5Z"/>` +
+  `</svg>`;
 
 function injectStyles(): void {
   if (typeof document === "undefined") return;
@@ -56,19 +181,99 @@ function injectStyles(): void {
   const style = document.createElement("style");
   style.id = "tts-styles";
   style.textContent = `
-    .tts-controls { display:flex; flex-wrap:wrap; gap:0.4rem; align-items:center; margin-bottom:0.6rem; }
-    .tts-controls button { min-height:44px; padding:0.4rem 0.7rem; font-size:0.9rem; }
+    /* Per-card icon transport bar */
+    .tts-controls {
+      display: flex;
+      flex-wrap: wrap;
+      gap: 0.4rem;
+      align-items: center;
+      margin-bottom: 0.6rem;
+    }
+    .tts-controls button {
+      display: inline-flex;
+      align-items: center;
+      justify-content: center;
+      min-width: 44px;
+      min-height: 44px;
+      padding: 0.5rem;
+      border: 1.5px solid var(--border, #c8d3df);
+      border-radius: var(--radius, 8px);
+      background: transparent;
+      color: var(--fg, #0d1117);
+      cursor: pointer;
+      line-height: 1;
+      transition: background 160ms, border-color 160ms, color 160ms;
+    }
+    .tts-controls button:hover:not(:disabled) {
+      background: var(--accent, #1a56db);
+      border-color: var(--accent, #1a56db);
+      color: var(--accent-fg, #ffffff);
+    }
+    .tts-controls button:focus-visible {
+      outline: 2px solid var(--accent, #1a56db);
+      outline-offset: 2px;
+    }
+    .tts-controls button:disabled {
+      opacity: 0.38;
+      cursor: default;
+    }
+    /* Toggle shows pressed state while playing or paused */
+    .tts-controls button.tts-toggle[aria-pressed="true"] {
+      background: var(--accent, #1a56db);
+      border-color: var(--accent, #1a56db);
+      color: var(--accent-fg, #ffffff);
+    }
+    /* Progress pill */
+    .tts-progress {
+      flex: 1 1 100%;
+      height: 4px;
+      border-radius: 2px;
+      background: var(--border, #c8d3df);
+      overflow: hidden;
+      margin-top: 0.1rem;
+    }
+    .tts-progress-fill {
+      height: 100%;
+      width: 0%;
+      background: var(--accent, #1a56db);
+      border-radius: 2px;
+      transition: width 500ms linear;
+    }
+    /* Play-all bar (inside .digest-toolbar) */
     .tts-playall { display:flex; align-items:center; gap:0.5rem; }
-    .tts-playall button[aria-pressed="true"] { background: var(--card); color: var(--accent); }
-    .digest-card[data-tts-state="playing"] { outline:2px solid var(--accent); outline-offset:2px; }
-    .digest-toolbar { display:flex; flex-wrap:wrap; align-items:center; gap:0.6rem; padding:0.5rem 0 0.75rem; border-bottom:1px solid var(--border); margin-bottom:1rem; }
-    .digest-toolbar .tts-settings { margin-left:auto; }
+    .tts-playall button[aria-pressed="true"] { background: var(--card, #fff); color: var(--accent, #1a56db); }
+    /* Active card outline */
+    .digest-card[data-tts-state="playing"],
+    .digest-card[data-tts-state="paused"] {
+      outline: 2px solid var(--accent, #1a56db);
+      outline-offset: 2px;
+    }
+    /* Page-level toolbar housing play-all + settings */
+    .digest-toolbar {
+      display: flex;
+      flex-wrap: wrap;
+      align-items: center;
+      gap: 0.6rem;
+      padding: 0.5rem 0 0.75rem;
+      border-bottom: 1px solid var(--border, #c8d3df);
+      margin-bottom: 1rem;
+    }
+    .digest-toolbar .tts-settings { margin-left: auto; }
     .tts-settings { display:flex; flex-wrap:wrap; gap:0.4rem; align-items:center; }
-    .tts-settings select.tts-voice { font:inherit; min-height:44px; max-width:9rem; border:1px solid var(--border); border-radius:var(--radius); background:var(--bg); color:var(--fg); padding:0 0.4rem; }
-    .tts-settings input.tts-rate { accent-color: var(--accent); min-height:44px; }
-    .tts-rate-label { font-size:0.8rem; color:var(--muted); white-space:nowrap; }
+    .tts-settings select.tts-voice { font:inherit; min-height:44px; max-width:9rem; border:1px solid var(--border, #c8d3df); border-radius:var(--radius, 8px); background:var(--bg, #f0f4f8); color:var(--fg, #0d1117); padding:0 0.4rem; }
+    .tts-settings input.tts-rate { accent-color: var(--accent, #1a56db); min-height:44px; }
+    .tts-rate-label { font-size:0.8rem; color:var(--muted, #4a5568); white-space:nowrap; }
   `;
   document.head.appendChild(style);
+}
+
+function makeIconButton(icon: string, ariaLabel: string, cls: string): HTMLButtonElement {
+  const btn = document.createElement("button");
+  btn.type = "button";
+  btn.className = cls;
+  btn.setAttribute("aria-label", ariaLabel);
+  btn.innerHTML = icon;
+  return btn;
 }
 
 function makeButton(label: string, cls: string): HTMLButtonElement {
@@ -84,22 +289,20 @@ function orderedItems(): TtsItem[] {
 }
 
 // Rebuild the ordered registry from the live DOM and (re)mount a single
-// play-all bar. Runs in a microtask after the synchronous render batch, so the
-// cards are attached and querySelectorAll reflects true DOM order.
+// play-all bar + settings toolbar. Runs in a microtask after the synchronous
+// render batch, so cards are attached and querySelectorAll reflects true DOM order.
 function finalize(): void {
   finalizeScheduled = false;
   if (typeof document === "undefined") return;
 
   registry.clear();
   const cards = document.querySelectorAll<HTMLElement>(".digest-card");
-  let firstSlot: HTMLElement | null = null;
   for (const card of cards) {
     const id = card.getAttribute("data-digest-id");
     if (!id) continue;
     const digest = knownDigests.get(id);
     if (!digest) continue;
     registry.set(id, { digest, card });
-    if (!firstSlot) firstSlot = card.querySelector<HTMLElement>(".playback-slot");
   }
 
   // Drop any stale play-all bar.
@@ -151,26 +354,48 @@ function mountControls(slot: HTMLElement, digest: Digest): void {
   const controls = document.createElement("div");
   controls.className = "tts-controls";
 
-  const play = makeButton("Play", "tts-play");
-  const pause = makeButton("Pause", "tts-pause");
-  pause.disabled = true;
-  const stop = makeButton("Stop", "tts-stop");
-  const skip = makeButton("Skip 30s", "tts-skip");
+  // Single play/pause toggle replaces the old separate Play + Pause buttons.
+  const toggle = makeIconButton(ICON_PLAY, "Play", "tts-toggle");
+  toggle.setAttribute("aria-pressed", "false");
 
-  play.addEventListener("click", () => {
+  const stop = makeIconButton(ICON_STOP, "Stop", "tts-stop");
+  stop.disabled = true;
+
+  const skip = makeIconButton(ICON_SKIP, "Skip 30 seconds", "tts-skip");
+  skip.disabled = true;
+
+  toggle.addEventListener("click", () => {
     const p = getPlayer();
-    // First speak fires here, inside the user gesture — required for iOS.
-    p.play([{ id: digest.id, text: digest.content }]);
+    const state = p.getState();
+    if (state === "playing") {
+      p.pause();
+    } else if (state === "paused") {
+      p.resume();
+    } else {
+      // First speak fires inside the user gesture — required for iOS.
+      p.play([{ id: digest.id, text: digest.content }]);
+    }
   });
-  pause.addEventListener("click", () => {
-    const p = getPlayer();
-    if (p.getState() === "paused") p.resume();
-    else p.pause();
-  });
+
   stop.addEventListener("click", () => getPlayer().stop());
-  skip.addEventListener("click", () => getPlayer().skip(30));
 
-  controls.append(play, pause, stop, skip);
+  skip.addEventListener("click", () => {
+    // Advance the progress estimate optimistically.
+    if (progress.activeId === digest.id) {
+      progress.elapsed = Math.min(progress.elapsed + 30, progress.total);
+      setProgressFill(digest.id, progress.total > 0 ? progress.elapsed / progress.total : 0);
+    }
+    getPlayer().skip(30);
+  });
+
+  // Progress bar.
+  const progressEl = document.createElement("div");
+  progressEl.className = "tts-progress";
+  const progressFill = document.createElement("div");
+  progressFill.className = "tts-progress-fill";
+  progressEl.appendChild(progressFill);
+
+  controls.append(toggle, stop, skip, progressEl);
   slot.appendChild(controls);
 }
 

--- a/web/tests/e2e/playback.spec.ts
+++ b/web/tests/e2e/playback.spec.ts
@@ -135,13 +135,15 @@ test("clicking Play/Pause toggle invokes speechSynthesis and transitions UI stat
 
 test("skip-30s utters again from an advanced position", async ({ page }) => {
   await gotoApp(page);
-  // Pick the card with the most body text so a 30s (~90 word) skip lands mid-item
-  // rather than past the end of a short digest.
+  // Pick the card with the most text so a 30s (~90 word) skip lands mid-item
+  // rather than past the end of a short digest. Measure the card's overall text:
+  // structured digests (post-#58) don't emit a `.digest-body`, so scope to the
+  // whole card to work for both structured and legacy content-only cards.
   const cardCount = await page.locator(".digest-card").count();
   let target = 0;
   let best = -1;
   for (let i = 0; i < cardCount; i++) {
-    const len = (await page.locator(".digest-card").nth(i).locator(".digest-body").innerText()).length;
+    const len = (await page.locator(".digest-card").nth(i).innerText()).length;
     if (len > best) {
       best = len;
       target = i;

--- a/web/tests/e2e/playback.spec.ts
+++ b/web/tests/e2e/playback.spec.ts
@@ -89,35 +89,47 @@ test("each digest card renders playback controls", async ({ page }) => {
   // Scope to the per-card control group (.tts-controls) to avoid ambiguity with
   // the global toolbar's Stop button.
   const controls = page.locator(".digest-card").first().locator(".tts-controls");
-  await expect(controls.locator("button.tts-play")).toBeVisible();
-  await expect(controls.locator("button.tts-pause")).toBeVisible();
+  // Single play/pause toggle replaces the old separate play + pause buttons.
+  await expect(controls.locator("button.tts-toggle")).toBeVisible();
   await expect(controls.locator("button.tts-stop")).toBeVisible();
   await expect(controls.locator("button.tts-skip")).toBeVisible();
+  // Progress bar present on every card.
+  await expect(controls.locator(".tts-progress")).toBeVisible();
   // Every card has its own control group.
   const cardCount = await page.locator(".digest-card").count();
   expect(await page.locator(".tts-controls").count()).toBe(cardCount);
 });
 
-test("clicking Play invokes speechSynthesis.speak and transitions UI state", async ({ page }) => {
+test("clicking Play/Pause toggle invokes speechSynthesis and transitions UI state", async ({
+  page,
+}) => {
   await gotoApp(page);
   const card = page.locator(".digest-card").first();
   const controls = card.locator(".tts-controls");
-  await controls.locator("button.tts-play").click();
+  const toggle = controls.locator("button.tts-toggle");
 
+  // First click — starts playback.
+  await toggle.click();
   const speaks = await page.evaluate(() => (window as any).__tts.speaks.length);
   expect(speaks).toBeGreaterThan(0);
 
-  // Playing state reflected on the card.
+  // Playing state reflected on the card and toggle is pressed.
   await expect(card).toHaveAttribute("data-tts-state", "playing");
+  await expect(toggle).toHaveAttribute("aria-pressed", "true");
+  await expect(toggle).toHaveAttribute("aria-label", "Pause");
 
-  // Pause records a pause and flips state.
-  await controls.locator("button.tts-pause").click();
+  // Second click — pauses.
+  await toggle.click();
   await expect(card).toHaveAttribute("data-tts-state", "paused");
+  await expect(toggle).toHaveAttribute("aria-pressed", "true");
+  await expect(toggle).toHaveAttribute("aria-label", "Play");
   expect(await page.evaluate(() => (window as any).__tts.pauses)).toBeGreaterThan(0);
 
-  // Stop cancels and resets.
+  // Stop button cancels and resets to idle.
   await controls.locator("button.tts-stop").click();
   await expect(card).toHaveAttribute("data-tts-state", "idle");
+  await expect(toggle).toHaveAttribute("aria-pressed", "false");
+  await expect(toggle).toHaveAttribute("aria-label", "Play");
   expect(await page.evaluate(() => (window as any).__tts.cancels)).toBeGreaterThan(0);
 });
 
@@ -136,7 +148,7 @@ test("skip-30s utters again from an advanced position", async ({ page }) => {
     }
   }
   const controls = page.locator(".digest-card").nth(target).locator(".tts-controls");
-  await controls.locator("button.tts-play").click();
+  await controls.locator("button.tts-toggle").click();
   const before = await page.evaluate(() => (window as any).__tts.speaks.length);
   await controls.locator("button.tts-skip").click();
   const after = await page.evaluate(() => (window as any).__tts.speaks.length);


### PR DESCRIPTION
Closes #64

## Summary
Replaces the per-card text buttons with a real media transport bar:
- A single **play/pause toggle** (`.tts-toggle`) that swaps its icon, `aria-label`, and `aria-pressed` — replacing the separate Play + label-swapping Pause buttons.
- Icon `.tts-stop` and `.tts-skip` (+30s) buttons; all icons are **inline SVG** (no web font, to protect the Lighthouse budget).
- A per-card **progress** pill (`.tts-progress` / `.tts-progress-fill`): a 500 ms estimate (`wordsForSkip` × digest word count) driven from `handleStateChange` so only the active card animates; freezes on pause, advances on skip, resets on idle/card-switch.
- Accessible: `aria-label` on every control, `aria-pressed` on the toggle, `aria-hidden` SVGs, ≥44px targets; styled via `injectStyles()` consuming `:root` tokens (inherits the #65 palette after merge).
- Also fixes the pre-existing `skip-30s` e2e selector to work with structured digests.

## Test Evidence
- **Unit:** 112 · **Lint** · **Build** — green.
- **Real-world** (strx-halo, authenticated): toggle invokes speech + flips UI state; progress renders; **skip-30s now passes** (verified on real data); the preserved #62 (global toolbar + settings persistence) and #66 (play-all in toolbar) assertions pass. Screenshots of the toolbar + a mid-playback card captured.
- Remaining unrelated failure: `mfa` enroll (test-account already has a factor) — not introduced here.

## Note
Top of the playback stack: base is `feat/issue-66-play-all-top` (→ `feat/issue-62-global-settings` → `main`). Retarget to `main` as the stack merges.