### PR TITLE
Enable neural TTS voice in production (#63)

### DIFF
--- a/web/.env.production
+++ b/web/.env.production
@@ -1,0 +1,6 @@
+# Production build env (Vite loads this for `vite build`).
+# Point digest playback at the neural TTS proxy (Supabase Edge Function over
+# Google Cloud TTS). Not a secret: the endpoint is JWT-gated and the anon key
+# is already public in the client bundle. If unset, the app falls back to the
+# browser Web Speech voice.
+VITE_TTS_NEURAL_URL=https://eedfyviypptfpghyffip.supabase.co/functions/v1/tts


### PR DESCRIPTION
Part of #63 / follow-up to #75.

Adds `web/.env.production` so production Vite builds inline `VITE_TTS_NEURAL_URL`, switching digest playback from the browser Web Speech fallback to the Google Cloud TTS neural voice (via the deployed `tts` Supabase Edge Function).

- The endpoint is **not a secret**: it is JWT-gated (function deployed with `verify_jwt`) and the Supabase anon key is already public in the client bundle.
- Unset → app falls back to Web Speech, so this is the single switch that turns the neural voice on for real visitors.
- Verified live: the `tts` function returns real `audio/mpeg` and the prod bundle already ships the neural client; this feeds it the endpoint at build time.