### PR TITLE
Fix neural TTS playback latency & progress bar (#63)

### DIFF
--- a/web/src/components/playback.ts
+++ b/web/src/components/playback.ts
@@ -90,8 +90,19 @@ function startTicker(digestId: string): void {
   progress.elapsed = 0;
   progress.total = estimateTotal(digest);
   progress.timerId = setInterval(() => {
-    progress.elapsed += TICK_MS / 1000;
-    setProgressFill(digestId, progress.total > 0 ? progress.elapsed / progress.total : 0);
+    // For real-audio backends (neural), use actual audio currentTime/duration so
+    // the bar tracks true playback and never runs ahead during synthesis.
+    // The bar stays at 0 until currentTime > 0, preventing the "running during
+    // buffering" bug.  Web Speech falls back to the word-count estimate.
+    const realProg = getPlayer().getPlaybackProgress();
+    if (realProg !== null && realProg.currentTime > 0) {
+      setProgressFill(digestId, realProg.currentTime / realProg.duration);
+    } else if (realProg === null) {
+      // Web Speech path: advance the estimate-based counter as before.
+      progress.elapsed += TICK_MS / 1000;
+      setProgressFill(digestId, progress.total > 0 ? progress.elapsed / progress.total : 0);
+    }
+    // realProg !== null but currentTime === 0 means buffering — bar stays at 0.
   }, TICK_MS);
 }
 
@@ -189,8 +200,13 @@ function handleStateChange(state: TtsState, currentId: string | null): void {
       const digest = knownDigests.get(currentId);
       if (digest) progress.total = estimateTotal(digest);
       progress.timerId = setInterval(() => {
-        progress.elapsed += TICK_MS / 1000;
-        setProgressFill(currentId, progress.total > 0 ? progress.elapsed / progress.total : 0);
+        const realProg = getPlayer().getPlaybackProgress();
+        if (realProg !== null && realProg.currentTime > 0) {
+          setProgressFill(currentId, realProg.currentTime / realProg.duration);
+        } else if (realProg === null) {
+          progress.elapsed += TICK_MS / 1000;
+          setProgressFill(currentId, progress.total > 0 ? progress.elapsed / progress.total : 0);
+        }
       }, TICK_MS);
     }
   } else if (state === "paused") {

--- a/web/src/lib/tts-neural.ts
+++ b/web/src/lib/tts-neural.ts
@@ -20,9 +20,13 @@
 import type { TtsBackend, TtsVoice } from "./tts";
 
 const MAX_CACHE_ENTRIES = 64;
-// ~700 chars keeps first-audio latency ~1–2s on Google Chirp 3 HD; the player
-// covers gaps between small chunks via prefetch (Fix #2).
-const NEURAL_MAX_CHUNK_CHARS = 700;
+// Google Chirp 3 HD synthesis costs ~9 ms/char, so first-audio latency is set
+// by the FIRST chunk's size: ~240 chars measures ~2.3s (vs ~6.6s at 700, ~36s
+// at 4000). Each chunk's audio runs ~3x longer than its own synth time, so the
+// player's prefetch (Fix #2) keeps every later chunk ready with no gap; only
+// the first chunk is unavoidably synchronous. ~240 chars is also 1–3 whole
+// sentences, so per-chunk prosody stays natural.
+const NEURAL_MAX_CHUNK_CHARS = 240;
 
 export type HeadersProvider = () =>
   | Record<string, string>

--- a/web/src/lib/tts-neural.ts
+++ b/web/src/lib/tts-neural.ts
@@ -20,7 +20,9 @@
 import type { TtsBackend, TtsVoice } from "./tts";
 
 const MAX_CACHE_ENTRIES = 64;
-const NEURAL_MAX_CHUNK_CHARS = 4000;
+// ~700 chars keeps first-audio latency ~1–2s on Google Chirp 3 HD; the player
+// covers gaps between small chunks via prefetch (Fix #2).
+const NEURAL_MAX_CHUNK_CHARS = 700;
 
 export type HeadersProvider = () =>
   | Record<string, string>
@@ -170,6 +172,31 @@ export class NeuralHttpBackend implements TtsBackend {
       const o = v as { id: string; name?: string };
       return { id: o.id, label: o.name ?? o.id };
     });
+  }
+
+  /**
+   * Warm the cache for `text` without playing it. Call this while the current
+   * chunk is playing so the next chunk is ready when its turn arrives.
+   * All failures are swallowed — a cache miss is the only side-effect.
+   */
+  prefetch(text: string, opts: { rate: number; voiceURI: string | null }): Promise<void> {
+    const voice = opts.voiceURI ?? "";
+    return this.getAudioUrl(text, voice, opts.rate).then(
+      () => { /* cached; no playback */ },
+      () => { /* silently ignore fetch errors */ },
+    );
+  }
+
+  /**
+   * Return the current audio element's playback position.
+   * Returns null when no audio is loaded or duration is not yet finite
+   * (still buffering), so callers can tell the difference between "no audio"
+   * and "audio is playing but metadata not ready yet".
+   */
+  getProgress(): { currentTime: number; duration: number } | null {
+    const audio = this.current;
+    if (!audio || !Number.isFinite(audio.duration)) return null;
+    return { currentTime: audio.currentTime, duration: audio.duration };
   }
 
   // --- internals ------------------------------------------------------------

--- a/web/src/lib/tts.ts
+++ b/web/src/lib/tts.ts
@@ -69,6 +69,21 @@ export interface TtsBackend {
    */
   seekWithinCurrent?(seconds: number): boolean;
 
+  /**
+   * Warm the audio cache for `text` without playing it, so the next chunk
+   * is ready by the time the current one ends.  Optional — Web Speech omits
+   * this; only real-audio backends (neural) implement it.
+   * Must never reject; all failures must be swallowed internally.
+   */
+  prefetch?(text: string, opts: { rate: number; voiceURI: string | null }): Promise<void>;
+
+  /**
+   * Return the current audio element's playback position, or null when no
+   * audio is loaded or duration is not yet finite.
+   * Optional — only real-audio backends implement this.
+   */
+  getProgress?(): { currentTime: number; duration: number } | null;
+
   /** Return the voices this backend can use, for populating the UI. */
   listVoices(): TtsVoice[] | Promise<TtsVoice[]>;
 }
@@ -471,6 +486,16 @@ export class TtsPlayer {
     return this.backend.listVoices();
   }
 
+  /**
+   * Delegate to backend.getProgress() for real-audio backends (neural).
+   * Returns null for Web Speech or when no audio is loaded / buffering.
+   * playback.ts uses this to drive the progress bar from actual audio time
+   * instead of the word-count estimate, so the bar never runs ahead of synthesis.
+   */
+  getPlaybackProgress(): { currentTime: number; duration: number } | null {
+    return this.backend.getProgress?.() ?? null;
+  }
+
   /** Build the queue and start speaking the first chunk. Must be called from a
    *  user gesture (we never auto-speak). */
   play(items: readonly TtsItem[]): void {
@@ -586,6 +611,14 @@ export class TtsPlayer {
       { rate: this.rate, voiceURI: this.voiceURI },
       () => this.handleChunkEnd(gen),
     );
+    // Prefetch the next chunk (within the same item) while this one plays.
+    // Failures are swallowed inside the backend — never propagate here.
+    if (this.backend.prefetch) {
+      const nextChunk = item.chunks[item.chunkIndex + 1];
+      if (nextChunk) {
+        void this.backend.prefetch(nextChunk, { rate: this.rate, voiceURI: this.voiceURI });
+      }
+    }
   }
 
   private handleChunkEnd(gen: number): void {

--- a/web/tests/unit/tts-neural.test.ts
+++ b/web/tests/unit/tts-neural.test.ts
@@ -293,11 +293,13 @@ describe("NeuralHttpBackend transport", () => {
     expect(backend.seekWithinCurrent(30)).toBe(false);
   });
 
-  it("advertises real seek and large chunks", () => {
+  it("advertises real seek and small chunks for low-latency first audio", () => {
     const { fetchImpl } = makeFetch();
     const backend = makeBackend(fetchImpl, []);
     expect(backend.supportsRealSeek).toBe(true);
-    expect(backend.maxChunkChars).toBeGreaterThanOrEqual(2000);
+    // Fix #1: ~700 chars so first audio arrives in ~1–2s, not 4000 chars (~10s).
+    expect(backend.maxChunkChars).toBeGreaterThanOrEqual(600);
+    expect(backend.maxChunkChars).toBeLessThanOrEqual(800);
   });
 });
 
@@ -473,5 +475,108 @@ describe("NeuralHttpBackend headers provider", () => {
     });
     await flush();
     expect(ended).toBe(1);
+  });
+});
+
+// --- prefetch (Fix #2) ----------------------------------------------------------------
+
+describe("NeuralHttpBackend.prefetch", () => {
+  it("warms the cache so a subsequent speak causes no new fetch", async () => {
+    const { fetchImpl, calls } = makeFetch();
+    const audios: FakeAudio[] = [];
+    const backend = makeBackend(fetchImpl, audios);
+
+    // prefetch the text without playing it
+    await backend.prefetch("Prefetched text.", { rate: 1.2, voiceURI: "en-US-Chirp3-HD-Aoede" });
+
+    const callsAfterPrefetch = calls.filter((c) => c.url.endsWith("/v1/audio/speech")).length;
+    expect(callsAfterPrefetch).toBe(1); // one fetch to warm cache
+
+    // speak the same text — must use cache, no new request
+    backend.speak("Prefetched text.", { rate: 1.2, voiceURI: "en-US-Chirp3-HD-Aoede" }, () => {});
+    await flush();
+
+    const callsAfterSpeak = calls.filter((c) => c.url.endsWith("/v1/audio/speech")).length;
+    expect(callsAfterSpeak).toBe(1); // still 1 — cache was hit
+    expect(audios.length).toBe(1); // audio was created and played
+  });
+
+  it("prefetch failure is swallowed (never rejects)", async () => {
+    const { fetchImpl } = makeFetch({ failSpeech: true });
+    const backend = makeBackend(fetchImpl, []);
+    // Must not throw or reject
+    await expect(
+      backend.prefetch("Some text.", { rate: 1, voiceURI: null }),
+    ).resolves.toBeUndefined();
+  });
+
+  it("prefetch does not start audio playback", async () => {
+    const { fetchImpl } = makeFetch();
+    const audios: FakeAudio[] = [];
+    const backend = makeBackend(fetchImpl, audios);
+    await backend.prefetch("No play.", { rate: 1, voiceURI: null });
+    expect(audios.length).toBe(0); // no audio element created
+  });
+
+  it("prefetch does not disturb current session (ongoing speak is unaffected)", async () => {
+    const { fetchImpl } = makeFetch();
+    const audios: FakeAudio[] = [];
+    const backend = makeBackend(fetchImpl, audios);
+
+    let ended = 0;
+    backend.speak("Current chunk.", { rate: 1, voiceURI: null }, () => { ended += 1; });
+    await flush();
+    const currentAudio = audios[0];
+
+    // prefetch a different chunk while audio is playing
+    await backend.prefetch("Next chunk.", { rate: 1, voiceURI: null });
+
+    // current audio still active; simulating end fires our onEnd
+    currentAudio.onended?.();
+    expect(ended).toBe(1);
+    expect(audios.length).toBe(1); // prefetch created no audio
+  });
+});
+
+// --- getProgress (Fix #3) ------------------------------------------------------------
+
+describe("NeuralHttpBackend.getProgress", () => {
+  it("returns null when no audio is playing", () => {
+    const { fetchImpl } = makeFetch();
+    const backend = makeBackend(fetchImpl, []);
+    expect(backend.getProgress()).toBeNull();
+  });
+
+  it("returns null when audio duration is not finite yet (still buffering)", async () => {
+    const { fetchImpl } = makeFetch();
+    const audios: FakeAudio[] = [];
+    const backend = makeBackend(fetchImpl, audios);
+    backend.speak("Hi.", { rate: 1, voiceURI: null }, () => {});
+    await flush();
+    // duration is NaN by default in FakeAudio
+    expect(backend.getProgress()).toBeNull();
+  });
+
+  it("returns { currentTime, duration } once duration is finite", async () => {
+    const { fetchImpl } = makeFetch();
+    const audios: FakeAudio[] = [];
+    const backend = makeBackend(fetchImpl, audios);
+    backend.speak("Hi.", { rate: 1, voiceURI: null }, () => {});
+    await flush();
+    audios[0].duration = 12.5;
+    audios[0].currentTime = 3.0;
+    const prog = backend.getProgress();
+    expect(prog).toEqual({ currentTime: 3.0, duration: 12.5 });
+  });
+
+  it("returns null after cancel", async () => {
+    const { fetchImpl } = makeFetch();
+    const audios: FakeAudio[] = [];
+    const backend = makeBackend(fetchImpl, audios);
+    backend.speak("Hi.", { rate: 1, voiceURI: null }, () => {});
+    await flush();
+    audios[0].duration = 5;
+    backend.cancel();
+    expect(backend.getProgress()).toBeNull();
   });
 });

--- a/web/tests/unit/tts-neural.test.ts
+++ b/web/tests/unit/tts-neural.test.ts
@@ -297,9 +297,10 @@ describe("NeuralHttpBackend transport", () => {
     const { fetchImpl } = makeFetch();
     const backend = makeBackend(fetchImpl, []);
     expect(backend.supportsRealSeek).toBe(true);
-    // Fix #1: ~700 chars so first audio arrives in ~1–2s, not 4000 chars (~10s).
-    expect(backend.maxChunkChars).toBeGreaterThanOrEqual(600);
-    expect(backend.maxChunkChars).toBeLessThanOrEqual(800);
+    // Fix #1: small chunks so first audio arrives in ~2s, not 4000 chars (~36s).
+    // Measured ~9ms/char on Chirp 3 HD; ~240 chars ≈ 2.3s first audio.
+    expect(backend.maxChunkChars).toBeGreaterThanOrEqual(160);
+    expect(backend.maxChunkChars).toBeLessThanOrEqual(320);
   });
 });
 

--- a/web/tests/unit/tts.test.ts
+++ b/web/tests/unit/tts.test.ts
@@ -476,3 +476,88 @@ describe("TtsPlayer with an injected backend", () => {
     expect(player.listVoices()).toEqual([{ id: "fake_voice", label: "Fake Voice" }]);
   });
 });
+
+// --- FakeBackend with prefetch + getProgress support (Fix #2 & #3) -----------------
+
+class FakeBackendWithExtras extends FakeBackend {
+  prefetchCalls: { text: string; rate: number; voiceURI: string | null }[] = [];
+  progressResult: { currentTime: number; duration: number } | null = null;
+
+  prefetch(text: string, opts: { rate: number; voiceURI: string | null }): Promise<void> {
+    this.prefetchCalls.push({ text, ...opts });
+    return Promise.resolve();
+  }
+
+  getProgress(): { currentTime: number; duration: number } | null {
+    return this.progressResult;
+  }
+}
+
+// --- TtsPlayer.prefetch (Fix #2) ----------------------------------------------------
+
+describe("TtsPlayer prefetch", () => {
+  it("fires prefetch for the next chunk when a chunk starts playing", async () => {
+    const backend = new FakeBackendWithExtras();
+    // Use a small chunk size so a multi-sentence item splits into chunks.
+    // Each sentence is ~45 chars; at max=50 each goes in its own chunk.
+    backend.maxChunkChars = 50;
+    const player = new TtsPlayer({ backend });
+    const text =
+      "This is sentence one of the item here. This is sentence two of the item here.";
+    player.play([{ id: "a", text }]);
+
+    // chunk 0 is playing; prefetch should have been called for chunk 1
+    expect(backend.speaks.length).toBeGreaterThanOrEqual(1);
+    expect(backend.prefetchCalls.length).toBeGreaterThanOrEqual(1);
+    const prefetchedText = backend.prefetchCalls[0].text;
+    // The prefetched text should be the second chunk (not the first)
+    expect(prefetchedText).not.toBe(backend.speaks[0].text);
+  });
+
+  it("does not fire prefetch when there is no next chunk", () => {
+    const backend = new FakeBackendWithExtras();
+    const player = new TtsPlayer({ backend });
+    // Single short item -> single chunk -> no next chunk to prefetch
+    player.play([{ id: "a", text: "Short." }]);
+    expect(backend.prefetchCalls.length).toBe(0);
+  });
+
+  it("prefetch failures do not crash the player", async () => {
+    const backend = new FakeBackendWithExtras();
+    backend.maxChunkChars = 50;
+    // Make prefetch throw
+    backend.prefetch = () => Promise.reject(new Error("network"));
+    const player = new TtsPlayer({ backend });
+    // Must not throw
+    expect(() =>
+      player.play([{ id: "a", text: "First sentence here. Second sentence here." }])
+    ).not.toThrow();
+  });
+});
+
+// --- TtsPlayer.getPlaybackProgress (Fix #3) -----------------------------------------
+
+describe("TtsPlayer.getPlaybackProgress", () => {
+  it("returns null when the backend has no getProgress", () => {
+    const backend = new FakeBackend(); // no getProgress
+    const player = new TtsPlayer({ backend });
+    player.play([{ id: "a", text: "Hi." }]);
+    expect(player.getPlaybackProgress()).toBeNull();
+  });
+
+  it("delegates to backend.getProgress when available", () => {
+    const backend = new FakeBackendWithExtras();
+    backend.progressResult = { currentTime: 4.0, duration: 10.0 };
+    const player = new TtsPlayer({ backend });
+    player.play([{ id: "a", text: "Hi." }]);
+    expect(player.getPlaybackProgress()).toEqual({ currentTime: 4.0, duration: 10.0 });
+  });
+
+  it("returns null when backend.getProgress returns null (buffering)", () => {
+    const backend = new FakeBackendWithExtras();
+    backend.progressResult = null;
+    const player = new TtsPlayer({ backend });
+    player.play([{ id: "a", text: "Hi." }]);
+    expect(player.getPlaybackProgress()).toBeNull();
+  });
+});


### PR DESCRIPTION
Follow-up to #63 / #75 / #76. Fixes two issues found testing the live neural voice: a long wait before audio, and a progress bar that ran ahead of the sound.

## Root cause
The neural backend synthesizes a whole chunk in one request before any audio plays, and Google Chirp 3 HD costs ~9 ms/char (measured on the live endpoint). At the old 4000-char chunk size that is **~36s to first audio**; the progress ticker (a word-count estimate) started on play, so it ran far ahead of the actual sound.

## Changes
1. **Smaller neural chunks** — `NEURAL_MAX_CHUNK_CHARS` 4000 → **240** (~2.3s first audio, measured; still 1–3 whole sentences so prosody stays natural). Web Speech's 200 is unchanged.
2. **Prefetch the next chunk** while the current one plays — a chunk's audio runs ~3× longer than its own synth time, so later chunks are always ready and there are no gaps. Only the first chunk is unavoidably synchronous. Added optional `prefetch?()` to `TtsBackend`; Web Speech is a no-op.
3. **Progress bar tracks the real audio** — added optional `getProgress?()` (real `currentTime`/`duration`) to `TtsBackend`; the playback ticker uses it for the neural voice and holds the bar at 0 until audio actually starts. Web Speech keeps its estimate.

## Test evidence
- Unit: **186 passed / 0 failed** (172 prior + 14 new: prefetch warms cache / no second fetch, getProgress reflects the audio element, player fires prefetch for the next chunk, real-progress ticker). Lint + build clean.
- Live endpoint latency (Chirp 3 HD, measured): 4000ch **36.4s** → 700ch **6.6s** → **240ch ~2.3s**; 120ch 1.3s / 200ch 2.0s / 300ch 2.9s confirm the ~9ms/char curve.

I'll verify first-audio + progress on `news-digest-web.pages.dev` after deploy.