### PR TITLE
Fix neural TTS playback across chunks (Safari) + element reuse (#63)

### DIFF
--- a/web/src/lib/tts-neural.ts
+++ b/web/src/lib/tts-neural.ts
@@ -153,11 +153,19 @@ export class NeuralHttpBackend implements TtsBackend {
         // Detach any handlers from a previous chunk before reassigning.
         audio.onended = null;
         audio.onerror = null;
+        const previousSrc = this.elementSrc;
         // Swap the SAME element's source to this chunk. elementSrc records the
         // URL the element is now streaming so eviction never revokes it.
         this.elementSrc = url;
         this.hasCurrentTrack = true;
         audio.src = url;
+        // The element has moved on from previousSrc. If that URL was evicted
+        // from the cache while it was the live src (its revocation deferred),
+        // revoke it now — nothing references it anymore, so it would otherwise
+        // leak. Done AFTER reassigning src so we never revoke the live source.
+        if (previousSrc && previousSrc !== url && !this.cacheHasUrl(previousSrc)) {
+          URL.revokeObjectURL(previousSrc);
+        }
         const finish = (): void => {
           if (session !== this.session) return;
           this.hasCurrentTrack = false;
@@ -276,6 +284,14 @@ export class NeuralHttpBackend implements TtsBackend {
       this.audioEl = this.audioFactory();
     }
     return this.audioEl;
+  }
+
+  /** True when `url` is still held by the cache (so it must not be revoked). */
+  private cacheHasUrl(url: string): boolean {
+    for (const v of this.cache.values()) {
+      if (v === url) return true;
+    }
+    return false;
   }
 
   private async resolveHeaders(): Promise<Record<string, string>> {

--- a/web/src/lib/tts-neural.ts
+++ b/web/src/lib/tts-neural.ts
@@ -6,7 +6,8 @@
 //   GET  /v1/audio/voices  -> { voices: [{ id, name }] }
 //
 // Responsibilities:
-//   - Synthesize one chunk per request, play via HTMLAudioElement.
+//   - Synthesize one chunk per request, play via a SINGLE long-lived
+//     HTMLAudioElement (src is swapped per chunk — never a new element).
 //   - Attach caller-provided headers (Supabase JWT) to every request — the
 //     function is deployed with JWT verification on.
 //   - In-memory cache keyed `${voice}|${rate}|hash(text)` -> object URL so a
@@ -16,6 +17,7 @@
 //     token guards the async fetch).
 //   - Fetch/decoding failure -> call onEnd so the player advances instead of
 //     wedging; never throw out of speak().
+//   - unlock() primes the element inside the user gesture (Safari autoplay fix).
 
 import type { TtsBackend, TtsVoice } from "./tts";
 
@@ -28,6 +30,13 @@ const MAX_CACHE_ENTRIES = 64;
 // sentences, so per-chunk prosody stays natural.
 const NEURAL_MAX_CHUNK_CHARS = 240;
 
+// Minimal silent MP3 (44 bytes): used to prime the audio element in unlock()
+// without triggering audible output.  The howler.js-style Safari unlock pattern
+// requires a real play() call on the element inside the gesture; a data-URI of
+// a tiny silent clip avoids a network round-trip.
+const SILENT_MP3_DATA_URI =
+  "data:audio/mpeg;base64,SUQzBAAAAAAAI1RTU0UAAAAPAAADTGF2ZjU4LjI5LjEwMAAAAAAAAAAAAAAA//tQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAASW5mbwAAAA8AAAACAAABhgC7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA//tQxAADwAABpAAAACAAADSAAAAETEFNRTMuOTkuNVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVV";
+
 export type HeadersProvider = () =>
   | Record<string, string>
   | Promise<Record<string, string>>;
@@ -35,8 +44,12 @@ export type HeadersProvider = () =>
 export interface NeuralHttpBackendOptions {
   /** Injectable for tests; defaults to global fetch. */
   fetchImpl?: typeof fetch;
-  /** Injectable for tests; defaults to `new Audio(src)`. */
-  audioFactory?: (src: string) => HTMLAudioElement;
+  /**
+   * Injectable for tests; called at most once to create the single long-lived
+   * HTMLAudioElement.  Subsequent speaks reassign .src on the same element.
+   * Defaults to `new Audio()`.
+   */
+  audioFactory?: () => HTMLAudioElement;
   /** Cache size cap; defaults to 64. */
   maxCacheEntries?: number;
   /** Extra request headers (auth) applied to every voices/speech request. */
@@ -58,14 +71,24 @@ export class NeuralHttpBackend implements TtsBackend {
 
   private readonly baseUrl: string;
   private readonly fetchImpl: typeof fetch;
-  private readonly audioFactory: (src: string) => HTMLAudioElement;
+  private readonly audioFactory: () => HTMLAudioElement;
   private readonly maxCacheEntries: number;
   private readonly headers?: HeadersProvider;
 
   // key -> object URL. Map preserves insertion order, so the first key is the
   // oldest entry when we need to evict.
   private readonly cache = new Map<string, string>();
-  private current: HTMLAudioElement | null = null;
+  // The single long-lived audio element, created lazily on first use.
+  private audioEl: HTMLAudioElement | null = null;
+  // The object URL actually assigned to audioEl.src right now. Tracked so cache
+  // eviction never revokes a URL the element is still streaming. Survives
+  // cancel() (the src stays loaded until the next speak() overwrites it).
+  private elementSrc: string | null = null;
+  // True while a (non-cancelled) chunk is the current track — drives
+  // getProgress()/seekWithinCurrent(), which must report nothing after cancel().
+  private hasCurrentTrack = false;
+  // True once unlock() has run, so we don't re-prime on repeated calls.
+  private unlocked = false;
   // Monotonic token: cancel() bumps it, so an in-flight speak() whose token no
   // longer matches must not start playback or report an end.
   private session = 0;
@@ -75,10 +98,42 @@ export class NeuralHttpBackend implements TtsBackend {
     this.fetchImpl = opts.fetchImpl ?? fetch.bind(globalThis);
     this.audioFactory =
       opts.audioFactory ??
-      ((src: string) =>
-        new (globalThis as unknown as { Audio: new (s: string) => HTMLAudioElement }).Audio(src));
+      (() =>
+        new (globalThis as unknown as { Audio: new () => HTMLAudioElement }).Audio());
     this.maxCacheEntries = opts.maxCacheEntries ?? MAX_CACHE_ENTRIES;
     this.headers = opts.headers;
+  }
+
+  /**
+   * Prime the single audio element inside a user gesture so Safari grants
+   * autoplay permission for all future chunk plays on the same element.
+   * Call this synchronously at the top of any user-gesture handler (e.g.
+   * TtsPlayer.play()) BEFORE any awaits.  Idempotent — safe to call multiple
+   * times; the unlock only happens once.
+   */
+  unlock(): void {
+    if (this.unlocked) return;
+    this.unlocked = true;
+    const audio = this.getOrCreateElement();
+    // howler.js-style Safari unlock: assign a silent clip and play+pause
+    // immediately inside the gesture.  This registers the element's origin
+    // with Safari's autoplay policy so later play() calls (outside the
+    // gesture, after an async fetch) are permitted on the SAME element.
+    audio.src = SILENT_MP3_DATA_URI;
+    try {
+      const p = audio.play();
+      // Swallow a rejected play() promise (autoplay refusal pre-gesture, jsdom
+      // with no media stack) so unlock never throws into the click handler.
+      if (p && typeof p.catch === "function") p.catch(() => {});
+    } catch {
+      // ignore — element still registered with Safari's policy.
+    }
+    // Pause synchronously, inside the same gesture, so no audible blip plays.
+    try {
+      audio.pause();
+    } catch {
+      // ignore
+    }
   }
 
   speak(
@@ -94,22 +149,29 @@ export class NeuralHttpBackend implements TtsBackend {
     void this.getAudioUrl(text, voice, opts.rate)
       .then((url) => {
         if (session !== this.session) return; // superseded while fetching
-        const audio = this.audioFactory(url);
+        const audio = this.getOrCreateElement();
+        // Detach any handlers from a previous chunk before reassigning.
+        audio.onended = null;
+        audio.onerror = null;
+        // Swap the SAME element's source to this chunk. elementSrc records the
+        // URL the element is now streaming so eviction never revokes it.
+        this.elementSrc = url;
+        this.hasCurrentTrack = true;
+        audio.src = url;
         const finish = (): void => {
           if (session !== this.session) return;
-          this.current = null;
+          this.hasCurrentTrack = false;
           onEnd();
         };
         audio.onended = finish;
         audio.onerror = finish;
-        this.current = audio;
         const p = audio.play();
         // play() returns a promise in browsers; a rejection (autoplay policy,
         // decode failure) must advance the queue, not wedge it.
         if (p && typeof p.catch === "function") {
           p.catch(() => {
             if (session !== this.session) return;
-            this.current = null;
+            this.hasCurrentTrack = false;
             onEnd();
           });
         }
@@ -124,21 +186,24 @@ export class NeuralHttpBackend implements TtsBackend {
 
   pause(): void {
     try {
-      this.current?.pause();
+      this.audioEl?.pause();
     } catch {
       // ignore
     }
   }
 
   resume(): void {
-    const p = this.current?.play();
+    const p = this.audioEl?.play();
     if (p && typeof p.catch === "function") p.catch(() => {});
   }
 
   cancel(): void {
     this.session += 1;
-    const audio = this.current;
-    this.current = null;
+    const audio = this.audioEl;
+    // Stop reporting progress/seek for this track, but keep the element alive
+    // for reuse and keep elementSrc set — the src stays loaded until the next
+    // speak() overwrites it, so we must not let eviction revoke it meanwhile.
+    this.hasCurrentTrack = false;
     if (!audio) return;
     audio.onended = null;
     audio.onerror = null;
@@ -155,8 +220,8 @@ export class NeuralHttpBackend implements TtsBackend {
    * the target is at/past the end of the chunk.
    */
   seekWithinCurrent(seconds: number): boolean {
-    const audio = this.current;
-    if (!audio) return false;
+    const audio = this.audioEl;
+    if (!audio || !this.hasCurrentTrack) return false;
     const target = audio.currentTime + seconds;
     if (Number.isFinite(audio.duration) && target >= audio.duration) return false;
     audio.currentTime = Math.max(0, target);
@@ -198,12 +263,20 @@ export class NeuralHttpBackend implements TtsBackend {
    * and "audio is playing but metadata not ready yet".
    */
   getProgress(): { currentTime: number; duration: number } | null {
-    const audio = this.current;
-    if (!audio || !Number.isFinite(audio.duration)) return null;
+    const audio = this.audioEl;
+    if (!audio || !this.hasCurrentTrack || !Number.isFinite(audio.duration)) return null;
     return { currentTime: audio.currentTime, duration: audio.duration };
   }
 
   // --- internals ------------------------------------------------------------
+
+  /** Lazily create and return the single reused audio element. */
+  private getOrCreateElement(): HTMLAudioElement {
+    if (!this.audioEl) {
+      this.audioEl = this.audioFactory();
+    }
+    return this.audioEl;
+  }
 
   private async resolveHeaders(): Promise<Record<string, string>> {
     if (!this.headers) return {};
@@ -240,7 +313,12 @@ export class NeuralHttpBackend implements TtsBackend {
       const oldest = this.cache.keys().next().value as string;
       const evicted = this.cache.get(oldest);
       this.cache.delete(oldest);
-      if (evicted) URL.revokeObjectURL(evicted);
+      // Never revoke a URL that is currently set as the element's src — the
+      // browser may still be streaming it.  Defer: it will be overwritten the
+      // next time speak() runs, at which point it is safe to drop.
+      if (evicted && evicted !== this.elementSrc) {
+        URL.revokeObjectURL(evicted);
+      }
     }
     return url;
   }

--- a/web/src/lib/tts.ts
+++ b/web/src/lib/tts.ts
@@ -63,6 +63,15 @@ export interface TtsBackend {
   cancel(): void;
 
   /**
+   * Prime the engine inside the user gesture that started playback (Safari
+   * binds HTMLAudioElement autoplay permission to an element unlocked by a
+   * gesture).  TtsPlayer.play() calls this synchronously, before any await, so
+   * the gesture is still active.  Idempotent.  Optional — Web Speech, which
+   * needs no element unlock, omits it.
+   */
+  unlock?(): void;
+
+  /**
    * Seek forward/back within the currently-playing chunk by `seconds`.
    * Return false when the seek position is past the end (caller should advance).
    * Optional — backends that don't support real seek omit this method.
@@ -171,7 +180,7 @@ export interface CreateBackendOptions {
   /** Injectable for tests; passed through to NeuralHttpBackend. */
   fetchImpl?: typeof fetch;
   /** Injectable for tests; passed through to NeuralHttpBackend. */
-  audioFactory?: (src: string) => HTMLAudioElement;
+  audioFactory?: () => HTMLAudioElement;
   /** Auth headers provider, applied to the probe and all neural requests. */
   headers?: () => Record<string, string> | Promise<Record<string, string>>;
 }
@@ -499,6 +508,11 @@ export class TtsPlayer {
   /** Build the queue and start speaking the first chunk. Must be called from a
    *  user gesture (we never auto-speak). */
   play(items: readonly TtsItem[]): void {
+    // Unlock the backend's audio element synchronously, before any await or
+    // queue building, so it runs inside the user gesture that called play().
+    // Safari grants autoplay permission to the element only when primed within
+    // the gesture; later chunks then play on that same unlocked element.
+    this.backend.unlock?.();
     this.cancel();
     this.queue = items
       .map((it) => this.buildItem(it.id, it.text, 0))

--- a/web/tests/unit/tts-neural.test.ts
+++ b/web/tests/unit/tts-neural.test.ts
@@ -1,13 +1,13 @@
 // @vitest-environment jsdom
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { NeuralHttpBackend } from "../../src/lib/tts-neural";
-import { createDefaultBackend, WebSpeechBackend } from "../../src/lib/tts";
+import { createDefaultBackend, TtsPlayer, WebSpeechBackend } from "../../src/lib/tts";
 
 // --- fakes -------------------------------------------------------------------
 
 /** Minimal HTMLAudioElement stand-in: records calls, lets tests fire events. */
 class FakeAudio {
-  src: string;
+  src = "";
   currentTime = 0;
   duration = NaN;
   paused = true;
@@ -16,9 +16,6 @@ class FakeAudio {
   onended: (() => void) | null = null;
   onerror: (() => void) | null = null;
 
-  constructor(src: string) {
-    this.src = src;
-  }
   play(): Promise<void> {
     this.playCalls += 1;
     this.paused = false;
@@ -62,16 +59,21 @@ function makeFetch(opts: { failSpeech?: boolean; failVoices?: boolean } = {}) {
   return { fetchImpl: fetchImpl as unknown as typeof fetch, calls };
 }
 
+/**
+ * Build a backend with an injectable audioFactory that returns a single
+ * FakeAudio.  The factory is called at most once (lazy element creation);
+ * subsequent speaks just reassign .src on the same element.
+ */
 function makeBackend(
   fetchImpl: typeof fetch,
-  audios: FakeAudio[],
+  singleAudio: { ref: FakeAudio | null },
   cacheCap?: number,
 ): NeuralHttpBackend {
   return new NeuralHttpBackend("http://tts.local:8880", {
     fetchImpl,
-    audioFactory: (src: string) => {
-      const a = new FakeAudio(src);
-      audios.push(a);
+    audioFactory: () => {
+      const a = new FakeAudio();
+      singleAudio.ref = a;
       return a as unknown as HTMLAudioElement;
     },
     maxCacheEntries: cacheCap,
@@ -110,8 +112,8 @@ afterEach(() => {
 describe("NeuralHttpBackend.speak", () => {
   it("POSTs the locked OpenAI-compatible body to /v1/audio/speech", async () => {
     const { fetchImpl, calls } = makeFetch();
-    const audios: FakeAudio[] = [];
-    const backend = makeBackend(fetchImpl, audios);
+    const audio = { ref: null as FakeAudio | null };
+    const backend = makeBackend(fetchImpl, audio);
 
     backend.speak("Hello world.", { rate: 1.5, voiceURI: "en-US-Chirp3-HD-Puck" }, () => {});
     await flush();
@@ -131,40 +133,40 @@ describe("NeuralHttpBackend.speak", () => {
 
   it("sends an empty voice when voiceURI is null so the server default applies", async () => {
     const { fetchImpl, calls } = makeFetch();
-    const backend = makeBackend(fetchImpl, []);
+    const backend = makeBackend(fetchImpl, { ref: null });
     backend.speak("Hi.", { rate: 1, voiceURI: null }, () => {});
     await flush();
     const body = JSON.parse(String(calls[0].init?.body));
     expect(body.voice).toBe("");
   });
 
-  it("turns the response blob into an object URL and plays it", async () => {
+  it("turns the response blob into an object URL and plays it via the single element", async () => {
     const { fetchImpl } = makeFetch();
-    const audios: FakeAudio[] = [];
-    const backend = makeBackend(fetchImpl, audios);
+    const audioRef = { ref: null as FakeAudio | null };
+    const backend = makeBackend(fetchImpl, audioRef);
     backend.speak("Hi.", { rate: 1, voiceURI: null }, () => {});
     await flush();
-    expect(audios.length).toBe(1);
-    expect(audios[0].src).toMatch(/^blob:fake-/);
-    expect(audios[0].playCalls).toBe(1);
+    expect(audioRef.ref).not.toBeNull();
+    expect(audioRef.ref!.src).toMatch(/^blob:fake-/);
+    expect(audioRef.ref!.playCalls).toBe(1);
   });
 
   it("fires onEnd when the audio element ends", async () => {
     const { fetchImpl } = makeFetch();
-    const audios: FakeAudio[] = [];
-    const backend = makeBackend(fetchImpl, audios);
+    const audioRef = { ref: null as FakeAudio | null };
+    const backend = makeBackend(fetchImpl, audioRef);
     let ended = 0;
     backend.speak("Hi.", { rate: 1, voiceURI: null }, () => {
       ended += 1;
     });
     await flush();
-    audios[0].onended?.();
+    audioRef.ref!.onended?.();
     expect(ended).toBe(1);
   });
 
   it("fires onEnd (graceful, no crash) when fetch rejects", async () => {
     const { fetchImpl } = makeFetch({ failSpeech: true });
-    const backend = makeBackend(fetchImpl, []);
+    const backend = makeBackend(fetchImpl, { ref: null });
     let ended = 0;
     backend.speak("Hi.", { rate: 1, voiceURI: null }, () => {
       ended += 1;
@@ -175,16 +177,162 @@ describe("NeuralHttpBackend.speak", () => {
 
   it("does not play or call onEnd when cancelled before the fetch resolves", async () => {
     const { fetchImpl } = makeFetch();
-    const audios: FakeAudio[] = [];
-    const backend = makeBackend(fetchImpl, audios);
+    const audioRef = { ref: null as FakeAudio | null };
+    const backend = makeBackend(fetchImpl, audioRef);
     let ended = 0;
     backend.speak("Hi.", { rate: 1, voiceURI: null }, () => {
       ended += 1;
     });
     backend.cancel(); // before flush — fetch still in flight
     await flush();
-    expect(audios.length).toBe(0);
+    // Even if element was created by unlock(), play() must not have been called.
+    expect(audioRef.ref?.playCalls ?? 0).toBe(0);
     expect(ended).toBe(0);
+  });
+});
+
+// --- single reused element (Fix #63) -------------------------------------------
+
+describe("NeuralHttpBackend single reused audio element", () => {
+  it("reuses the same element instance across multiple speak() calls", async () => {
+    const { fetchImpl } = makeFetch();
+    const audioRef = { ref: null as FakeAudio | null };
+    const backend = makeBackend(fetchImpl, audioRef);
+
+    backend.speak("Chunk one.", { rate: 1, voiceURI: null }, () => {});
+    await flush();
+    const firstInstance = audioRef.ref;
+    expect(firstInstance).not.toBeNull();
+    // Simulate chunk end so second speak happens next in queue.
+    firstInstance!.onended?.();
+
+    backend.speak("Chunk two.", { rate: 1, voiceURI: null }, () => {});
+    await flush();
+
+    // The element instance is the same object — no new element was created.
+    expect(audioRef.ref).toBe(firstInstance);
+    // .src was updated to the new chunk's URL.
+    expect(audioRef.ref!.src).toMatch(/^blob:fake-1/);
+    // play() was called for both chunks.
+    expect(audioRef.ref!.playCalls).toBe(2);
+  });
+
+  it("sets .src on the existing element rather than creating a fresh one per chunk", async () => {
+    const { fetchImpl } = makeFetch();
+    let factoryCalls = 0;
+    const backend = new NeuralHttpBackend("http://tts.local:8880", {
+      fetchImpl,
+      audioFactory: () => {
+        factoryCalls += 1;
+        const a = new FakeAudio();
+        return a as unknown as HTMLAudioElement;
+      },
+    });
+
+    backend.speak("A.", { rate: 1, voiceURI: null }, () => {});
+    await flush();
+    backend.speak("B.", { rate: 1, voiceURI: null }, () => {});
+    await flush();
+    backend.speak("C.", { rate: 1, voiceURI: null }, () => {});
+    await flush();
+
+    // Factory called exactly once regardless of how many speak()s.
+    expect(factoryCalls).toBe(1);
+  });
+
+  it("onended on the reused element advances the queue to the next chunk", async () => {
+    const { fetchImpl } = makeFetch();
+    const audioRef = { ref: null as FakeAudio | null };
+    const backend = makeBackend(fetchImpl, audioRef);
+
+    const endedOrder: string[] = [];
+    // Simulate TtsPlayer driving two sequential chunks on the backend.
+    const speakNext = () => {
+      backend.speak("Chunk two.", { rate: 1, voiceURI: null }, () => {
+        endedOrder.push("two");
+      });
+    };
+    backend.speak("Chunk one.", { rate: 1, voiceURI: null }, () => {
+      endedOrder.push("one");
+      speakNext();
+    });
+    await flush();
+
+    // Fire onended on the element — should advance queue.
+    audioRef.ref!.onended?.();
+    await flush();
+
+    audioRef.ref!.onended?.();
+    await flush();
+
+    expect(endedOrder).toEqual(["one", "two"]);
+  });
+});
+
+// --- unlock (Fix #63 Safari) -----------------------------------------------------
+
+describe("NeuralHttpBackend.unlock", () => {
+  it("unlock() is callable and idempotent (no throws)", () => {
+    const { fetchImpl } = makeFetch();
+    const audioRef = { ref: null as FakeAudio | null };
+    const backend = makeBackend(fetchImpl, audioRef);
+    // Must not throw and must be callable multiple times.
+    expect(() => {
+      backend.unlock();
+      backend.unlock();
+      backend.unlock();
+    }).not.toThrow();
+  });
+
+  it("unlock() creates and primes the audio element (play+pause pattern)", () => {
+    const { fetchImpl } = makeFetch();
+    const audioRef = { ref: null as FakeAudio | null };
+    const backend = makeBackend(fetchImpl, audioRef);
+
+    backend.unlock();
+
+    // Element must be created synchronously inside unlock.
+    expect(audioRef.ref).not.toBeNull();
+    // Safari unlock pattern: play() was called to prime the element.
+    expect(audioRef.ref!.playCalls).toBeGreaterThanOrEqual(1);
+    // Followed immediately by pause() — Safari doesn't actually play silent audio.
+    expect(audioRef.ref!.pauseCalls).toBeGreaterThanOrEqual(1);
+  });
+
+  it("unlock() called twice does not create a second element", () => {
+    const { fetchImpl } = makeFetch();
+    let factoryCalls = 0;
+    const backend = new NeuralHttpBackend("http://tts.local:8880", {
+      fetchImpl,
+      audioFactory: () => {
+        factoryCalls += 1;
+        return new FakeAudio() as unknown as HTMLAudioElement;
+      },
+    });
+    backend.unlock();
+    backend.unlock();
+    expect(factoryCalls).toBe(1);
+  });
+
+  it("TtsPlayer.play() calls unlock() on the backend before speakCurrentChunk", () => {
+    const { fetchImpl } = makeFetch();
+    const unlockCalls: number[] = [];
+    const backend = new NeuralHttpBackend("http://tts.local:8880", {
+      fetchImpl,
+      audioFactory: () => new FakeAudio() as unknown as HTMLAudioElement,
+    });
+    // Spy on unlock.
+    const origUnlock = backend.unlock.bind(backend);
+    backend.unlock = () => {
+      unlockCalls.push(Date.now());
+      origUnlock();
+    };
+
+    const player = new TtsPlayer({ backend });
+    player.play([{ id: "1", text: "Hello." }]);
+
+    // unlock must have been called (synchronously in play()).
+    expect(unlockCalls.length).toBeGreaterThanOrEqual(1);
   });
 });
 
@@ -193,8 +341,8 @@ describe("NeuralHttpBackend.speak", () => {
 describe("NeuralHttpBackend cache", () => {
   it("serves a repeat of the same voice|rate|text from cache (no 2nd fetch)", async () => {
     const { fetchImpl, calls } = makeFetch();
-    const audios: FakeAudio[] = [];
-    const backend = makeBackend(fetchImpl, audios);
+    const audioRef = { ref: null as FakeAudio | null };
+    const backend = makeBackend(fetchImpl, audioRef);
 
     backend.speak("Same text.", { rate: 1.2, voiceURI: "en-US-Chirp3-HD-Aoede" }, () => {});
     await flush();
@@ -203,12 +351,13 @@ describe("NeuralHttpBackend cache", () => {
 
     const speechCalls = calls.filter((c) => c.url.endsWith("/v1/audio/speech"));
     expect(speechCalls.length).toBe(1);
-    expect(audios.length).toBe(2); // played twice, fetched once
+    // Played twice on the same element.
+    expect(audioRef.ref!.playCalls).toBe(2);
   });
 
   it("misses the cache when rate or voice differs", async () => {
     const { fetchImpl, calls } = makeFetch();
-    const backend = makeBackend(fetchImpl, []);
+    const backend = makeBackend(fetchImpl, { ref: null });
     backend.speak("Same text.", { rate: 1.2, voiceURI: "en-US-Chirp3-HD-Aoede" }, () => {});
     await flush();
     backend.speak("Same text.", { rate: 1.5, voiceURI: "en-US-Chirp3-HD-Aoede" }, () => {});
@@ -221,7 +370,7 @@ describe("NeuralHttpBackend cache", () => {
 
   it("evicts the oldest entry (and revokes its URL) past the cap", async () => {
     const { fetchImpl, calls } = makeFetch();
-    const backend = makeBackend(fetchImpl, [], 2); // tiny cap for the test
+    const backend = makeBackend(fetchImpl, { ref: null }, 2); // tiny cap for the test
 
     backend.speak("One.", { rate: 1, voiceURI: null }, () => {});
     await flush();
@@ -237,6 +386,28 @@ describe("NeuralHttpBackend cache", () => {
     expect(speechCalls.length).toBe(4);
     expect(URL.revokeObjectURL).toHaveBeenCalled();
   });
+
+  it("does NOT revoke a blob URL that is currently set as the element's src", async () => {
+    const { fetchImpl } = makeFetch();
+    const audioRef = { ref: null as FakeAudio | null };
+    // cap=1 so every new speak() evicts the previous entry
+    const backend = makeBackend(fetchImpl, audioRef, 1);
+
+    // Speak "One." — its URL goes into cache and becomes current src.
+    backend.speak("One.", { rate: 1, voiceURI: null }, () => {});
+    await flush();
+    const urlForOne = audioRef.ref!.src;
+
+    // Speak "Two." — evicts "One." from cache, but "One."'s URL is still the
+    // element's current src — must NOT be revoked yet.
+    backend.speak("Two.", { rate: 1, voiceURI: null }, () => {});
+    await flush();
+
+    const revoked = (URL.revokeObjectURL as ReturnType<typeof vi.fn>).mock.calls.map(
+      (c: unknown[]) => c[0],
+    );
+    expect(revoked).not.toContain(urlForOne);
+  });
 });
 
 // --- transport controls ---------------------------------------------------------
@@ -244,11 +415,11 @@ describe("NeuralHttpBackend cache", () => {
 describe("NeuralHttpBackend transport", () => {
   async function playing(): Promise<{ backend: NeuralHttpBackend; audio: FakeAudio }> {
     const { fetchImpl } = makeFetch();
-    const audios: FakeAudio[] = [];
-    const backend = makeBackend(fetchImpl, audios);
+    const audioRef = { ref: null as FakeAudio | null };
+    const backend = makeBackend(fetchImpl, audioRef);
     backend.speak("Hello.", { rate: 1, voiceURI: null }, () => {});
     await flush();
-    return { backend, audio: audios[0] };
+    return { backend, audio: audioRef.ref! };
   }
 
   it("pause/resume drive the audio element", async () => {
@@ -272,6 +443,25 @@ describe("NeuralHttpBackend transport", () => {
     expect(endedAfterCancel).toBe(0);
   });
 
+  it("cancel keeps the element alive (does not discard it)", async () => {
+    const { fetchImpl } = makeFetch();
+    let factoryCalls = 0;
+    const backend = new NeuralHttpBackend("http://tts.local:8880", {
+      fetchImpl,
+      audioFactory: () => {
+        factoryCalls += 1;
+        return new FakeAudio() as unknown as HTMLAudioElement;
+      },
+    });
+    backend.speak("A.", { rate: 1, voiceURI: null }, () => {});
+    await flush();
+    backend.cancel();
+    backend.speak("B.", { rate: 1, voiceURI: null }, () => {});
+    await flush();
+    // Factory still called only once — element reused after cancel.
+    expect(factoryCalls).toBe(1);
+  });
+
   it("seekWithinCurrent bumps currentTime and returns true within bounds", async () => {
     const { backend, audio } = await playing();
     audio.duration = 100;
@@ -289,13 +479,13 @@ describe("NeuralHttpBackend transport", () => {
 
   it("seekWithinCurrent returns false with no current audio", () => {
     const { fetchImpl } = makeFetch();
-    const backend = makeBackend(fetchImpl, []);
+    const backend = makeBackend(fetchImpl, { ref: null });
     expect(backend.seekWithinCurrent(30)).toBe(false);
   });
 
   it("advertises real seek and small chunks for low-latency first audio", () => {
     const { fetchImpl } = makeFetch();
-    const backend = makeBackend(fetchImpl, []);
+    const backend = makeBackend(fetchImpl, { ref: null });
     expect(backend.supportsRealSeek).toBe(true);
     // Fix #1: small chunks so first audio arrives in ~2s, not 4000 chars (~36s).
     // Measured ~9ms/char on Chirp 3 HD; ~240 chars ≈ 2.3s first audio.
@@ -309,7 +499,7 @@ describe("NeuralHttpBackend transport", () => {
 describe("NeuralHttpBackend.listVoices", () => {
   it("GETs /v1/audio/voices and maps {id, name} to {id, label}", async () => {
     const { fetchImpl, calls } = makeFetch();
-    const backend = makeBackend(fetchImpl, []);
+    const backend = makeBackend(fetchImpl, { ref: null });
     const voices = await backend.listVoices();
     expect(calls[0].url).toBe("http://tts.local:8880/v1/audio/voices");
     expect(voices).toEqual([
@@ -333,7 +523,7 @@ describe("NeuralHttpBackend.listVoices", () => {
 
   it("rejects when the endpoint is unreachable (probe contract)", async () => {
     const { fetchImpl } = makeFetch({ failVoices: true });
-    const backend = makeBackend(fetchImpl, []);
+    const backend = makeBackend(fetchImpl, { ref: null });
     await expect(backend.listVoices()).rejects.toThrow();
   });
 });
@@ -404,12 +594,12 @@ describe("createDefaultBackend", () => {
 // --- auth headers ------------------------------------------------------------------
 
 describe("NeuralHttpBackend headers provider", () => {
-  function authedBackend(fetchImpl: typeof fetch, audios: FakeAudio[]) {
+  function authedBackend(fetchImpl: typeof fetch, audioRef: { ref: FakeAudio | null }) {
     return new NeuralHttpBackend("http://tts.local:8880", {
       fetchImpl,
-      audioFactory: (src: string) => {
-        const a = new FakeAudio(src);
-        audios.push(a);
+      audioFactory: () => {
+        const a = new FakeAudio();
+        audioRef.ref = a;
         return a as unknown as HTMLAudioElement;
       },
       headers: () => ({ Authorization: "Bearer test-token", apikey: "anon-key" }),
@@ -418,7 +608,7 @@ describe("NeuralHttpBackend headers provider", () => {
 
   it("attaches headers to the speech POST", async () => {
     const { fetchImpl, calls } = makeFetch();
-    const backend = authedBackend(fetchImpl, []);
+    const backend = authedBackend(fetchImpl, { ref: null });
     backend.speak("Hi.", { rate: 1, voiceURI: null }, () => {});
     await flush();
     const speech = calls.find((c) => c.url.endsWith("/v1/audio/speech"))!;
@@ -431,7 +621,7 @@ describe("NeuralHttpBackend headers provider", () => {
 
   it("attaches headers to listVoices", async () => {
     const { fetchImpl, calls } = makeFetch();
-    const backend = authedBackend(fetchImpl, []);
+    const backend = authedBackend(fetchImpl, { ref: null });
     await backend.listVoices();
     const voices = calls.find((c) => c.url.endsWith("/v1/audio/voices"))!;
     expect((voices.init?.headers as Record<string, string>).Authorization).toBe(
@@ -453,11 +643,11 @@ describe("NeuralHttpBackend headers provider", () => {
 
   it("speaks fine (no headers) when the provider is omitted", async () => {
     const { fetchImpl, calls } = makeFetch();
-    const audios: FakeAudio[] = [];
-    const backend = makeBackend(fetchImpl, audios);
+    const audioRef = { ref: null as FakeAudio | null };
+    const backend = makeBackend(fetchImpl, audioRef);
     backend.speak("Hi.", { rate: 1, voiceURI: null }, () => {});
     await flush();
-    expect(audios.length).toBe(1);
+    expect(audioRef.ref).not.toBeNull();
     const headers = calls[0].init?.headers as Record<string, string>;
     expect(headers.Authorization).toBeUndefined();
   });
@@ -484,8 +674,8 @@ describe("NeuralHttpBackend headers provider", () => {
 describe("NeuralHttpBackend.prefetch", () => {
   it("warms the cache so a subsequent speak causes no new fetch", async () => {
     const { fetchImpl, calls } = makeFetch();
-    const audios: FakeAudio[] = [];
-    const backend = makeBackend(fetchImpl, audios);
+    const audioRef = { ref: null as FakeAudio | null };
+    const backend = makeBackend(fetchImpl, audioRef);
 
     // prefetch the text without playing it
     await backend.prefetch("Prefetched text.", { rate: 1.2, voiceURI: "en-US-Chirp3-HD-Aoede" });
@@ -499,12 +689,14 @@ describe("NeuralHttpBackend.prefetch", () => {
 
     const callsAfterSpeak = calls.filter((c) => c.url.endsWith("/v1/audio/speech")).length;
     expect(callsAfterSpeak).toBe(1); // still 1 — cache was hit
-    expect(audios.length).toBe(1); // audio was created and played
+    // audio element was created and played
+    expect(audioRef.ref).not.toBeNull();
+    expect(audioRef.ref!.playCalls).toBe(1);
   });
 
   it("prefetch failure is swallowed (never rejects)", async () => {
     const { fetchImpl } = makeFetch({ failSpeech: true });
-    const backend = makeBackend(fetchImpl, []);
+    const backend = makeBackend(fetchImpl, { ref: null });
     // Must not throw or reject
     await expect(
       backend.prefetch("Some text.", { rate: 1, voiceURI: null }),
@@ -513,29 +705,29 @@ describe("NeuralHttpBackend.prefetch", () => {
 
   it("prefetch does not start audio playback", async () => {
     const { fetchImpl } = makeFetch();
-    const audios: FakeAudio[] = [];
-    const backend = makeBackend(fetchImpl, audios);
+    const audioRef = { ref: null as FakeAudio | null };
+    const backend = makeBackend(fetchImpl, audioRef);
     await backend.prefetch("No play.", { rate: 1, voiceURI: null });
-    expect(audios.length).toBe(0); // no audio element created
+    // No play() should have been called — audioFactory not invoked for prefetch,
+    // or if the element was pre-created by unlock(), no play() triggered.
+    expect(audioRef.ref?.playCalls ?? 0).toBe(0);
   });
 
   it("prefetch does not disturb current session (ongoing speak is unaffected)", async () => {
     const { fetchImpl } = makeFetch();
-    const audios: FakeAudio[] = [];
-    const backend = makeBackend(fetchImpl, audios);
+    const audioRef = { ref: null as FakeAudio | null };
+    const backend = makeBackend(fetchImpl, audioRef);
 
     let ended = 0;
     backend.speak("Current chunk.", { rate: 1, voiceURI: null }, () => { ended += 1; });
     await flush();
-    const currentAudio = audios[0];
 
     // prefetch a different chunk while audio is playing
     await backend.prefetch("Next chunk.", { rate: 1, voiceURI: null });
 
     // current audio still active; simulating end fires our onEnd
-    currentAudio.onended?.();
+    audioRef.ref!.onended?.();
     expect(ended).toBe(1);
-    expect(audios.length).toBe(1); // prefetch created no audio
   });
 });
 
@@ -544,14 +736,14 @@ describe("NeuralHttpBackend.prefetch", () => {
 describe("NeuralHttpBackend.getProgress", () => {
   it("returns null when no audio is playing", () => {
     const { fetchImpl } = makeFetch();
-    const backend = makeBackend(fetchImpl, []);
+    const backend = makeBackend(fetchImpl, { ref: null });
     expect(backend.getProgress()).toBeNull();
   });
 
   it("returns null when audio duration is not finite yet (still buffering)", async () => {
     const { fetchImpl } = makeFetch();
-    const audios: FakeAudio[] = [];
-    const backend = makeBackend(fetchImpl, audios);
+    const audioRef = { ref: null as FakeAudio | null };
+    const backend = makeBackend(fetchImpl, audioRef);
     backend.speak("Hi.", { rate: 1, voiceURI: null }, () => {});
     await flush();
     // duration is NaN by default in FakeAudio
@@ -560,23 +752,23 @@ describe("NeuralHttpBackend.getProgress", () => {
 
   it("returns { currentTime, duration } once duration is finite", async () => {
     const { fetchImpl } = makeFetch();
-    const audios: FakeAudio[] = [];
-    const backend = makeBackend(fetchImpl, audios);
+    const audioRef = { ref: null as FakeAudio | null };
+    const backend = makeBackend(fetchImpl, audioRef);
     backend.speak("Hi.", { rate: 1, voiceURI: null }, () => {});
     await flush();
-    audios[0].duration = 12.5;
-    audios[0].currentTime = 3.0;
+    audioRef.ref!.duration = 12.5;
+    audioRef.ref!.currentTime = 3.0;
     const prog = backend.getProgress();
     expect(prog).toEqual({ currentTime: 3.0, duration: 12.5 });
   });
 
   it("returns null after cancel", async () => {
     const { fetchImpl } = makeFetch();
-    const audios: FakeAudio[] = [];
-    const backend = makeBackend(fetchImpl, audios);
+    const audioRef = { ref: null as FakeAudio | null };
+    const backend = makeBackend(fetchImpl, audioRef);
     backend.speak("Hi.", { rate: 1, voiceURI: null }, () => {});
     await flush();
-    audios[0].duration = 5;
+    audioRef.ref!.duration = 5;
     backend.cancel();
     expect(backend.getProgress()).toBeNull();
   });

--- a/web/tests/unit/tts-neural.test.ts
+++ b/web/tests/unit/tts-neural.test.ts
@@ -387,7 +387,7 @@ describe("NeuralHttpBackend cache", () => {
     expect(URL.revokeObjectURL).toHaveBeenCalled();
   });
 
-  it("does NOT revoke a blob URL that is currently set as the element's src", async () => {
+  it("does NOT revoke a blob URL while it is still the element's live src", async () => {
     const { fetchImpl } = makeFetch();
     const audioRef = { ref: null as FakeAudio | null };
     // cap=1 so every new speak() evicts the previous entry
@@ -397,16 +397,47 @@ describe("NeuralHttpBackend cache", () => {
     backend.speak("One.", { rate: 1, voiceURI: null }, () => {});
     await flush();
     const urlForOne = audioRef.ref!.src;
+    expect(urlForOne).toMatch(/^blob:fake-/);
 
-    // Speak "Two." — evicts "One." from cache, but "One."'s URL is still the
-    // element's current src — must NOT be revoked yet.
+    // The eviction of "One." (which happens inside getAudioUrl for "Two.",
+    // before the new src is assigned) must NOT revoke urlForOne — at that
+    // instant the element is still streaming it. We assert by spying on the
+    // moment of revocation: when revokeObjectURL is called for urlForOne, the
+    // element's src must already have moved on (it is no longer the live src).
+    const revokedWhileLive: string[] = [];
+    (URL.revokeObjectURL as ReturnType<typeof vi.fn>).mockImplementation((u: string) => {
+      if (u === urlForOne && audioRef.ref!.src === urlForOne) {
+        revokedWhileLive.push(u);
+      }
+    });
+
+    backend.speak("Two.", { rate: 1, voiceURI: null }, () => {});
+    await flush();
+
+    // urlForOne was never revoked while it was still the element's src.
+    expect(revokedWhileLive).toEqual([]);
+  });
+
+  it("eventually revokes a deferred URL once the element's src moves on (no leak)", async () => {
+    const { fetchImpl } = makeFetch();
+    const audioRef = { ref: null as FakeAudio | null };
+    const backend = makeBackend(fetchImpl, audioRef, 1);
+
+    backend.speak("One.", { rate: 1, voiceURI: null }, () => {});
+    await flush();
+    const urlForOne = audioRef.ref!.src;
+
+    // "Two." evicts "One." (deferred, since it's live), then reassigns src and
+    // revokes the now-orphaned urlForOne so it does not leak.
     backend.speak("Two.", { rate: 1, voiceURI: null }, () => {});
     await flush();
 
     const revoked = (URL.revokeObjectURL as ReturnType<typeof vi.fn>).mock.calls.map(
       (c: unknown[]) => c[0],
     );
-    expect(revoked).not.toContain(urlForOne);
+    expect(revoked).toContain(urlForOne);
+    // And the element has moved on to "Two."'s URL.
+    expect(audioRef.ref!.src).not.toBe(urlForOne);
   });
 });
 


### PR DESCRIPTION
Follow-up to #63 / #77. Fixes the user-reported bug: **Safari plays the first chunk then goes silent; Chrome crashed** during playback.

## Root cause
`NeuralHttpBackend` created a NEW `HTMLAudioElement` for every chunk and called `play()` on it after the fetch `await`. Safari binds audio-playback permission to the specific element a user gesture unlocked; each fresh per-chunk element (created outside the gesture, later ones driven by `onended`) is refused → playback halts after chunk 1. The per-chunk element + blob-URL churn is also the likely Chrome-instability trigger.

## Fix
1. **One reused audio element** — created once, `src` swapped per chunk; all of play/pause/resume/cancel/seek/getProgress operate on it. (Factory now `() => HTMLAudioElement`, still injectable for tests.)
2. **Gesture unlock** — optional `unlock()` on `TtsBackend`; the neural backend primes the single element with a 44-byte silent MP3 (`play()`→`pause()`, howler.js pattern) so Safari grants it. `TtsPlayer.play()` calls `unlock()` synchronously as its first statement, inside the click gesture.
3. **Safe blob-URL lifecycle** — never `revokeObjectURL` the URL currently set as the element's `src`; deferred URLs from a long "Play all today" run are reclaimed after `src` moves on (no leak, no churn).

## Test evidence
- Unit: **196 passed / 0 failed** (+10: same element reused across chunks, factory called once, unlock primes + idempotent, `play()` invokes unlock, live src never revoked, deferred URL reclaimed). Lint + build clean.
- WebKit (Playwright) A/B run: **inconclusive** — Playwright's WebKit relaxes autoplay gating, so it can't reproduce Safari's restriction (control also played). The unlock pattern is the standard proven fix; **real-Safari confirmation is the manual gate before/at merge.**

## Risk
Safari autoplay grant is verified only by the well-known pattern + unit tests, not a real Safari run (no device in CI). Worst case if a Safari version rejects the silent clip: playback still falls back to Web Speech; no regression to other features.