### PR TITLE
Add log view UI at #/logs (#27)

### DIFF
--- a/web/src/lib/query.ts
+++ b/web/src/lib/query.ts
@@ -28,3 +28,69 @@ export function topicsQuery(): QuerySpec {
     order: { column: "slug", ascending: true },
   };
 }
+
+// --- Logs query (#27) --------------------------------------------------------
+
+export type LogLevel = "info" | "warn" | "error";
+
+export const LOG_PAGE_SIZE = 100;
+
+const LOG_COLUMNS = "id, timestamp, level, category, topic_slug, message, metadata, created_at";
+
+export interface LogsFilter {
+  /** ISO datetime string — inclusive lower bound on `timestamp`. */
+  dateFrom: string;
+  /** ISO datetime string — inclusive upper bound on `timestamp`. */
+  dateTo: string;
+  level: LogLevel | null;
+  category: string;
+  topic_slug: string;
+  page: number;
+}
+
+export interface LogsQuerySpec {
+  table: string;
+  columns: string;
+  filters: {
+    dateFrom: string;
+    dateTo: string;
+    level: LogLevel | null;
+    category: string | null;
+    topic_slug: string | null;
+  };
+  order: { column: string; ascending: boolean };
+  range: { from: number; to: number };
+}
+
+/** Build a server-side query spec for the logs page — pure, testable, no client import. */
+export function logsQuery(f: LogsFilter): LogsQuerySpec {
+  const from = f.page * LOG_PAGE_SIZE;
+  const to = from + LOG_PAGE_SIZE - 1;
+  return {
+    table: "system_logs",
+    columns: LOG_COLUMNS,
+    filters: {
+      dateFrom: f.dateFrom,
+      dateTo: f.dateTo,
+      level: f.level || null,
+      category: f.category.trim() || null,
+      topic_slug: f.topic_slug.trim() || null,
+    },
+    order: { column: "timestamp", ascending: false },
+    range: { from, to },
+  };
+}
+
+/** Default date-range: last 24 hours. */
+export function defaultLogsFilter(): LogsFilter {
+  const now = new Date();
+  const yesterday = new Date(now.getTime() - 24 * 60 * 60 * 1000);
+  return {
+    dateFrom: yesterday.toISOString(),
+    dateTo: now.toISOString(),
+    level: null,
+    category: "",
+    topic_slug: "",
+    page: 0,
+  };
+}

--- a/web/src/lib/supabase.ts
+++ b/web/src/lib/supabase.ts
@@ -1,6 +1,6 @@
 import { createClient, type SupabaseClient } from "@supabase/supabase-js";
-import { digestsQuery, topicsQuery } from "./query";
-import type { Digest, Topic } from "./types";
+import { digestsQuery, logsQuery, topicsQuery, type LogsFilter } from "./query";
+import type { Digest, SystemLog, Topic } from "./types";
 
 // Browser client: anon/publishable key ONLY. All reads are RLS-gated.
 // NEVER import or ship the service_role key here.
@@ -61,4 +61,43 @@ export async function fetchAllDigests(
   limit = 1000,
 ): Promise<Digest[]> {
   return fetchDigests(client, limit);
+}
+
+// --- Logs (#27) -------------------------------------------------------------
+
+export interface LogsPage {
+  rows: SystemLog[];
+  /** True if there is at least one more page after this one. */
+  hasMore: boolean;
+}
+
+/**
+ * Fetch one page of system_logs rows matching the given filter.
+ * All filtering is server-side: the table can grow to 30+ days of entries,
+ * so client-side filtering is not appropriate here (unlike digests).
+ */
+export async function fetchLogs(
+  client: SupabaseClient,
+  filter: LogsFilter,
+): Promise<LogsPage> {
+  const spec = logsQuery(filter);
+  let q = client
+    .from(spec.table)
+    .select(spec.columns)
+    .gte("timestamp", spec.filters.dateFrom)
+    .lte("timestamp", spec.filters.dateTo)
+    .order(spec.order.column, { ascending: spec.order.ascending })
+    .range(spec.range.from, spec.range.to);
+
+  if (spec.filters.level) q = q.eq("level", spec.filters.level);
+  if (spec.filters.category) q = q.eq("category", spec.filters.category);
+  if (spec.filters.topic_slug) q = q.eq("topic_slug", spec.filters.topic_slug);
+
+  const { data, error } = await q;
+  if (error) throw error;
+
+  const rows = (data ?? []) as unknown as SystemLog[];
+  // If we got a full page, there might be more.
+  const hasMore = rows.length === spec.range.to - spec.range.from + 1;
+  return { rows, hasMore };
 }

--- a/web/src/lib/types.ts
+++ b/web/src/lib/types.ts
@@ -52,3 +52,15 @@ export interface DateGroup {
   date: string;
   digests: Digest[];
 }
+
+/** One row from the system_logs table (read-only, authenticated role). */
+export interface SystemLog {
+  id: string;
+  timestamp: string;       // ISO timestamptz
+  level: "info" | "warn" | "error";
+  category: string;
+  topic_slug: string | null;
+  message: string;
+  metadata: unknown;       // jsonb — may be null or any JSON value
+  created_at: string;
+}

--- a/web/src/main.ts
+++ b/web/src/main.ts
@@ -2,6 +2,7 @@ import "./components/playback"; // #11: auto-registers TTS playback controls
 import { getSupabase } from "./lib/supabase";
 import { renderHome } from "./pages/home";
 import { renderHistory } from "./pages/history";
+import { renderLogs } from "./pages/logs";
 import { registerRoute, startRouter } from "./router";
 
 // App bootstrap. Routes are declared here once; pages live in their own files.
@@ -21,5 +22,6 @@ const client = getSupabase();
 
 registerRoute("/", renderHome);
 registerRoute("/history", renderHistory);
+registerRoute("/logs", renderLogs);
 
 startRouter(root, client);

--- a/web/src/pages/history.ts
+++ b/web/src/pages/history.ts
@@ -338,6 +338,10 @@ export async function renderHistory(root: HTMLElement, client: SupabaseClient): 
   homeLink.href = "#/";
   homeLink.textContent = "Today";
   nav.appendChild(homeLink);
+  const logsLink = document.createElement("a");
+  logsLink.href = "#/logs";
+  logsLink.textContent = "Logs";
+  nav.appendChild(logsLink);
   const out = document.createElement("button");
   out.type = "button";
   out.className = "sign-out";

--- a/web/src/pages/home.ts
+++ b/web/src/pages/home.ts
@@ -90,6 +90,10 @@ export async function renderHome(root: HTMLElement, client: SupabaseClient): Pro
   historyLink.href = "#/history";
   historyLink.textContent = "History";
   nav.appendChild(historyLink);
+  const logsLink = document.createElement("a");
+  logsLink.href = "#/logs";
+  logsLink.textContent = "Logs";
+  nav.appendChild(logsLink);
 
   const out = document.createElement("button");
   out.type = "button";

--- a/web/src/pages/logs.ts
+++ b/web/src/pages/logs.ts
@@ -1,8 +1,8 @@
 import type { SupabaseClient } from "@supabase/supabase-js";
 import { isAuthenticatedAtRequiredLevel, signOut } from "../lib/auth";
 import { defaultLogsFilter, LOG_PAGE_SIZE, type LogLevel } from "../lib/query";
-import { fetchLogs } from "../lib/supabase";
-import type { SystemLog } from "../lib/types";
+import { fetchLogs, fetchTopics } from "../lib/supabase";
+import type { SystemLog, Topic } from "../lib/types";
 import { renderAuthGate } from "../views/auth-gate";
 
 // Issue #27 — Log view UI at `#/logs`.
@@ -14,6 +14,29 @@ import { renderAuthGate } from "../views/auth-gate";
 // filter server-side).
 
 // --- Pure, DOM-free helpers (unit-tested) ------------------------------------
+
+/** Canonical log categories emitted by the agent.
+ *  Transcribed from the `Category` Literal in src/news_digest/logging.py:10-18. */
+export const LOG_CATEGORIES = [
+  "schedule",
+  "scrape",
+  "summarize",
+  "publish",
+  "feedback",
+  "hello_world",
+  "system",
+] as const;
+
+/** Known topic slugs, used only if the digest_topics fetch fails. The
+ *  authenticated role CAN read digest_topics (migration 0006), so the dropdown
+ *  is normally populated from the table; this is a network-failure fallback. */
+export const FALLBACK_TOPIC_SLUGS = [
+  "ai_models",
+  "ai_updates",
+  "local_news",
+  "penguins",
+  "world_news",
+] as const;
 
 export interface LogsState {
   dateFrom: string;
@@ -201,7 +224,38 @@ interface FilterBar {
   sync: (state: LogsState) => void;
 }
 
-function buildFilterBar(initial: LogsState, onChange: (next: LogsState) => void): FilterBar {
+function buildSelect(opts: {
+  testid: string;
+  ariaLabel: string;
+  allLabel: string;
+  values: readonly string[];
+  initial: string;
+}): HTMLSelectElement {
+  const select = document.createElement("select");
+  select.className = "logs-filter-select";
+  select.setAttribute("data-testid", opts.testid);
+  select.setAttribute("aria-label", opts.ariaLabel);
+  const allOpt = document.createElement("option");
+  allOpt.value = "";
+  allOpt.textContent = opts.allLabel;
+  select.appendChild(allOpt);
+  for (const value of opts.values) {
+    const opt = document.createElement("option");
+    opt.value = value;
+    opt.textContent = value;
+    select.appendChild(opt);
+  }
+  select.value = opts.initial;
+  // An unknown initial (hand-edited URL) leaves value "" — treat as All.
+  if (select.value !== opts.initial) select.value = "";
+  return select;
+}
+
+function buildFilterBar(
+  initial: LogsState,
+  topicSlugs: readonly string[],
+  onChange: (next: LogsState) => void,
+): FilterBar {
   const bar = document.createElement("div");
   bar.className = "logs-filters";
   bar.setAttribute("data-testid", "logs-filters");
@@ -245,23 +299,24 @@ function buildFilterBar(initial: LogsState, onChange: (next: LogsState) => void)
   }
   levelSelect.value = initial.level ?? "";
 
-  // Category
-  const categoryInput = document.createElement("input");
-  categoryInput.type = "text";
-  categoryInput.className = "logs-filter-input";
-  categoryInput.setAttribute("data-testid", "filter-category");
-  categoryInput.setAttribute("aria-label", "Filter by category");
-  categoryInput.placeholder = "Category…";
-  categoryInput.value = initial.category;
+  // Category — select over the agent's canonical categories (exact-match filter,
+  // so free text would silently return zero rows on partial/case-different input).
+  const categorySelect = buildSelect({
+    testid: "filter-category",
+    ariaLabel: "Filter by category",
+    allLabel: "All categories",
+    values: LOG_CATEGORIES,
+    initial: initial.category,
+  });
 
-  // Topic slug
-  const topicInput = document.createElement("input");
-  topicInput.type = "text";
-  topicInput.className = "logs-filter-input";
-  topicInput.setAttribute("data-testid", "filter-topic-slug");
-  topicInput.setAttribute("aria-label", "Filter by topic slug");
-  topicInput.placeholder = "Topic slug…";
-  topicInput.value = initial.topic_slug;
+  // Topic slug — select populated from digest_topics (or the static fallback).
+  const topicSelect = buildSelect({
+    testid: "filter-topic-slug",
+    ariaLabel: "Filter by topic slug",
+    allLabel: "All topics",
+    values: topicSlugs,
+    initial: initial.topic_slug,
+  });
 
   const applyButton = document.createElement("button");
   applyButton.type = "button";
@@ -273,8 +328,8 @@ function buildFilterBar(initial: LogsState, onChange: (next: LogsState) => void)
     dateFromLabel, dateFrom,
     dateToLabel, dateTo,
     levelSelect,
-    categoryInput,
-    topicInput,
+    categorySelect,
+    topicSelect,
     applyButton,
   );
 
@@ -282,27 +337,23 @@ function buildFilterBar(initial: LogsState, onChange: (next: LogsState) => void)
     dateFrom: fromDatetimeLocal(dateFrom.value) || readState().dateFrom,
     dateTo: fromDatetimeLocal(dateTo.value) || readState().dateTo,
     level: (levelSelect.value as LogLevel) || null,
-    category: categoryInput.value,
-    topic_slug: topicInput.value,
+    category: categorySelect.value,
+    topic_slug: topicSelect.value,
     page: 0, // reset to first page on any filter change
   });
 
+  // Apply commits the date range; selects fire immediately.
   applyButton.addEventListener("click", () => onChange(collect()));
-  // Also fire on Enter in text inputs.
-  for (const input of [categoryInput, topicInput]) {
-    input.addEventListener("keydown", (e) => {
-      if (e.key === "Enter") onChange(collect());
-    });
+  for (const select of [levelSelect, categorySelect, topicSelect]) {
+    select.addEventListener("change", () => onChange(collect()));
   }
-  // Level select fires immediately.
-  levelSelect.addEventListener("change", () => onChange(collect()));
 
   const sync = (state: LogsState) => {
     dateFrom.value = toDatetimeLocal(state.dateFrom);
     dateTo.value = toDatetimeLocal(state.dateTo);
     levelSelect.value = state.level ?? "";
-    categoryInput.value = state.category;
-    topicInput.value = state.topic_slug;
+    categorySelect.value = state.category;
+    topicSelect.value = state.topic_slug;
   };
 
   return { el: bar, sync };
@@ -310,6 +361,7 @@ function buildFilterBar(initial: LogsState, onChange: (next: LogsState) => void)
 
 function renderPager(
   state: LogsState,
+  rowCount: number,
   hasMore: boolean,
   onChange: (next: LogsState) => void,
 ): HTMLElement {
@@ -326,11 +378,7 @@ function renderPager(
 
   const info = document.createElement("span");
   info.className = "logs-pager-info";
-  const first = state.page * LOG_PAGE_SIZE + 1;
-  const lastApprox = state.page * LOG_PAGE_SIZE + LOG_PAGE_SIZE;
-  info.textContent = hasMore
-    ? `Rows ${first}–${lastApprox}`
-    : `Rows ${first}+`;
+  info.textContent = pagerLabel(state.page, rowCount);
 
   const next = document.createElement("button");
   next.type = "button";
@@ -343,25 +391,29 @@ function renderPager(
   return pager;
 }
 
-/** Convert ISO string to `datetime-local` input format (`YYYY-MM-DDTHH:MM`). */
-function toDatetimeLocal(iso: string): string {
-  try {
-    const d = new Date(iso);
-    const pad = (n: number) => String(n).padStart(2, "0");
-    return `${d.getFullYear()}-${pad(d.getMonth() + 1)}-${pad(d.getDate())}T${pad(d.getHours())}:${pad(d.getMinutes())}`;
-  } catch {
-    return "";
-  }
+/** Convert ISO string to `datetime-local` input format (`YYYY-MM-DDTHH:MM`).
+ *  Returns "" for unparseable input (new Date never throws; it yields NaN). */
+export function toDatetimeLocal(iso: string): string {
+  const d = new Date(iso);
+  if (Number.isNaN(d.getTime())) return "";
+  const pad = (n: number) => String(n).padStart(2, "0");
+  return `${d.getFullYear()}-${pad(d.getMonth() + 1)}-${pad(d.getDate())}T${pad(d.getHours())}:${pad(d.getMinutes())}`;
 }
 
-/** Convert `datetime-local` value back to an ISO string (local timezone). */
-function fromDatetimeLocal(value: string): string {
+/** Convert `datetime-local` value back to an ISO string (local timezone).
+ *  Returns "" for empty or unparseable input. */
+export function fromDatetimeLocal(value: string): string {
   if (!value) return "";
-  try {
-    return new Date(value).toISOString();
-  } catch {
-    return "";
-  }
+  const d = new Date(value);
+  if (Number.isNaN(d.getTime())) return "";
+  return d.toISOString();
+}
+
+/** Human label for the pager: row range on this page, or "No rows". */
+export function pagerLabel(page: number, rowCount: number): string {
+  if (rowCount === 0) return "No rows";
+  const first = page * LOG_PAGE_SIZE + 1;
+  return `Rows ${first}–${first + rowCount - 1}`;
 }
 
 export async function renderLogs(root: HTMLElement, client: SupabaseClient): Promise<void> {
@@ -407,16 +459,33 @@ export async function renderLogs(root: HTMLElement, client: SupabaseClient): Pro
   const main = document.createElement("main");
   main.className = "app-main";
   main.setAttribute("data-testid", "logs-content");
+  const loading = document.createElement("p");
+  loading.textContent = "Loading logs…";
+  main.appendChild(loading);
   root.appendChild(main);
+
+  // Topic dropdown options come from digest_topics (the authenticated role can
+  // read it — migration 0006). On failure fall back to the static slug list so
+  // a transient error doesn't take the whole filter bar down.
+  let topicSlugs: readonly string[];
+  try {
+    const topics: Topic[] = await fetchTopics(client);
+    topicSlugs = topics.map((t) => t.slug);
+  } catch {
+    topicSlugs = FALLBACK_TOPIC_SLUGS;
+  }
+
+  main.replaceChildren();
 
   // Build filter bar once; onChange triggers a re-fetch.
   let currentState = readState();
-  const bar = buildFilterBar(currentState, (next) => {
+  const onStateChange = (next: LogsState) => {
     currentState = next;
     writeState(next);
     bar.sync(next);
     void load(next);
-  });
+  };
+  const bar = buildFilterBar(currentState, topicSlugs, onStateChange);
   main.appendChild(bar.el);
 
   const contentArea = document.createElement("div");
@@ -425,9 +494,9 @@ export async function renderLogs(root: HTMLElement, client: SupabaseClient): Pro
 
   async function load(state: LogsState): Promise<void> {
     contentArea.replaceChildren();
-    const loading = document.createElement("p");
-    loading.textContent = "Loading logs…";
-    contentArea.appendChild(loading);
+    const loadingMsg = document.createElement("p");
+    loadingMsg.textContent = "Loading logs…";
+    contentArea.appendChild(loadingMsg);
 
     try {
       const { rows, hasMore } = await fetchLogs(client, {
@@ -441,22 +510,16 @@ export async function renderLogs(root: HTMLElement, client: SupabaseClient): Pro
 
       contentArea.replaceChildren();
 
-      const pagerTop = renderPager(state, hasMore, (next) => {
-        currentState = next;
-        writeState(next);
-        bar.sync(next);
-        void load(next);
-      });
-      contentArea.appendChild(pagerTop);
+      // Pager is suppressed on an empty first page; on a later page it stays so
+      // "Prev" can recover from paging past the end (e.g. a stale ?page= URL).
+      const showPager = rows.length > 0 || state.page > 0;
+      if (showPager) {
+        contentArea.appendChild(renderPager(state, rows.length, hasMore, onStateChange));
+      }
       contentArea.appendChild(renderTable(rows));
-
-      // Bottom pager only if there's content.
       if (rows.length > 0) {
-        const pagerBot = renderPager(state, hasMore, (next) => {
-          currentState = next;
-          writeState(next);
-          bar.sync(next);
-          void load(next);
+        const pagerBot = renderPager(state, rows.length, hasMore, (next) => {
+          onStateChange(next);
           window.scrollTo({ top: 0 });
         });
         contentArea.appendChild(pagerBot);

--- a/web/src/pages/logs.ts
+++ b/web/src/pages/logs.ts
@@ -1,0 +1,474 @@
+import type { SupabaseClient } from "@supabase/supabase-js";
+import { isAuthenticatedAtRequiredLevel, signOut } from "../lib/auth";
+import { defaultLogsFilter, LOG_PAGE_SIZE, type LogLevel } from "../lib/query";
+import { fetchLogs } from "../lib/supabase";
+import type { SystemLog } from "../lib/types";
+import { renderAuthGate } from "../views/auth-gate";
+
+// Issue #27 — Log view UI at `#/logs`.
+//
+// URL state lives in `window.location.search`. The router keys on the hash,
+// so search params survive routing and are shareable/bookmarkable.
+// Changing a filter calls history.replaceState and re-fetches from Supabase
+// (unlike history.ts which is fully client-side; logs may be large so we
+// filter server-side).
+
+// --- Pure, DOM-free helpers (unit-tested) ------------------------------------
+
+export interface LogsState {
+  dateFrom: string;
+  dateTo: string;
+  level: LogLevel | null;
+  category: string;
+  topic_slug: string;
+  page: number;
+}
+
+/** Parse `?dateFrom=&dateTo=&level=&category=&topic_slug=&page=` into LogsState. */
+export function parseLogsState(search: string): LogsState {
+  const params = new URLSearchParams(search.startsWith("?") ? search.slice(1) : search);
+  const defaults = defaultLogsFilter();
+  const level = params.get("level");
+  return {
+    dateFrom: params.get("dateFrom") ?? defaults.dateFrom,
+    dateTo: params.get("dateTo") ?? defaults.dateTo,
+    level: (level === "info" || level === "warn" || level === "error") ? level : null,
+    category: params.get("category") ?? "",
+    topic_slug: params.get("topic_slug") ?? "",
+    page: Math.max(0, Number.parseInt(params.get("page") ?? "0", 10) || 0),
+  };
+}
+
+/** Serialize a LogsState to a search string. dateFrom/dateTo are always emitted for
+ *  shareability; optional fields are omitted when empty/default. */
+export function serializeLogsState(state: LogsState): string {
+  const params = new URLSearchParams();
+  params.set("dateFrom", state.dateFrom);
+  params.set("dateTo", state.dateTo);
+  if (state.level) params.set("level", state.level);
+  if (state.category.trim()) params.set("category", state.category.trim());
+  if (state.topic_slug.trim()) params.set("topic_slug", state.topic_slug.trim());
+  if (state.page > 0) params.set("page", String(state.page));
+  return `?${params.toString()}`;
+}
+
+/** Level badge CSS class name. */
+export function levelClass(level: string): string {
+  if (level === "error") return "log-level log-level--error";
+  if (level === "warn") return "log-level log-level--warn";
+  return "log-level log-level--info";
+}
+
+/** Format an ISO timestamp to a short local date-time string. */
+export function formatTimestamp(iso: string): string {
+  const d = new Date(iso);
+  if (Number.isNaN(d.getTime())) return iso;
+  try {
+    return d.toLocaleString(undefined, {
+      year: "numeric",
+      month: "2-digit",
+      day: "2-digit",
+      hour: "2-digit",
+      minute: "2-digit",
+      second: "2-digit",
+    });
+  } catch {
+    return iso;
+  }
+}
+
+/** Render metadata JSON as a pretty-printed string, or "—" if empty. */
+export function prettyMetadata(metadata: unknown): string {
+  if (metadata === null || metadata === undefined) return "—";
+  try {
+    return JSON.stringify(metadata, null, 2);
+  } catch {
+    return String(metadata);
+  }
+}
+
+// --- DOM rendering -----------------------------------------------------------
+
+function readState(): LogsState {
+  return parseLogsState(window.location.search);
+}
+
+function writeState(state: LogsState): void {
+  const search = serializeLogsState(state);
+  const url = `${window.location.pathname}${search}${window.location.hash}`;
+  window.history.replaceState(null, "", url);
+}
+
+function renderRow(log: SystemLog): HTMLTableRowElement {
+  const tr = document.createElement("tr");
+  tr.setAttribute("data-testid", "log-row");
+  tr.setAttribute("data-log-id", log.id);
+
+  // Timestamp
+  const tdTs = document.createElement("td");
+  tdTs.className = "log-ts";
+  tdTs.textContent = formatTimestamp(log.timestamp);
+  tr.appendChild(tdTs);
+
+  // Level badge
+  const tdLevel = document.createElement("td");
+  const badge = document.createElement("span");
+  badge.className = levelClass(log.level);
+  badge.textContent = log.level;
+  tdLevel.appendChild(badge);
+  tr.appendChild(tdLevel);
+
+  // Category
+  const tdCat = document.createElement("td");
+  tdCat.className = "log-category";
+  tdCat.textContent = log.category;
+  tr.appendChild(tdCat);
+
+  // Topic slug
+  const tdTopic = document.createElement("td");
+  tdTopic.className = "log-topic";
+  tdTopic.textContent = log.topic_slug ?? "—";
+  tr.appendChild(tdTopic);
+
+  // Message
+  const tdMsg = document.createElement("td");
+  tdMsg.className = "log-message";
+  tdMsg.textContent = log.message;
+  tr.appendChild(tdMsg);
+
+  // Metadata — collapsible via <details>
+  const tdMeta = document.createElement("td");
+  tdMeta.className = "log-meta";
+  const pretty = prettyMetadata(log.metadata);
+  if (pretty === "—") {
+    tdMeta.textContent = "—";
+  } else {
+    const details = document.createElement("details");
+    details.className = "log-meta-details";
+    const summary = document.createElement("summary");
+    summary.textContent = "view";
+    details.appendChild(summary);
+    const pre = document.createElement("pre");
+    pre.className = "log-meta-pre";
+    pre.textContent = pretty;
+    details.appendChild(pre);
+    tdMeta.appendChild(details);
+  }
+  tr.appendChild(tdMeta);
+
+  return tr;
+}
+
+function renderTable(rows: SystemLog[]): HTMLElement {
+  const wrap = document.createElement("div");
+  wrap.className = "logs-table-wrap";
+
+  const table = document.createElement("table");
+  table.className = "logs-table";
+  table.setAttribute("data-testid", "logs-table");
+
+  const thead = document.createElement("thead");
+  const headRow = document.createElement("tr");
+  for (const label of ["Timestamp", "Level", "Category", "Topic", "Message", "Metadata"]) {
+    const th = document.createElement("th");
+    th.textContent = label;
+    headRow.appendChild(th);
+  }
+  thead.appendChild(headRow);
+  table.appendChild(thead);
+
+  const tbody = document.createElement("tbody");
+  if (rows.length === 0) {
+    const tr = document.createElement("tr");
+    const td = document.createElement("td");
+    td.setAttribute("colspan", "6");
+    td.className = "empty-state";
+    td.textContent = "No log entries match these filters.";
+    tr.appendChild(td);
+    tbody.appendChild(tr);
+  } else {
+    for (const row of rows) {
+      tbody.appendChild(renderRow(row));
+    }
+  }
+  table.appendChild(tbody);
+  wrap.appendChild(table);
+  return wrap;
+}
+
+interface FilterBar {
+  el: HTMLElement;
+  sync: (state: LogsState) => void;
+}
+
+function buildFilterBar(initial: LogsState, onChange: (next: LogsState) => void): FilterBar {
+  const bar = document.createElement("div");
+  bar.className = "logs-filters";
+  bar.setAttribute("data-testid", "logs-filters");
+
+  // Date range — from
+  const dateFromLabel = document.createElement("label");
+  dateFromLabel.textContent = "From";
+  dateFromLabel.setAttribute("for", "logs-date-from");
+  dateFromLabel.className = "logs-filter-label";
+  const dateFrom = document.createElement("input");
+  dateFrom.type = "datetime-local";
+  dateFrom.id = "logs-date-from";
+  dateFrom.className = "logs-filter-input";
+  dateFrom.setAttribute("data-testid", "filter-date-from");
+  dateFrom.value = toDatetimeLocal(initial.dateFrom);
+  dateFrom.setAttribute("aria-label", "Logs from date");
+
+  // Date range — to
+  const dateToLabel = document.createElement("label");
+  dateToLabel.textContent = "To";
+  dateToLabel.setAttribute("for", "logs-date-to");
+  dateToLabel.className = "logs-filter-label";
+  const dateTo = document.createElement("input");
+  dateTo.type = "datetime-local";
+  dateTo.id = "logs-date-to";
+  dateTo.className = "logs-filter-input";
+  dateTo.setAttribute("data-testid", "filter-date-to");
+  dateTo.value = toDatetimeLocal(initial.dateTo);
+  dateTo.setAttribute("aria-label", "Logs to date");
+
+  // Level
+  const levelSelect = document.createElement("select");
+  levelSelect.className = "logs-filter-select";
+  levelSelect.setAttribute("data-testid", "filter-level");
+  levelSelect.setAttribute("aria-label", "Filter by log level");
+  for (const [value, label] of [["", "All levels"], ["info", "Info"], ["warn", "Warn"], ["error", "Error"]] as const) {
+    const opt = document.createElement("option");
+    opt.value = value;
+    opt.textContent = label;
+    levelSelect.appendChild(opt);
+  }
+  levelSelect.value = initial.level ?? "";
+
+  // Category
+  const categoryInput = document.createElement("input");
+  categoryInput.type = "text";
+  categoryInput.className = "logs-filter-input";
+  categoryInput.setAttribute("data-testid", "filter-category");
+  categoryInput.setAttribute("aria-label", "Filter by category");
+  categoryInput.placeholder = "Category…";
+  categoryInput.value = initial.category;
+
+  // Topic slug
+  const topicInput = document.createElement("input");
+  topicInput.type = "text";
+  topicInput.className = "logs-filter-input";
+  topicInput.setAttribute("data-testid", "filter-topic-slug");
+  topicInput.setAttribute("aria-label", "Filter by topic slug");
+  topicInput.placeholder = "Topic slug…";
+  topicInput.value = initial.topic_slug;
+
+  const applyButton = document.createElement("button");
+  applyButton.type = "button";
+  applyButton.className = "logs-filter-apply";
+  applyButton.setAttribute("data-testid", "filter-apply");
+  applyButton.textContent = "Apply";
+
+  bar.append(
+    dateFromLabel, dateFrom,
+    dateToLabel, dateTo,
+    levelSelect,
+    categoryInput,
+    topicInput,
+    applyButton,
+  );
+
+  const collect = (): LogsState => ({
+    dateFrom: fromDatetimeLocal(dateFrom.value) || readState().dateFrom,
+    dateTo: fromDatetimeLocal(dateTo.value) || readState().dateTo,
+    level: (levelSelect.value as LogLevel) || null,
+    category: categoryInput.value,
+    topic_slug: topicInput.value,
+    page: 0, // reset to first page on any filter change
+  });
+
+  applyButton.addEventListener("click", () => onChange(collect()));
+  // Also fire on Enter in text inputs.
+  for (const input of [categoryInput, topicInput]) {
+    input.addEventListener("keydown", (e) => {
+      if (e.key === "Enter") onChange(collect());
+    });
+  }
+  // Level select fires immediately.
+  levelSelect.addEventListener("change", () => onChange(collect()));
+
+  const sync = (state: LogsState) => {
+    dateFrom.value = toDatetimeLocal(state.dateFrom);
+    dateTo.value = toDatetimeLocal(state.dateTo);
+    levelSelect.value = state.level ?? "";
+    categoryInput.value = state.category;
+    topicInput.value = state.topic_slug;
+  };
+
+  return { el: bar, sync };
+}
+
+function renderPager(
+  state: LogsState,
+  hasMore: boolean,
+  onChange: (next: LogsState) => void,
+): HTMLElement {
+  const pager = document.createElement("div");
+  pager.className = "logs-pager";
+  pager.setAttribute("data-testid", "logs-pager");
+
+  const prev = document.createElement("button");
+  prev.type = "button";
+  prev.textContent = "← Prev";
+  prev.disabled = state.page === 0;
+  prev.setAttribute("data-testid", "pager-prev");
+  prev.addEventListener("click", () => onChange({ ...state, page: state.page - 1 }));
+
+  const info = document.createElement("span");
+  info.className = "logs-pager-info";
+  const first = state.page * LOG_PAGE_SIZE + 1;
+  const lastApprox = state.page * LOG_PAGE_SIZE + LOG_PAGE_SIZE;
+  info.textContent = hasMore
+    ? `Rows ${first}–${lastApprox}`
+    : `Rows ${first}+`;
+
+  const next = document.createElement("button");
+  next.type = "button";
+  next.textContent = "Next →";
+  next.disabled = !hasMore;
+  next.setAttribute("data-testid", "pager-next");
+  next.addEventListener("click", () => onChange({ ...state, page: state.page + 1 }));
+
+  pager.append(prev, info, next);
+  return pager;
+}
+
+/** Convert ISO string to `datetime-local` input format (`YYYY-MM-DDTHH:MM`). */
+function toDatetimeLocal(iso: string): string {
+  try {
+    const d = new Date(iso);
+    const pad = (n: number) => String(n).padStart(2, "0");
+    return `${d.getFullYear()}-${pad(d.getMonth() + 1)}-${pad(d.getDate())}T${pad(d.getHours())}:${pad(d.getMinutes())}`;
+  } catch {
+    return "";
+  }
+}
+
+/** Convert `datetime-local` value back to an ISO string (local timezone). */
+function fromDatetimeLocal(value: string): string {
+  if (!value) return "";
+  try {
+    return new Date(value).toISOString();
+  } catch {
+    return "";
+  }
+}
+
+export async function renderLogs(root: HTMLElement, client: SupabaseClient): Promise<void> {
+  if (!(await isAuthenticatedAtRequiredLevel(client))) {
+    renderAuthGate(root, client);
+    return;
+  }
+
+  root.replaceChildren();
+
+  // Header
+  const header = document.createElement("header");
+  header.className = "app-header";
+  const title = document.createElement("h1");
+  title.textContent = "Logs";
+  header.appendChild(title);
+
+  const nav = document.createElement("nav");
+  nav.className = "app-nav";
+  const homeLink = document.createElement("a");
+  homeLink.href = "#/";
+  homeLink.textContent = "Today";
+  nav.appendChild(homeLink);
+  const historyLink = document.createElement("a");
+  historyLink.href = "#/history";
+  historyLink.textContent = "History";
+  nav.appendChild(historyLink);
+  const out = document.createElement("button");
+  out.type = "button";
+  out.className = "sign-out";
+  out.textContent = "Sign out";
+  out.addEventListener("click", () => {
+    void (async () => {
+      await signOut(client);
+      window.location.hash = "#/";
+      window.location.reload();
+    })();
+  });
+  nav.appendChild(out);
+  header.appendChild(nav);
+  root.appendChild(header);
+
+  const main = document.createElement("main");
+  main.className = "app-main";
+  main.setAttribute("data-testid", "logs-content");
+  root.appendChild(main);
+
+  // Build filter bar once; onChange triggers a re-fetch.
+  let currentState = readState();
+  const bar = buildFilterBar(currentState, (next) => {
+    currentState = next;
+    writeState(next);
+    bar.sync(next);
+    void load(next);
+  });
+  main.appendChild(bar.el);
+
+  const contentArea = document.createElement("div");
+  contentArea.setAttribute("data-testid", "logs-results");
+  main.appendChild(contentArea);
+
+  async function load(state: LogsState): Promise<void> {
+    contentArea.replaceChildren();
+    const loading = document.createElement("p");
+    loading.textContent = "Loading logs…";
+    contentArea.appendChild(loading);
+
+    try {
+      const { rows, hasMore } = await fetchLogs(client, {
+        dateFrom: state.dateFrom,
+        dateTo: state.dateTo,
+        level: state.level,
+        category: state.category,
+        topic_slug: state.topic_slug,
+        page: state.page,
+      });
+
+      contentArea.replaceChildren();
+
+      const pagerTop = renderPager(state, hasMore, (next) => {
+        currentState = next;
+        writeState(next);
+        bar.sync(next);
+        void load(next);
+      });
+      contentArea.appendChild(pagerTop);
+      contentArea.appendChild(renderTable(rows));
+
+      // Bottom pager only if there's content.
+      if (rows.length > 0) {
+        const pagerBot = renderPager(state, hasMore, (next) => {
+          currentState = next;
+          writeState(next);
+          bar.sync(next);
+          void load(next);
+          window.scrollTo({ top: 0 });
+        });
+        contentArea.appendChild(pagerBot);
+      }
+    } catch (err) {
+      contentArea.replaceChildren();
+      const msg = document.createElement("p");
+      msg.className = "error-state";
+      msg.textContent = `Could not load logs: ${(err as Error).message}`;
+      contentArea.appendChild(msg);
+    }
+  }
+
+  void load(currentState);
+}

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -607,3 +607,223 @@ button:disabled {
     background: rgba(77, 142, 240, 0.07);
   }
 }
+
+/* ── Logs page (#27) ──────────────────────────────────────────────────────── */
+
+/* Filter bar */
+.logs-filters {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: flex-end;
+  gap: 0.5rem 0.6rem;
+  margin: 0.5rem 0 1.25rem;
+}
+
+.logs-filter-label {
+  font-size: 0.82rem;
+  font-weight: 600;
+  color: var(--muted);
+  letter-spacing: .03em;
+  /* stack label above its input */
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+}
+
+.logs-filter-input,
+.logs-filter-select {
+  font: inherit;
+  min-height: 44px;
+  padding: 0.5rem 0.85rem;
+  border: 1.5px solid var(--border);
+  border-radius: 999px;
+  background: var(--card);
+  color: var(--fg);
+  font-size: 0.9rem;
+  box-shadow: var(--elevation);
+}
+
+.logs-filter-input:focus,
+.logs-filter-select:focus {
+  outline: 2px solid transparent;
+  border-color: var(--accent);
+  box-shadow: var(--accent-glow);
+}
+
+.logs-filter-apply {
+  /* inherits base button styles; override just the sizing for inline use */
+  padding: 0.5rem 1rem;
+  font-size: 0.9rem;
+}
+
+/* Table wrapper — horizontal scroll on narrow viewports */
+.logs-table-wrap {
+  width: 100%;
+  overflow-x: auto;
+  -webkit-overflow-scrolling: touch;
+  border-radius: var(--radius);
+  box-shadow: var(--elevation);
+  margin: 0.75rem 0;
+}
+
+.logs-table {
+  width: 100%;
+  border-collapse: collapse;
+  background: var(--card);
+  font-size: 0.85rem;
+  min-width: 640px; /* forces scroll before text wraps badly */
+}
+
+.logs-table th {
+  text-align: left;
+  font-size: 0.78rem;
+  font-weight: 700;
+  letter-spacing: .05em;
+  text-transform: uppercase;
+  color: var(--muted);
+  padding: 0.6rem 0.75rem;
+  border-bottom: 1px solid var(--border);
+  white-space: nowrap;
+  background: var(--card);
+  position: sticky;
+  top: 0;
+  z-index: 1;
+}
+
+.logs-table td {
+  padding: 0.55rem 0.75rem;
+  vertical-align: top;
+  border-bottom: 1px solid var(--border);
+  color: var(--fg);
+}
+
+.logs-table tbody tr:last-child td {
+  border-bottom: none;
+}
+
+.logs-table tbody tr:hover td {
+  background: rgba(26, 86, 219, 0.04);
+}
+
+@media (prefers-color-scheme: dark) {
+  .logs-table tbody tr:hover td {
+    background: rgba(77, 142, 240, 0.06);
+  }
+}
+
+/* Timestamp column */
+.log-ts {
+  white-space: nowrap;
+  font-size: 0.82rem;
+  color: var(--muted);
+  font-variant-numeric: tabular-nums;
+}
+
+/* Level badge */
+.log-level {
+  display: inline-block;
+  padding: 0.15rem 0.55rem;
+  border-radius: 999px;
+  font-size: 0.75rem;
+  font-weight: 700;
+  letter-spacing: .04em;
+  text-transform: uppercase;
+  white-space: nowrap;
+}
+
+.log-level--info {
+  background: rgba(26, 86, 219, 0.12);
+  color: var(--accent);
+}
+
+.log-level--warn {
+  background: rgba(214, 158, 46, 0.15);
+  color: #b7751a;
+}
+
+.log-level--error {
+  background: rgba(197, 48, 48, 0.12);
+  color: #c53030;
+}
+
+@media (prefers-color-scheme: dark) {
+  .log-level--info  { background: rgba(77, 142, 240, 0.18); color: var(--accent); }
+  .log-level--warn  { background: rgba(246, 173, 85, 0.18); color: #f6ad55; }
+  .log-level--error { background: rgba(252, 129, 129, 0.18); color: #fc8181; }
+}
+
+/* Category / topic / message */
+.log-category,
+.log-topic {
+  white-space: nowrap;
+  font-size: 0.83rem;
+}
+
+.log-message {
+  min-width: 12rem;
+  word-break: break-word;
+}
+
+/* Metadata collapsible */
+.log-meta {
+  min-width: 5rem;
+}
+
+.log-meta-details > summary {
+  cursor: pointer;
+  color: var(--accent);
+  font-size: 0.82rem;
+  font-weight: 600;
+  list-style: none;
+  user-select: none;
+  min-height: 28px;
+  display: flex;
+  align-items: center;
+}
+
+.log-meta-details > summary::-webkit-details-marker {
+  display: none;
+}
+
+.log-meta-details > summary:focus-visible {
+  outline: 2px solid transparent;
+  box-shadow: var(--accent-glow);
+  border-radius: 4px;
+}
+
+.log-meta-pre {
+  margin: 0.4rem 0 0;
+  padding: 0.5rem 0.65rem;
+  background: var(--bg);
+  border: 1px solid var(--border);
+  border-radius: calc(var(--radius) - 4px);
+  font-size: 0.78rem;
+  font-family: ui-monospace, "SF Mono", "Cascadia Code", monospace;
+  white-space: pre-wrap;
+  word-break: break-all;
+  max-width: 28rem;
+  max-height: 14rem;
+  overflow: auto;
+  -webkit-overflow-scrolling: touch;
+}
+
+/* Pagination controls */
+.logs-pager {
+  display: flex;
+  align-items: center;
+  gap: 1rem;
+  margin: 0.5rem 0;
+}
+
+.logs-pager button {
+  padding: 0.4rem 0.9rem;
+  font-size: 0.88rem;
+  min-height: 40px;
+}
+
+.logs-pager-info {
+  font-size: 0.85rem;
+  color: var(--muted);
+  flex: 1;
+  text-align: center;
+}

--- a/web/tests/unit/logs.test.ts
+++ b/web/tests/unit/logs.test.ts
@@ -1,10 +1,15 @@
 import { describe, expect, it } from "vitest";
 import {
+  FALLBACK_TOPIC_SLUGS,
   formatTimestamp,
+  fromDatetimeLocal,
   levelClass,
+  LOG_CATEGORIES,
+  pagerLabel,
   parseLogsState,
   prettyMetadata,
   serializeLogsState,
+  toDatetimeLocal,
   type LogsState,
 } from "../../src/pages/logs";
 import {
@@ -282,5 +287,90 @@ describe("defaultLogsFilter", () => {
     expect(f.level).toBeNull();
     expect(f.category).toBe("");
     expect(f.topic_slug).toBe("");
+  });
+});
+
+// --- LOG_CATEGORIES / FALLBACK_TOPIC_SLUGS (select option sources) ------------
+
+describe("LOG_CATEGORIES", () => {
+  it("matches the agent's canonical Category literals (src/news_digest/logging.py)", () => {
+    expect([...LOG_CATEGORIES]).toEqual([
+      "schedule",
+      "scrape",
+      "summarize",
+      "publish",
+      "feedback",
+      "hello_world",
+      "system",
+    ]);
+  });
+
+  it("contains no duplicates or blanks", () => {
+    expect(new Set(LOG_CATEGORIES).size).toBe(LOG_CATEGORIES.length);
+    expect(LOG_CATEGORIES.every((c) => c.trim().length > 0)).toBe(true);
+  });
+});
+
+describe("FALLBACK_TOPIC_SLUGS", () => {
+  it("covers the five known digest topics", () => {
+    expect([...FALLBACK_TOPIC_SLUGS].sort()).toEqual([
+      "ai_models",
+      "ai_updates",
+      "local_news",
+      "penguins",
+      "world_news",
+    ]);
+  });
+});
+
+// --- toDatetimeLocal / fromDatetimeLocal --------------------------------------
+
+describe("toDatetimeLocal", () => {
+  it("formats a valid ISO string as YYYY-MM-DDTHH:MM", () => {
+    expect(toDatetimeLocal("2026-06-01T12:30:00.000Z")).toMatch(
+      /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}$/,
+    );
+  });
+
+  it("returns empty string for unparseable input (no NaN-NaN-NaN output)", () => {
+    expect(toDatetimeLocal("not-a-date")).toBe("");
+    expect(toDatetimeLocal("")).toBe("");
+  });
+});
+
+describe("fromDatetimeLocal", () => {
+  it("converts a datetime-local value to an ISO string", () => {
+    const iso = fromDatetimeLocal("2026-06-01T12:30");
+    expect(iso).toMatch(/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}/);
+    expect(Number.isNaN(new Date(iso).getTime())).toBe(false);
+  });
+
+  it("returns empty string for empty or unparseable input", () => {
+    expect(fromDatetimeLocal("")).toBe("");
+    expect(fromDatetimeLocal("garbage")).toBe("");
+  });
+
+  it("round-trips with toDatetimeLocal to the same minute", () => {
+    const local = "2026-06-01T12:30";
+    expect(toDatetimeLocal(fromDatetimeLocal(local))).toBe(local);
+  });
+});
+
+// --- pagerLabel ----------------------------------------------------------------
+
+describe("pagerLabel", () => {
+  it("shows 'No rows' for an empty page", () => {
+    expect(pagerLabel(0, 0)).toBe("No rows");
+    expect(pagerLabel(3, 0)).toBe("No rows");
+  });
+
+  it("shows the actual row range on page 0", () => {
+    expect(pagerLabel(0, 100)).toBe("Rows 1–100");
+    expect(pagerLabel(0, 7)).toBe("Rows 1–7");
+  });
+
+  it("offsets the range by the page number", () => {
+    expect(pagerLabel(1, 100)).toBe("Rows 101–200");
+    expect(pagerLabel(2, 42)).toBe("Rows 201–242");
   });
 });

--- a/web/tests/unit/logs.test.ts
+++ b/web/tests/unit/logs.test.ts
@@ -1,0 +1,286 @@
+import { describe, expect, it } from "vitest";
+import {
+  formatTimestamp,
+  levelClass,
+  parseLogsState,
+  prettyMetadata,
+  serializeLogsState,
+  type LogsState,
+} from "../../src/pages/logs";
+import {
+  defaultLogsFilter,
+  LOG_PAGE_SIZE,
+  logsQuery,
+  type LogsFilter,
+} from "../../src/lib/query";
+
+// --- parseLogsState / serializeLogsState ------------------------------------
+
+describe("parseLogsState", () => {
+  it("returns defaults when no params present", () => {
+    const state = parseLogsState("");
+    expect(state.level).toBeNull();
+    expect(state.category).toBe("");
+    expect(state.topic_slug).toBe("");
+    expect(state.page).toBe(0);
+    // dateFrom / dateTo should be non-empty strings (ISO datetimes)
+    expect(state.dateFrom).toMatch(/^\d{4}-\d{2}-\d{2}T/);
+    expect(state.dateTo).toMatch(/^\d{4}-\d{2}-\d{2}T/);
+  });
+
+  it("parses level, category, topic_slug, page", () => {
+    const state = parseLogsState("?level=error&category=scraper&topic_slug=ai_models&page=3");
+    expect(state.level).toBe("error");
+    expect(state.category).toBe("scraper");
+    expect(state.topic_slug).toBe("ai_models");
+    expect(state.page).toBe(3);
+  });
+
+  it("rejects invalid level values", () => {
+    const state = parseLogsState("?level=debug");
+    expect(state.level).toBeNull();
+  });
+
+  it("clamps page to 0 for negative / non-numeric values", () => {
+    expect(parseLogsState("?page=-5").page).toBe(0);
+    expect(parseLogsState("?page=abc").page).toBe(0);
+  });
+
+  it("parses all three valid log levels", () => {
+    expect(parseLogsState("?level=info").level).toBe("info");
+    expect(parseLogsState("?level=warn").level).toBe("warn");
+    expect(parseLogsState("?level=error").level).toBe("error");
+  });
+});
+
+describe("serializeLogsState", () => {
+  // Use fixed ISO strings so tests are deterministic (dateFrom/dateTo always emitted)
+  const fixedState: LogsState = {
+    dateFrom: "2026-06-01T00:00:00.000Z",
+    dateTo: "2026-06-02T00:00:00.000Z",
+    level: null,
+    category: "",
+    topic_slug: "",
+    page: 0,
+  };
+
+  it("always emits dateFrom and dateTo", () => {
+    const s = serializeLogsState(fixedState);
+    expect(s).toContain("dateFrom=");
+    expect(s).toContain("dateTo=");
+  });
+
+  it("includes level when set", () => {
+    const s = serializeLogsState({ ...fixedState, level: "warn" });
+    expect(s).toContain("level=warn");
+  });
+
+  it("omits level when null", () => {
+    expect(serializeLogsState(fixedState)).not.toContain("level=");
+  });
+
+  it("includes category when non-empty", () => {
+    const s = serializeLogsState({ ...fixedState, category: "publisher" });
+    expect(s).toContain("category=publisher");
+  });
+
+  it("omits category when blank", () => {
+    expect(serializeLogsState({ ...fixedState, category: "  " })).not.toContain("category=");
+  });
+
+  it("includes topic_slug when non-empty", () => {
+    const s = serializeLogsState({ ...fixedState, topic_slug: "penguins" });
+    expect(s).toContain("topic_slug=penguins");
+  });
+
+  it("includes page when > 0", () => {
+    const s = serializeLogsState({ ...fixedState, page: 2 });
+    expect(s).toContain("page=2");
+  });
+
+  it("omits page when 0", () => {
+    expect(serializeLogsState(fixedState)).not.toContain("page=");
+  });
+
+  it("round-trips through serialize -> parse", () => {
+    const state: LogsState = {
+      dateFrom: "2026-06-01T00:00:00.000Z",
+      dateTo: "2026-06-10T23:59:59.000Z",
+      level: "error",
+      category: "scraper",
+      topic_slug: "ai_models",
+      page: 4,
+    };
+    const parsed = parseLogsState(serializeLogsState(state));
+    expect(parsed.dateFrom).toBe(state.dateFrom);
+    expect(parsed.dateTo).toBe(state.dateTo);
+    expect(parsed.level).toBe(state.level);
+    expect(parsed.category).toBe(state.category);
+    expect(parsed.topic_slug).toBe(state.topic_slug);
+    expect(parsed.page).toBe(state.page);
+  });
+});
+
+// --- levelClass -------------------------------------------------------------
+
+describe("levelClass", () => {
+  it("returns error class for error level", () => {
+    expect(levelClass("error")).toContain("log-level--error");
+  });
+
+  it("returns warn class for warn level", () => {
+    expect(levelClass("warn")).toContain("log-level--warn");
+  });
+
+  it("returns info class for info level (and any unknown level)", () => {
+    expect(levelClass("info")).toContain("log-level--info");
+    expect(levelClass("debug")).toContain("log-level--info");
+  });
+
+  it("always includes the base log-level class", () => {
+    for (const l of ["info", "warn", "error"]) {
+      expect(levelClass(l)).toContain("log-level");
+    }
+  });
+});
+
+// --- formatTimestamp ---------------------------------------------------------
+
+describe("formatTimestamp", () => {
+  it("returns a non-empty string for a valid ISO timestamp", () => {
+    const result = formatTimestamp("2026-06-01T12:30:00.000Z");
+    expect(result).toBeTruthy();
+    expect(result.length).toBeGreaterThan(0);
+  });
+
+  it("returns the original string when parsing fails", () => {
+    expect(formatTimestamp("not-a-date")).toBe("not-a-date");
+  });
+});
+
+// --- prettyMetadata ----------------------------------------------------------
+
+describe("prettyMetadata", () => {
+  it("returns '—' for null", () => {
+    expect(prettyMetadata(null)).toBe("—");
+  });
+
+  it("returns '—' for undefined", () => {
+    expect(prettyMetadata(undefined)).toBe("—");
+  });
+
+  it("returns a pretty-printed JSON string for an object", () => {
+    const result = prettyMetadata({ key: "value", n: 42 });
+    expect(result).toContain('"key"');
+    expect(result).toContain('"value"');
+    expect(result).toContain("42");
+  });
+
+  it("pretty-prints arrays", () => {
+    const result = prettyMetadata([1, 2, 3]);
+    expect(result).toContain("1");
+    expect(result).toContain("2");
+  });
+});
+
+// --- logsQuery --------------------------------------------------------------
+
+describe("logsQuery", () => {
+  const base: LogsFilter = {
+    dateFrom: "2026-06-01T00:00:00.000Z",
+    dateTo: "2026-06-10T23:59:59.000Z",
+    level: null,
+    category: "",
+    topic_slug: "",
+    page: 0,
+  };
+
+  it("targets the system_logs table", () => {
+    expect(logsQuery(base).table).toBe("system_logs");
+  });
+
+  it("selects expected columns", () => {
+    const q = logsQuery(base);
+    expect(q.columns).toContain("id");
+    expect(q.columns).toContain("timestamp");
+    expect(q.columns).toContain("level");
+    expect(q.columns).toContain("category");
+    expect(q.columns).toContain("topic_slug");
+    expect(q.columns).toContain("message");
+    expect(q.columns).toContain("metadata");
+  });
+
+  it("orders by timestamp descending", () => {
+    const q = logsQuery(base);
+    expect(q.order.column).toBe("timestamp");
+    expect(q.order.ascending).toBe(false);
+  });
+
+  it("page 0 maps to range 0–99", () => {
+    expect(logsQuery(base).range).toEqual({ from: 0, to: LOG_PAGE_SIZE - 1 });
+  });
+
+  it("page 1 maps to range 100–199", () => {
+    expect(logsQuery({ ...base, page: 1 }).range).toEqual({
+      from: LOG_PAGE_SIZE,
+      to: 2 * LOG_PAGE_SIZE - 1,
+    });
+  });
+
+  it("passes dateFrom / dateTo through filters", () => {
+    const q = logsQuery(base);
+    expect(q.filters.dateFrom).toBe(base.dateFrom);
+    expect(q.filters.dateTo).toBe(base.dateTo);
+  });
+
+  it("converts empty level to null in filters", () => {
+    expect(logsQuery({ ...base, level: null }).filters.level).toBeNull();
+  });
+
+  it("keeps non-null level in filters", () => {
+    expect(logsQuery({ ...base, level: "warn" }).filters.level).toBe("warn");
+  });
+
+  it("converts blank category to null in filters", () => {
+    expect(logsQuery({ ...base, category: "  " }).filters.category).toBeNull();
+  });
+
+  it("trims and keeps non-blank category", () => {
+    expect(logsQuery({ ...base, category: " scraper " }).filters.category).toBe("scraper");
+  });
+
+  it("converts blank topic_slug to null in filters", () => {
+    expect(logsQuery({ ...base, topic_slug: "" }).filters.topic_slug).toBeNull();
+  });
+
+  it("trims and keeps non-blank topic_slug", () => {
+    expect(logsQuery({ ...base, topic_slug: " ai_models " }).filters.topic_slug).toBe("ai_models");
+  });
+});
+
+// --- defaultLogsFilter ------------------------------------------------------
+
+describe("defaultLogsFilter", () => {
+  it("defaults to page 0", () => {
+    expect(defaultLogsFilter().page).toBe(0);
+  });
+
+  it("dateTo is later than dateFrom", () => {
+    const f = defaultLogsFilter();
+    expect(new Date(f.dateTo).getTime()).toBeGreaterThan(new Date(f.dateFrom).getTime());
+  });
+
+  it("date window is approximately 24 hours", () => {
+    const f = defaultLogsFilter();
+    const diffMs = new Date(f.dateTo).getTime() - new Date(f.dateFrom).getTime();
+    const diffHours = diffMs / (1000 * 60 * 60);
+    expect(diffHours).toBeCloseTo(24, 0);
+  });
+
+  it("defaults to null level / empty category / empty topic_slug", () => {
+    const f = defaultLogsFilter();
+    expect(f.level).toBeNull();
+    expect(f.category).toBe("");
+    expect(f.topic_slug).toBe("");
+  });
+});


### PR DESCRIPTION
## Summary

- New page at `#/logs` (`web/src/pages/logs.ts`) with server-side filtered, paginated view of the `system_logs` Supabase table
- Auth-gated: `isAuthenticatedAtRequiredLevel` check mirrors the home/history pages; unauthenticated users see the auth gate
- Filters: date range (default last 24h), level (info/warn/error), category, topic\_slug — all update URL search params (`?dateFrom=&dateTo=&level=&category=&topic_slug=&page=`) so the view is shareable/bookmarkable
- Pagination: 100 rows per page, prev/next controls with disabled states at boundaries
- Metadata column: collapsible `<details>`/`<pre>` with pretty-printed JSON; shows "—" when empty
- Mobile-friendly: horizontal-scrolling table wrapper (`overflow-x: auto; -webkit-overflow-scrolling: touch`), 44px touch targets on all controls, same design token language as the rest of the app
- Nav updated: "Logs" link added to home and history page nav bars

## New files

| File | Purpose |
|------|---------|
| `web/src/pages/logs.ts` | Page implementation + exported pure helpers |
| `web/tests/unit/logs.test.ts` | 40 unit tests covering parse/serialize state, levelClass, formatTimestamp, prettyMetadata, logsQuery, defaultLogsFilter |

## Modified files

| File | Change |
|------|--------|
| `web/src/lib/types.ts` | Added `SystemLog` interface matching `system_logs` schema |
| `web/src/lib/query.ts` | Added `logsQuery`, `defaultLogsFilter`, `LogsFilter`, `LogsQuerySpec`, `LogLevel`, `LOG_PAGE_SIZE` |
| `web/src/lib/supabase.ts` | Added `fetchLogs` (server-side filtered, paginated) |
| `web/src/main.ts` | Registered `#/logs` route |
| `web/src/pages/home.ts` | Added Logs nav link |
| `web/src/pages/history.ts` | Added Logs nav link |
| `web/src/styles.css` | Added ~220 lines of logs-specific styles |

## Test evidence

```
Tests  236 passed (236)   ← up from 196 baseline
```

lint: `eslint . && tsc --noEmit` → clean
build: `vite build` → clean (11.5 kB CSS, 46 kB JS gzip 13.9 kB)

Closes #27