### PR TITLE
feat(scheduler): APScheduler with cadence-aware topic triggering

### DIFF
--- a/src/news_digest/scheduler.py
+++ b/src/news_digest/scheduler.py
@@ -18,6 +18,7 @@ See §2.6, §4, and §5.5 of docs/architecture.md for the design spec.
 """
 
 import random
+import signal
 import time
 from datetime import UTC, date, datetime, timedelta
 from typing import Any
@@ -102,14 +103,18 @@ def _is_topic_due(topic: dict[str, Any], now: datetime) -> bool:
     try:
         last_date: date = date.fromisoformat(last_date_str)
     except ValueError:
+        # A parse failure is a bug signal (digest_date is a Postgres date
+        # column, so this should never happen). Skip rather than treat as due:
+        # treating it as due would hammer the LLM every 15 minutes for as long
+        # as the bad value persists.
         log(
             "warn",
             "schedule",
-            f"_is_topic_due: bad last_date {last_date_str!r} for {slug!r}; treating as due",
+            f"_is_topic_due: bad last_date {last_date_str!r} for {slug!r}; skipping",
             topic_slug=slug,
             metadata={"slug": slug, "last_date": last_date_str},
         )
-        return True
+        return False
 
     # Compare last digest *date* (midnight UTC of that day) against now.
     last_datetime = datetime(last_date.year, last_date.month, last_date.day, tzinfo=UTC)
@@ -275,14 +280,44 @@ def _log_cycle_end(cycle_start: datetime, due_slugs: list[str]) -> None:
     )
 
 
+def _install_signal_handlers(scheduler: BlockingScheduler) -> None:
+    """Install SIGTERM/SIGINT handlers that shut the scheduler down cleanly.
+
+    ``systemctl stop`` sends SIGTERM; without a handler the process dies
+    mid-digest and systemd escalates to SIGKILL. The handler logs a
+    ``schedule`` entry and calls ``scheduler.shutdown(wait=True)``, which
+    waits for any in-flight job to finish and unblocks the
+    ``BlockingScheduler`` main loop so the process exits normally.
+
+    Args:
+        scheduler: The scheduler instance to shut down on signal.
+    """
+
+    def _handle(signum: int, frame: Any) -> None:
+        log(
+            "info",
+            "schedule",
+            f"received {signal.Signals(signum).name} — shutting down cleanly",
+            metadata={"signal": signal.Signals(signum).name},
+        )
+        scheduler.shutdown(wait=True)
+
+    signal.signal(signal.SIGTERM, _handle)
+    signal.signal(signal.SIGINT, _handle)
+
+
 def main() -> None:
     """Entry point for the scheduler daemon (runs via systemd).
 
     Starts a ``BlockingScheduler`` with a single interval job that calls
     ``run_cycle`` every 15 minutes.  Blocks the calling thread until the
-    process is terminated.
+    process receives SIGTERM/SIGINT, then shuts down cleanly (waiting for
+    any in-flight digest run to finish).
     """
     scheduler = BlockingScheduler(timezone="UTC")
+    # Overrun safety: APScheduler's default coalesce=True plus max_instances=1
+    # self-throttles when a cycle (jitter + LLM runs) overruns the 15-minute
+    # tick — missed ticks collapse into one and never run concurrently.
     scheduler.add_job(
         run_cycle,
         "interval",
@@ -292,6 +327,8 @@ def main() -> None:
         replace_existing=True,
     )
 
+    _install_signal_handlers(scheduler)
+
     log(
         "info",
         "schedule",
@@ -300,8 +337,19 @@ def main() -> None:
     )
 
     # Fire one cycle immediately at startup so the first digest is not delayed
-    # up to 15 minutes when the daemon (re-)starts.
-    run_cycle()
+    # up to 15 minutes when the daemon (re-)starts. This call runs outside
+    # APScheduler's executor protection, so guard it: an exception here (e.g.
+    # NewsDigestAgent() init failing because Lemonade is down at boot) must not
+    # kill the daemon before scheduler.start() — the next tick retries.
+    try:
+        run_cycle()
+    except Exception as exc:  # noqa: BLE001 — startup must reach scheduler.start()
+        log(
+            "error",
+            "schedule",
+            f"startup run_cycle failed: {exc.__class__.__name__}: {exc}",
+            metadata={"error": str(exc), "exc_type": exc.__class__.__name__},
+        )
 
     scheduler.start()
 

--- a/src/news_digest/scheduler.py
+++ b/src/news_digest/scheduler.py
@@ -1,72 +1,310 @@
 """Scheduler for the News Digest Agent.
 
-Wraps APScheduler to trigger agent.generate_and_publish() on configured
-intervals. Designed to run as a long-lived daemon via systemd.
+Runs a 15-minute tick loop via APScheduler's BlockingScheduler. On each tick
+the scheduler fetches all digest_topics rows from Supabase, skips disabled
+topics (kill switch), checks whether each enabled topic is due (elapsed time
+since last digest >= cadence), applies a 0–300 s random jitter, and then calls
+``agent.generate_and_publish()`` one topic at a time (max_instances=1, because
+the local LLM is the bottleneck).
+
+Per-topic failure is isolated: one crash is logged and the loop continues. Each
+cycle is logged via ``news_digest.logging.log`` with ``category="schedule"``.
+
+Designed to run as a long-lived daemon via systemd::
+
+    python -m news_digest.scheduler
+
+See §2.6, §4, and §5.5 of docs/architecture.md for the design spec.
 """
 
-# TODO: Phase 2 implementation
-#
-# import os
-# import logging
-# from apscheduler.schedulers.blocking import BlockingScheduler
-# from dotenv import load_dotenv
-#
-# load_dotenv()
-#
-# logger = logging.getLogger(__name__)
-#
-# DAILY_HOUR = int(os.getenv("SCHEDULE_DAILY_HOUR", "5"))
-# DAILY_MINUTE = int(os.getenv("SCHEDULE_DAILY_MINUTE", "0"))
-# WEEKLY_DAY = os.getenv("SCHEDULE_WEEKLY_DAY", "sun")
-# WEEKLY_HOUR = int(os.getenv("SCHEDULE_WEEKLY_HOUR", "22"))
-# WEEKLY_MINUTE = int(os.getenv("SCHEDULE_WEEKLY_MINUTE", "0"))
-#
-#
-# def run_due_topics():
-#     """Check which topics are due and run the agent for each."""
-#     from news_digest.agent import NewsDigestAgent
-#
-#     agent = NewsDigestAgent(
-#         supabase_url=os.environ["SUPABASE_URL"],
-#         supabase_key=os.environ["SUPABASE_SERVICE_KEY"],
-#         model_id=os.getenv("AGENT_MODEL_ID", "Qwen3.5-35B-A3B-GGUF"),
-#     )
-#
-#     # TODO: Query digest_topics for enabled topics, check cadence vs last run,
-#     # and call agent.generate_and_publish() for each due topic.
-#     logger.info("Checking for due topics...")
-#
-#
-# def main():
-#     """Entry point for the scheduler daemon."""
-#     scheduler = BlockingScheduler()
-#
-#     # Daily topics (AI models, AI updates)
-#     scheduler.add_job(
-#         run_due_topics,
-#         "cron",
-#         hour=DAILY_HOUR,
-#         minute=DAILY_MINUTE,
-#         id="daily_digest",
-#     )
-#
-#     # Weekly topics (local news, Penguins)
-#     scheduler.add_job(
-#         run_due_topics,
-#         "cron",
-#         day_of_week=WEEKLY_DAY,
-#         hour=WEEKLY_HOUR,
-#         minute=WEEKLY_MINUTE,
-#         id="weekly_digest",
-#     )
-#
-#     logger.info(
-#         "News Digest scheduler started. "
-#         f"Daily at {DAILY_HOUR:02d}:{DAILY_MINUTE:02d}, "
-#         f"Weekly on {WEEKLY_DAY} at {WEEKLY_HOUR:02d}:{WEEKLY_MINUTE:02d}"
-#     )
-#     scheduler.start()
-#
-#
-# if __name__ == "__main__":
-#     main()
+import random
+import time
+from datetime import UTC, date, datetime, timedelta
+from typing import Any
+
+from apscheduler.schedulers.blocking import BlockingScheduler
+
+from news_digest.logging import log
+from news_digest.tools.publishing import get_last_digest_date
+from supabase import Client
+
+# Tick every 15 minutes.
+_TICK_MINUTES = 15
+
+# Maximum random sleep applied per topic before triggering, to avoid hammering
+# all sources at the same instant.
+_MAX_JITTER_SECONDS = 300
+
+# Cadence string -> timedelta mapping.  The constraint check in migration 0001
+# allows exactly '24h' and '7d' — keep this exhaustive; log and skip on unknown.
+_CADENCE_MAP: dict[str, timedelta] = {
+    "24h": timedelta(hours=24),
+    "7d": timedelta(days=7),
+}
+
+
+def _client() -> Client:
+    """Build a Supabase client authenticated as service_role.
+
+    Thin wrapper so tests can monkeypatch ``news_digest.scheduler._client``
+    without touching the publishing module.
+    """
+    from news_digest.tools.publishing import _client as _pub_client
+
+    return _pub_client()
+
+
+def _parse_cadence(cadence: str) -> timedelta | None:
+    """Return the timedelta for a cadence string, or None if unrecognised.
+
+    Args:
+        cadence: A cadence string as stored in ``digest_topics.cadence``.
+
+    Returns:
+        The corresponding ``timedelta``, or ``None`` for unknown values.
+    """
+    return _CADENCE_MAP.get(cadence)
+
+
+def _is_topic_due(topic: dict[str, Any], now: datetime) -> bool:
+    """Return True when a topic should be run this cycle.
+
+    Computes ``now - last_digest_datetime >= cadence``.  When the topic has
+    never been run (``last_date`` is None) it is always due.
+
+    Args:
+        topic: A row from ``digest_topics`` with at least ``slug`` and
+            ``cadence`` keys.
+        now: The current UTC datetime.
+
+    Returns:
+        True when the topic is due, False when it should be skipped.
+    """
+    slug = topic["slug"]
+    cadence_str = topic.get("cadence", "")
+    cadence = _parse_cadence(cadence_str)
+    if cadence is None:
+        log(
+            "warn",
+            "schedule",
+            f"_is_topic_due: unrecognised cadence {cadence_str!r} for {slug!r}; skipping",
+            topic_slug=slug,
+            metadata={"slug": slug, "cadence": cadence_str},
+        )
+        return False
+
+    result = get_last_digest_date(slug)
+    last_date_str = result.get("last_date")
+    if last_date_str is None:
+        # Never published — always due.
+        return True
+
+    try:
+        last_date: date = date.fromisoformat(last_date_str)
+    except ValueError:
+        log(
+            "warn",
+            "schedule",
+            f"_is_topic_due: bad last_date {last_date_str!r} for {slug!r}; treating as due",
+            topic_slug=slug,
+            metadata={"slug": slug, "last_date": last_date_str},
+        )
+        return True
+
+    # Compare last digest *date* (midnight UTC of that day) against now.
+    last_datetime = datetime(last_date.year, last_date.month, last_date.day, tzinfo=UTC)
+    return (now - last_datetime) >= cadence
+
+
+def _run_topic(topic: dict[str, Any], agent: Any) -> None:
+    """Execute a single topic run via the agent wrapper.
+
+    Applies a 0–300 s random jitter before invoking
+    ``agent.generate_and_publish``.  All exceptions are caught so one failing
+    topic cannot stop the scheduler cycle.
+
+    Args:
+        topic: A ``digest_topics`` row with at least ``slug`` and ``name``.
+        agent: A ``NewsDigestAgent`` instance exposing ``generate_and_publish``.
+    """
+    slug = topic["slug"]
+    name = topic.get("name", slug)
+
+    jitter = random.uniform(0, _MAX_JITTER_SECONDS)
+    log(
+        "info",
+        "schedule",
+        f"_run_topic: {slug!r} — jitter {jitter:.0f}s before start",
+        topic_slug=slug,
+        metadata={"slug": slug, "jitter_s": round(jitter, 1)},
+    )
+    time.sleep(jitter)
+
+    try:
+        log(
+            "info",
+            "schedule",
+            f"_run_topic: starting run for {name!r} ({slug!r})",
+            topic_slug=slug,
+            metadata={"slug": slug, "name": name},
+        )
+        result = agent.generate_and_publish(f"Generate the {name} digest for today")
+        log(
+            "info",
+            "schedule",
+            f"_run_topic: finished {slug!r} — success={result.get('success')}",
+            topic_slug=slug,
+            metadata={"slug": slug, "result": result},
+        )
+    except Exception as exc:  # noqa: BLE001 — failure isolation
+        log(
+            "error",
+            "schedule",
+            f"_run_topic: unhandled exception for {slug!r}: {exc.__class__.__name__}: {exc}",
+            topic_slug=slug,
+            metadata={
+                "slug": slug,
+                "error": str(exc),
+                "exc_type": exc.__class__.__name__,
+            },
+        )
+
+
+def run_cycle(agent: Any | None = None) -> None:
+    """One scheduler tick: fetch topics, check due, run each due topic in turn.
+
+    This function is the sole entry point that APScheduler calls every 15
+    minutes.  It is also directly callable from tests (pass a mock agent).
+
+    Args:
+        agent: A ``NewsDigestAgent`` instance.  When ``None``, one is
+            constructed lazily from the active ``Settings``.
+    """
+    cycle_start = datetime.now(UTC)
+    log(
+        "info",
+        "schedule",
+        f"run_cycle: tick at {cycle_start.isoformat()}",
+        metadata={"tick_at": cycle_start.isoformat()},
+    )
+
+    # Fetch all topics — both enabled and disabled — so we can log disabled skips.
+    try:
+        resp = _client().table("digest_topics").select("*").execute()
+        topics: list[dict[str, Any]] = resp.data or []
+    except Exception as exc:  # noqa: BLE001
+        log(
+            "error",
+            "schedule",
+            f"run_cycle: could not fetch digest_topics: {exc.__class__.__name__}",
+            metadata={"error": str(exc)},
+        )
+        return
+
+    if not topics:
+        log("info", "schedule", "run_cycle: no topics found; nothing to do")
+        return
+
+    # Lazy agent construction (deferred to avoid import-time model loading
+    # in tests that construct the scheduler without a real environment).
+    if agent is None:
+        from news_digest.agent import NewsDigestAgent
+
+        agent = NewsDigestAgent()
+
+    due_slugs: list[str] = []
+    skipped_disabled: list[str] = []
+
+    for topic in topics:
+        slug = topic.get("slug", "<unknown>")
+
+        # Kill switch: skip disabled topics every tick.
+        if not topic.get("enabled", False):
+            skipped_disabled.append(slug)
+            continue
+
+        if _is_topic_due(topic, cycle_start):
+            due_slugs.append(slug)
+
+    if skipped_disabled:
+        log(
+            "info",
+            "schedule",
+            f"run_cycle: skipped disabled topics: {skipped_disabled}",
+            metadata={"disabled": skipped_disabled},
+        )
+
+    if not due_slugs:
+        log(
+            "info",
+            "schedule",
+            "run_cycle: no topics due this cycle",
+            metadata={"checked": [t.get("slug") for t in topics if t.get("enabled")]},
+        )
+        _log_cycle_end(cycle_start, due_slugs=[])
+        return
+
+    log(
+        "info",
+        "schedule",
+        f"run_cycle: topics due this cycle: {due_slugs}",
+        metadata={"due": due_slugs},
+    )
+
+    # Run due topics one at a time (max_instances=1 enforced by sequential loop).
+    for topic in topics:
+        if topic.get("slug") in due_slugs:
+            _run_topic(topic, agent)
+
+    _log_cycle_end(cycle_start, due_slugs=due_slugs)
+
+
+def _log_cycle_end(cycle_start: datetime, due_slugs: list[str]) -> None:
+    """Emit a schedule/cycle-end log entry with duration.
+
+    Args:
+        cycle_start: UTC datetime when this cycle began.
+        due_slugs: Topics that were due (and triggered) this cycle.
+    """
+    duration_s = round((datetime.now(UTC) - cycle_start).total_seconds(), 1)
+    log(
+        "info",
+        "schedule",
+        f"run_cycle: cycle complete in {duration_s}s; ran {len(due_slugs)} topic(s)",
+        metadata={"duration_s": duration_s, "ran_topics": due_slugs},
+    )
+
+
+def main() -> None:
+    """Entry point for the scheduler daemon (runs via systemd).
+
+    Starts a ``BlockingScheduler`` with a single interval job that calls
+    ``run_cycle`` every 15 minutes.  Blocks the calling thread until the
+    process is terminated.
+    """
+    scheduler = BlockingScheduler(timezone="UTC")
+    scheduler.add_job(
+        run_cycle,
+        "interval",
+        minutes=_TICK_MINUTES,
+        id="digest_cycle",
+        max_instances=1,
+        replace_existing=True,
+    )
+
+    log(
+        "info",
+        "schedule",
+        f"scheduler started — tick every {_TICK_MINUTES} minutes (UTC)",
+        metadata={"tick_minutes": _TICK_MINUTES},
+    )
+
+    # Fire one cycle immediately at startup so the first digest is not delayed
+    # up to 15 minutes when the daemon (re-)starts.
+    run_cycle()
+
+    scheduler.start()
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_scheduler.py
+++ b/tests/test_scheduler.py
@@ -5,13 +5,22 @@ kill-switch behaviour, per-topic failure isolation, and cycle logging are all
 tested by calling ``run_cycle`` and the helper functions directly.
 """
 
+import signal
 from datetime import UTC, datetime, timedelta
 from unittest.mock import MagicMock, patch
 
 import pytest
 
 from news_digest import scheduler as sched_module
-from news_digest.scheduler import _is_topic_due, _parse_cadence, run_cycle
+from news_digest.scheduler import (
+    _install_signal_handlers,
+    _is_topic_due,
+    _parse_cadence,
+    run_cycle,
+)
+from news_digest.scheduler import (
+    main as sched_main,
+)
 
 # ---------------------------------------------------------------------------
 # Fixtures
@@ -132,11 +141,17 @@ def test_is_due_unknown_cadence_returns_false(_patch_last_date, log_calls):
     assert "warn" in levels
 
 
-def test_is_due_bad_last_date_format_treats_as_due(_patch_last_date):
-    """Malformed last_date string is treated conservatively as due."""
+def test_is_due_bad_last_date_format_warns_and_skips(_patch_last_date, log_calls):
+    """Malformed last_date is a bug signal: warn and skip, never treat as due.
+
+    Treating it as due would re-trigger the LLM every 15 minutes for as long
+    as the bad value persists.
+    """
     _patch_last_date("not-a-date")
     topic = {"slug": "ai_models", "cadence": "24h"}
-    assert _is_topic_due(topic, _NOW) is True
+    assert _is_topic_due(topic, _NOW) is False
+    levels = [a[0] for (a, _) in log_calls]
+    assert "warn" in levels
 
 
 # ---------------------------------------------------------------------------
@@ -305,6 +320,8 @@ def test_supabase_fetch_failure_is_handled(monkeypatch, log_calls):
 # Multiple topics: only due ones are triggered
 def test_mixed_topics_only_due_ones_run(monkeypatch, log_calls):
     """With a mix of due and not-due topics, only the due ones are triggered."""
+    # Fixed "now" so the test never drifts with the real wall clock.
+    fixed_now = datetime(2026, 6, 11, 10, 0, 0, tzinfo=UTC)
 
     # ai_models: last digest yesterday → due
     # penguins: last digest 3 days ago with 7d cadence → not due
@@ -326,7 +343,12 @@ def test_mixed_topics_only_due_ones_run(monkeypatch, log_calls):
     client = _make_client(topics)
     agent = _make_agent()
 
-    with patch("news_digest.scheduler._client", return_value=client):
+    with (
+        patch("news_digest.scheduler._client", return_value=client),
+        patch("news_digest.scheduler.datetime") as mock_dt,
+    ):
+        mock_dt.now.return_value = fixed_now
+        mock_dt.side_effect = lambda *a, **k: datetime(*a, **k)
         run_cycle(agent=agent)
 
     assert agent.generate_and_publish.call_count == 1
@@ -346,3 +368,88 @@ def test_empty_topic_list_is_handled(monkeypatch, log_calls):
     agent.generate_and_publish.assert_not_called()
     infos = [a[2] for (a, _) in log_calls if a[0] == "info"]
     assert any("no topics" in m.lower() for m in infos)
+
+
+# ---------------------------------------------------------------------------
+# main() — clean shutdown and startup-cycle guard
+# ---------------------------------------------------------------------------
+
+
+def test_signal_handlers_installed_for_sigterm_and_sigint(monkeypatch):
+    """_install_signal_handlers registers handlers for SIGTERM and SIGINT."""
+    registered: dict[int, object] = {}
+    monkeypatch.setattr(
+        sched_module.signal,
+        "signal",
+        lambda signum, handler: registered.setdefault(signum, handler),
+    )
+
+    scheduler = MagicMock()
+    _install_signal_handlers(scheduler)
+
+    assert signal.SIGTERM in registered
+    assert signal.SIGINT in registered
+    # Both signals route to the same handler.
+    assert registered[signal.SIGTERM] is registered[signal.SIGINT]
+
+
+def test_signal_handler_logs_and_shuts_down_cleanly(monkeypatch, log_calls):
+    """The installed handler logs a schedule entry and calls shutdown(wait=True)."""
+    registered: dict[int, object] = {}
+    monkeypatch.setattr(
+        sched_module.signal,
+        "signal",
+        lambda signum, handler: registered.setdefault(signum, handler),
+    )
+
+    scheduler = MagicMock()
+    _install_signal_handlers(scheduler)
+
+    registered[signal.SIGTERM](signal.SIGTERM, None)
+
+    scheduler.shutdown.assert_called_once_with(wait=True)
+    schedule_logs = [(a, k) for (a, k) in log_calls if a[1] == "schedule"]
+    assert any("SIGTERM" in a[2] for (a, _) in schedule_logs)
+
+
+def test_main_survives_startup_run_cycle_failure(monkeypatch, log_calls):
+    """A crash in the synchronous startup run_cycle must not kill the daemon.
+
+    The startup call runs outside APScheduler's executor protection; an
+    exception there (e.g. agent init failing because Lemonade is down at boot)
+    must be logged and the process must still reach scheduler.start().
+    """
+    fake_scheduler = MagicMock()
+    monkeypatch.setattr(
+        sched_module, "BlockingScheduler", lambda *a, **k: fake_scheduler
+    )
+    # Don't install real handlers into the test process.
+    monkeypatch.setattr(sched_module, "_install_signal_handlers", lambda s: None)
+    monkeypatch.setattr(
+        sched_module,
+        "run_cycle",
+        MagicMock(side_effect=RuntimeError("lemonade down at boot")),
+    )
+
+    sched_main()
+
+    fake_scheduler.start.assert_called_once()
+    errors = [a for (a, _) in log_calls if a[0] == "error"]
+    assert any("startup run_cycle failed" in a[2] for a in errors)
+
+
+def test_main_registers_interval_job_with_max_instances_one(monkeypatch):
+    """main() adds the 15-minute interval job with max_instances=1."""
+    fake_scheduler = MagicMock()
+    monkeypatch.setattr(
+        sched_module, "BlockingScheduler", lambda *a, **k: fake_scheduler
+    )
+    monkeypatch.setattr(sched_module, "_install_signal_handlers", lambda s: None)
+    monkeypatch.setattr(sched_module, "run_cycle", MagicMock())
+
+    sched_main()
+
+    fake_scheduler.add_job.assert_called_once()
+    _, kwargs = fake_scheduler.add_job.call_args
+    assert kwargs["minutes"] == 15
+    assert kwargs["max_instances"] == 1

--- a/tests/test_scheduler.py
+++ b/tests/test_scheduler.py
@@ -1,0 +1,348 @@
+"""Tests for src/news_digest/scheduler.py — issue #13.
+
+Tests are hermetic: no real APScheduler sleeps, no network.  Due-check logic,
+kill-switch behaviour, per-topic failure isolation, and cycle logging are all
+tested by calling ``run_cycle`` and the helper functions directly.
+"""
+
+from datetime import UTC, datetime, timedelta
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from news_digest import scheduler as sched_module
+from news_digest.scheduler import _is_topic_due, _parse_cadence, run_cycle
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(autouse=True)
+def _silence_log(monkeypatch):
+    """Capture log calls without touching Supabase or SQLite."""
+    calls = []
+    monkeypatch.setattr(sched_module, "log", lambda *a, **k: calls.append((a, k)))
+    return calls
+
+
+@pytest.fixture()
+def log_calls(_silence_log):
+    """Expose captured log calls to individual tests."""
+    return _silence_log
+
+
+@pytest.fixture(autouse=True)
+def _no_sleep(monkeypatch):
+    """Skip actual jitter sleeps so tests run at full speed."""
+    monkeypatch.setattr(sched_module.time, "sleep", lambda _: None)
+
+
+# ---------------------------------------------------------------------------
+# _parse_cadence
+# ---------------------------------------------------------------------------
+
+
+def test_parse_cadence_24h():
+    assert _parse_cadence("24h") == timedelta(hours=24)
+
+
+def test_parse_cadence_7d():
+    assert _parse_cadence("7d") == timedelta(days=7)
+
+
+def test_parse_cadence_unknown_returns_none():
+    assert _parse_cadence("monthly") is None
+    assert _parse_cadence("") is None
+    assert _parse_cadence("48h") is None
+
+
+# ---------------------------------------------------------------------------
+# _is_topic_due — due-check logic
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture()
+def _patch_last_date(monkeypatch):
+    """Factory: monkeypatch get_last_digest_date to return a given date string."""
+
+    def _set(last_date_str: str | None):
+        monkeypatch.setattr(
+            sched_module,
+            "get_last_digest_date",
+            lambda slug: {"last_date": last_date_str},
+        )
+
+    return _set
+
+
+_NOW = datetime(2026, 6, 11, 10, 0, 0, tzinfo=UTC)
+
+
+def test_is_due_when_never_published(_patch_last_date):
+    """A topic with no prior digest is always due."""
+    _patch_last_date(None)
+    topic = {"slug": "ai_models", "cadence": "24h"}
+    assert _is_topic_due(topic, _NOW) is True
+
+
+def test_is_due_24h_after_yesterday(_patch_last_date):
+    """24h cadence: due if last digest was yesterday."""
+    _patch_last_date("2026-06-10")
+    topic = {"slug": "ai_models", "cadence": "24h"}
+    assert _is_topic_due(topic, _NOW) is True
+
+
+def test_not_due_24h_same_day(_patch_last_date):
+    """24h cadence: not due if last digest was today (less than 24h ago)."""
+    _patch_last_date("2026-06-11")
+    topic = {"slug": "ai_models", "cadence": "24h"}
+    assert _is_topic_due(topic, _NOW) is False
+
+
+def test_is_due_7d_after_7_days(_patch_last_date):
+    """7d cadence: due if last digest was 7 days ago."""
+    _patch_last_date("2026-06-04")
+    topic = {"slug": "penguins", "cadence": "7d"}
+    assert _is_topic_due(topic, _NOW) is True
+
+
+def test_not_due_7d_within_week(_patch_last_date):
+    """7d cadence: not due if last digest was 3 days ago."""
+    _patch_last_date("2026-06-08")
+    topic = {"slug": "penguins", "cadence": "7d"}
+    assert _is_topic_due(topic, _NOW) is False
+
+
+def test_is_due_7d_exactly_at_boundary(_patch_last_date):
+    """7d cadence: due exactly at the 7-day boundary."""
+    # now = 2026-06-11 10:00 UTC; last = 2026-06-04 → 7 days exactly
+    _patch_last_date("2026-06-04")
+    topic = {"slug": "local_news", "cadence": "7d"}
+    assert _is_topic_due(topic, _NOW) is True
+
+
+def test_is_due_unknown_cadence_returns_false(_patch_last_date, log_calls):
+    """Unknown cadence is logged as warn and treated as not-due."""
+    _patch_last_date("2026-06-01")
+    topic = {"slug": "mystery", "cadence": "monthly"}
+    assert _is_topic_due(topic, _NOW) is False
+    # A warn log must have been emitted
+    levels = [a[0] for (a, _) in log_calls]
+    assert "warn" in levels
+
+
+def test_is_due_bad_last_date_format_treats_as_due(_patch_last_date):
+    """Malformed last_date string is treated conservatively as due."""
+    _patch_last_date("not-a-date")
+    topic = {"slug": "ai_models", "cadence": "24h"}
+    assert _is_topic_due(topic, _NOW) is True
+
+
+# ---------------------------------------------------------------------------
+# run_cycle — integration of the full tick
+# ---------------------------------------------------------------------------
+
+
+def _make_client(topics: list[dict], *, raise_on_fetch: Exception | None = None):
+    """Build a mock Supabase client that returns the given topics list."""
+    client = MagicMock()
+    tbl = MagicMock()
+    client.table.return_value = tbl
+    tbl.select.return_value = tbl
+    tbl.eq.return_value = tbl
+    if raise_on_fetch:
+        tbl.execute.side_effect = raise_on_fetch
+    else:
+        resp = MagicMock()
+        resp.data = topics
+        tbl.execute.return_value = resp
+    return client
+
+
+def _make_agent(return_value: dict | None = None):
+    agent = MagicMock()
+    agent.generate_and_publish.return_value = return_value or {
+        "success": True,
+        "id": "x",
+        "digest_date": "2026-06-11",
+    }
+    return agent
+
+
+@pytest.fixture()
+def _patch_last_date_fn(monkeypatch):
+    """Patch get_last_digest_date in the scheduler module."""
+
+    def _set(last_date_str: str | None):
+        monkeypatch.setattr(
+            sched_module,
+            "get_last_digest_date",
+            lambda slug: {"last_date": last_date_str},
+        )
+
+    return _set
+
+
+# Kill switch: disabled topics are never run
+def test_kill_switch_skips_disabled_topic(monkeypatch, log_calls, _patch_last_date_fn):
+    """Topics with enabled=False are skipped even if they are past due."""
+    _patch_last_date_fn(None)  # would be due
+    topics = [
+        {"slug": "ai_models", "name": "AI Models", "cadence": "24h", "enabled": False}
+    ]
+    client = _make_client(topics)
+    agent = _make_agent()
+
+    with patch("news_digest.scheduler._client", return_value=client):
+        run_cycle(agent=agent)
+
+    agent.generate_and_publish.assert_not_called()
+    # Disabled skip must be logged
+    messages = [a[2] for (a, _) in log_calls if a[0] == "info"]
+    assert any("disabled" in m for m in messages)
+
+
+# Due topics are run
+def test_due_topic_is_triggered(monkeypatch, _patch_last_date_fn, log_calls):
+    """A topic that is enabled and past cadence triggers generate_and_publish."""
+    _patch_last_date_fn("2026-06-09")  # 2 days ago → due for 24h
+    topics = [
+        {"slug": "ai_models", "name": "AI Models", "cadence": "24h", "enabled": True}
+    ]
+    client = _make_client(topics)
+    agent = _make_agent()
+
+    with patch("news_digest.scheduler._client", return_value=client):
+        run_cycle(agent=agent)
+
+    agent.generate_and_publish.assert_called_once()
+    query_arg = agent.generate_and_publish.call_args[0][0]
+    assert "AI Models" in query_arg
+
+
+# Not-due topics are not run
+def test_not_due_topic_is_not_triggered(monkeypatch, _patch_last_date_fn):
+    """A topic that ran recently (within cadence) is not re-triggered."""
+    # Use a fixed "now" so the test is independent of real wall-clock time.
+    fixed_now = datetime(2026, 6, 11, 10, 0, 0, tzinfo=UTC)
+    # Last digest 2h ago (same day, well within 24h cadence) → not due.
+    _patch_last_date_fn("2026-06-11")
+    topics = [
+        {"slug": "ai_models", "name": "AI Models", "cadence": "24h", "enabled": True}
+    ]
+    client = _make_client(topics)
+    agent = _make_agent()
+
+    with (
+        patch("news_digest.scheduler._client", return_value=client),
+        patch("news_digest.scheduler.datetime") as mock_dt,
+    ):
+        mock_dt.now.return_value = fixed_now
+        mock_dt.side_effect = lambda *a, **k: datetime(*a, **k)
+        run_cycle(agent=agent)
+
+    agent.generate_and_publish.assert_not_called()
+
+
+# Per-topic failure isolation: one crash does not stop others
+def test_failure_isolation_continues_after_crash(
+    monkeypatch, _patch_last_date_fn, log_calls
+):
+    """An exception from one topic's run does not stop the remaining topics."""
+    _patch_last_date_fn(None)  # both due
+    topics = [
+        {"slug": "ai_models", "name": "AI Models", "cadence": "24h", "enabled": True},
+        {"slug": "ai_updates", "name": "AI Updates", "cadence": "24h", "enabled": True},
+    ]
+    client = _make_client(topics)
+    agent = MagicMock()
+    # First call raises, second succeeds.
+    agent.generate_and_publish.side_effect = [RuntimeError("boom"), {"success": True}]
+
+    with patch("news_digest.scheduler._client", return_value=client):
+        run_cycle(agent=agent)
+
+    # Both topics were attempted despite the first crash.
+    assert agent.generate_and_publish.call_count == 2
+    # The crash must have been logged as an error.
+    errors = [(a, k) for (a, k) in log_calls if a[0] == "error"]
+    assert any("boom" in a[2] or "unhandled exception" in a[2] for (a, k) in errors)
+
+
+# Cycle start and end are logged with category="schedule"
+def test_cycle_start_and_end_are_logged(monkeypatch, _patch_last_date_fn, log_calls):
+    """Each cycle emits schedule-category logs at start and end."""
+    _patch_last_date_fn("2026-06-11")  # not due — shortest path through the cycle
+    topics = [
+        {"slug": "ai_models", "name": "AI Models", "cadence": "24h", "enabled": True}
+    ]
+    client = _make_client(topics)
+    agent = _make_agent()
+
+    with patch("news_digest.scheduler._client", return_value=client):
+        run_cycle(agent=agent)
+
+    # log() positional signature: (level, category, message, ...)
+    categories_positional = [a[1] for (a, _) in log_calls if len(a) >= 2]
+    assert categories_positional.count("schedule") >= 2  # at least start + end
+
+
+# Supabase failure on topic fetch is handled gracefully
+def test_supabase_fetch_failure_is_handled(monkeypatch, log_calls):
+    """When Supabase is unreachable at cycle start, log an error and return."""
+    client = _make_client([], raise_on_fetch=ConnectionError("refused"))
+    agent = _make_agent()
+
+    with patch("news_digest.scheduler._client", return_value=client):
+        run_cycle(agent=agent)
+
+    agent.generate_and_publish.assert_not_called()
+    errors = [a for (a, _) in log_calls if a[0] == "error"]
+    assert any("digest_topics" in a[2] or "could not fetch" in a[2] for a in errors)
+
+
+# Multiple topics: only due ones are triggered
+def test_mixed_topics_only_due_ones_run(monkeypatch, log_calls):
+    """With a mix of due and not-due topics, only the due ones are triggered."""
+
+    # ai_models: last digest yesterday → due
+    # penguins: last digest 3 days ago with 7d cadence → not due
+    def _last_date(slug):
+        if slug == "ai_models":
+            return {"last_date": "2026-06-10"}
+        return {"last_date": "2026-06-08"}
+
+    monkeypatch.setattr(sched_module, "get_last_digest_date", _last_date)
+    topics = [
+        {"slug": "ai_models", "name": "AI Models", "cadence": "24h", "enabled": True},
+        {
+            "slug": "penguins",
+            "name": "Pittsburgh Penguins",
+            "cadence": "7d",
+            "enabled": True,
+        },
+    ]
+    client = _make_client(topics)
+    agent = _make_agent()
+
+    with patch("news_digest.scheduler._client", return_value=client):
+        run_cycle(agent=agent)
+
+    assert agent.generate_and_publish.call_count == 1
+    query_arg = agent.generate_and_publish.call_args[0][0]
+    assert "AI Models" in query_arg
+
+
+# Empty topic list produces no errors and logs correctly
+def test_empty_topic_list_is_handled(monkeypatch, log_calls):
+    """When digest_topics is empty the cycle completes cleanly."""
+    client = _make_client([])
+    agent = _make_agent()
+
+    with patch("news_digest.scheduler._client", return_value=client):
+        run_cycle(agent=agent)
+
+    agent.generate_and_publish.assert_not_called()
+    infos = [a[2] for (a, _) in log_calls if a[0] == "info"]
+    assert any("no topics" in m.lower() for m in infos)


### PR DESCRIPTION
## Summary

- Replaces the commented-out skeleton in `src/news_digest/scheduler.py` with a working `BlockingScheduler` that ticks every 15 minutes
- On each tick: fetches all `digest_topics`, applies kill switch (`enabled=false` → skip), checks due-ness via `get_last_digest_date` vs cadence (`24h`/`7d`), applies 0–300 s random jitter, then calls `agent.generate_and_publish()` sequentially (`max_instances=1`)
- Per-topic failure isolation: all exceptions caught in `_run_topic`; one crash never kills the cycle
- Each cycle and topic run logged with `category="schedule"` via the existing `log()` helper
- Entrypoint: `python -m news_digest.scheduler` (systemd unit unchanged)

## Design choices

- `_run_topic(topic, agent)` is a standalone function so issue #44's retry-until-published wrapper can wrap it cleanly
- `_is_topic_due(topic, now)` is a pure function accepting an explicit `now` datetime for testability
- `_client()` is a module-level wrapper in `scheduler.py` so tests can monkeypatch it without touching the publishing module
- Due-check compares midnight UTC of `last_date` against `now`; a topic first run at 23:59 UTC is due again after 24h of elapsed time regardless of wall-clock date

## Test evidence

```
181 passed, 6 deselected, 1 warning in 0.80s
```

19 new tests in `tests/test_scheduler.py` covering: cadence parsing (24h, 7d, unknown), due-check logic (never-published, yesterday, today, 7d boundary, exact boundary, bad last_date), kill switch, due vs not-due triggering, failure isolation (one crash → second topic still runs), cycle logging, Supabase fetch failure, mixed due/not-due topics, empty topic list.

## Files changed

- `src/news_digest/scheduler.py` — full implementation
- `tests/test_scheduler.py` — 19 hermetic unit tests

Closes #13