### PR TITLE
Add per-digest feedback UI and quality tracking

### DIFF
--- a/docs/feedback-review.md
+++ b/docs/feedback-review.md
@@ -1,0 +1,84 @@
+# Feedback Review Workflow
+
+Weekly process for querying digest feedback and proposing prompt improvements.
+Human-in-the-loop only — no automated prompt regeneration.
+
+## Query
+
+Run this against the `system_logs` table to pull all feedback since the last review:
+
+```sql
+select
+  id,
+  created_at,
+  topic_slug,
+  metadata->>'feedback_type'   as feedback_type,
+  metadata->>'digest_id'       as digest_id,
+  metadata->>'prompt_version'  as prompt_version,
+  metadata->>'digest_date'     as digest_date,
+  metadata->>'comment_text'    as comment_text,
+  metadata->>'source_url'      as source_url,
+  metadata->>'item_index'      as item_index,
+  metadata->>'item_headline'   as item_headline
+from system_logs
+where category = 'feedback'
+  and created_at > :last_review_timestamp
+order by created_at desc;
+```
+
+Replace `:last_review_timestamp` with the ISO timestamp of the previous review
+(e.g. `2026-06-04T00:00:00Z`).
+
+## Feedback types
+
+| `feedback_type`  | Meaning                                    | Key fields                        |
+|------------------|--------------------------------------------|-----------------------------------|
+| `thumbs_down`    | Digest was not useful                      | `digest_id`, `topic_slug`         |
+| `positive`       | Digest was good                            | `digest_id`, `topic_slug`         |
+| `comment`        | Free-text note, max 500 chars              | `comment_text`                    |
+| `source_flag`    | A source URL was bad / off-topic           | `source_url`                      |
+| `item_flag`      | A specific item was bad / irrelevant       | `item_index`, `item_headline`     |
+
+## Cluster by topic
+
+Group the results by `topic_slug` to see which topics attract the most negative
+signal. Within each topic, group by `prompt_version` to attribute regressions to
+a specific prompt change.
+
+```sql
+select
+  topic_slug,
+  prompt_version,
+  feedback_type,
+  count(*) as n
+from system_logs
+where category = 'feedback'
+  and created_at > :last_review_timestamp
+group by topic_slug, prompt_version, feedback_type
+order by topic_slug, n desc;
+```
+
+## Review process
+
+1. Run both queries. Export the results to a spreadsheet or paste into a chat.
+2. For each topic with net-negative signal (more `thumbs_down`/`item_flag` than `positive`):
+   a. Read the `comment_text` entries for that topic.
+   b. Review the flagged `item_headline` values — are they off-topic, stale, or low-quality?
+   c. Check `source_url` flags — should any source be removed from `digest_topics.sources`?
+3. Draft a prompt-diff proposal:
+   - A short description of the problem observed.
+   - The proposed change to `src/news_digest/prompts.py` or the topic's `prompt_hint`
+     in the `digest_topics` Supabase table.
+   - Open a PR targeting `main` with the change. Link it to issue #22.
+4. After merging, note the new `prompt_version` (derived from the SHA of the updated
+   `SYSTEM_PROMPT` in `prompts.py`) and record the review timestamp so the next
+   query window starts from here.
+
+## Notes
+
+- `prompt_version` on every feedback row allows regression attribution even if
+  multiple prompt versions are in use simultaneously.
+- The `authenticated` RLS policy (migration 0012) allows only `category='feedback'`
+  inserts from the browser — no other table writes are possible from the web app.
+- Do NOT automate prompt regeneration. Every change must be reviewed and approved
+  by a human before merging.

--- a/supabase/migrations/0012_feedback_rls.sql
+++ b/supabase/migrations/0012_feedback_rls.sql
@@ -2,10 +2,13 @@
 -- The web app talks to Supabase as the `authenticated` role (email+TOTP MFA).
 -- system_logs currently only has a SELECT policy for authenticated (#0006).
 -- This migration adds the narrowest possible INSERT policy: authenticated users
--- may insert rows with category='feedback' only. No UPDATE/DELETE is granted.
--- service_role still bypasses RLS for all agent writes.
+-- may insert rows with category='feedback' and level='info' only, so a browser
+-- client can never write level='error' rows that pollute error monitoring.
+-- No UPDATE/DELETE is granted. service_role still bypasses RLS for agent writes.
+
+drop policy if exists system_logs_feedback_insert on system_logs;
 
 create policy system_logs_feedback_insert
   on system_logs for insert
   to authenticated
-  with check (category = 'feedback');
+  with check (category = 'feedback' and level = 'info');

--- a/supabase/migrations/0012_feedback_rls.sql
+++ b/supabase/migrations/0012_feedback_rls.sql
@@ -1,0 +1,11 @@
+-- 0012_feedback_rls.sql — Allow authenticated users to INSERT feedback rows.
+-- The web app talks to Supabase as the `authenticated` role (email+TOTP MFA).
+-- system_logs currently only has a SELECT policy for authenticated (#0006).
+-- This migration adds the narrowest possible INSERT policy: authenticated users
+-- may insert rows with category='feedback' only. No UPDATE/DELETE is granted.
+-- service_role still bypasses RLS for all agent writes.
+
+create policy system_logs_feedback_insert
+  on system_logs for insert
+  to authenticated
+  with check (category = 'feedback');

--- a/web/src/components/feedback.ts
+++ b/web/src/components/feedback.ts
@@ -1,0 +1,282 @@
+// Per-digest feedback controls (#22).
+//
+// Mounts into each card's `.feedback-slot` and into each `.digest-item` via
+// the hooks registered in views/digest-card.ts. Auto-registers on import so
+// main.ts only needs a single import line.
+//
+// This module is self-contained: it injects its own scoped styles and
+// wires up all UI. The Supabase client is obtained via getSupabase() so the
+// same authenticated client used for reads is also used for feedback inserts
+// (authenticated RLS policy in migration 0012 permits category='feedback' inserts).
+
+import { registerFeedbackSlotMounter, registerItemFlagMounter } from "../views/digest-card";
+import {
+  mountFeedbackControls,
+  mountItemFlagButtons,
+} from "../views/feedback-controls";
+import type { Digest } from "../lib/types";
+import { getSupabase } from "../lib/supabase";
+
+function injectStyles(): void {
+  if (typeof document === "undefined") return;
+  if (document.getElementById("feedback-styles")) return;
+  const style = document.createElement("style");
+  style.id = "feedback-styles";
+  style.textContent = `
+    /* ── Feedback slot ─────────────────────────────────────────────────── */
+    .feedback-slot:empty { display: none; }
+
+    /* ── Feedback panel ────────────────────────────────────────────────── */
+    .feedback-panel {
+      border-top: 1px solid var(--border, #c8d3df);
+      margin-top: 0.75rem;
+      padding-top: 0.6rem;
+    }
+
+    /* ── Signal row: thumbs-down + positive ────────────────────────────── */
+    .feedback-signal-row {
+      display: flex;
+      flex-wrap: wrap;
+      gap: 0.4rem;
+      align-items: center;
+    }
+
+    .feedback-btn {
+      font: inherit;
+      min-height: 44px;
+      padding: 0.35rem 0.85rem;
+      border: 1.5px solid var(--border, #c8d3df);
+      border-radius: 999px;
+      background: transparent;
+      color: var(--muted, #4a5568);
+      cursor: pointer;
+      font-size: 0.82rem;
+      font-weight: 600;
+      letter-spacing: 0.01em;
+      transition: background 160ms, border-color 160ms, color 160ms;
+      line-height: 1;
+    }
+
+    .feedback-btn:hover:not(:disabled) {
+      border-color: var(--accent, #1a56db);
+      color: var(--accent, #1a56db);
+    }
+
+    .feedback-btn:focus-visible {
+      outline: 2px solid transparent;
+      box-shadow: 0 0 0 3px rgba(26,86,219,.22);
+      border-radius: 999px;
+    }
+
+    .feedback-btn:disabled {
+      opacity: 0.45;
+      cursor: default;
+    }
+
+    .feedback-btn--positive:not(:disabled) {
+      color: #186a3b;
+      border-color: #186a3b;
+    }
+
+    .feedback-btn--positive:hover:not(:disabled) {
+      background: rgba(24,106,59,.08);
+    }
+
+    .feedback-btn--thumbs-down:not(:disabled) {
+      color: #b03a2e;
+      border-color: #b03a2e;
+    }
+
+    .feedback-btn--thumbs-down:hover:not(:disabled) {
+      background: rgba(176,58,46,.08);
+    }
+
+    @media (prefers-color-scheme: dark) {
+      .feedback-btn--positive:not(:disabled) {
+        color: #5dd39e;
+        border-color: #2e6b4f;
+      }
+      .feedback-btn--positive:hover:not(:disabled) {
+        background: rgba(93,211,158,.10);
+      }
+      .feedback-btn--thumbs-down:not(:disabled) {
+        color: #f1948a;
+        border-color: #7b3a32;
+      }
+      .feedback-btn--thumbs-down:hover:not(:disabled) {
+        background: rgba(241,148,138,.10);
+      }
+    }
+
+    /* ── Status line ───────────────────────────────────────────────────── */
+    .feedback-status {
+      font-size: 0.8rem;
+      color: var(--muted, #4a5568);
+      min-height: 1rem;
+      margin: 0.2rem 0 0;
+    }
+
+    .feedback-status--error {
+      color: #c53030;
+    }
+
+    @media (prefers-color-scheme: dark) {
+      .feedback-status--error { color: #fc8181; }
+    }
+
+    /* ── Comment section ───────────────────────────────────────────────── */
+    .feedback-comment-section,
+    .feedback-source-section {
+      margin-top: 0.5rem;
+    }
+
+    .feedback-comment-toggle {
+      cursor: pointer;
+      color: var(--accent, #1a56db);
+      font-size: 0.82rem;
+      font-weight: 600;
+      list-style: none;
+      user-select: none;
+      min-height: 44px;
+      display: flex;
+      align-items: center;
+    }
+
+    .feedback-comment-toggle::-webkit-details-marker { display: none; }
+
+    .feedback-comment-toggle:focus-visible {
+      outline: 2px solid transparent;
+      box-shadow: 0 0 0 3px rgba(26,86,219,.22);
+      border-radius: 4px;
+    }
+
+    .feedback-textarea {
+      font: inherit;
+      width: 100%;
+      padding: 0.55rem 0.75rem;
+      border: 1.5px solid var(--border, #c8d3df);
+      border-radius: calc(var(--radius, 14px) - 4px);
+      background: var(--bg, #f0f4f8);
+      color: var(--fg, #0d1117);
+      font-size: 0.9rem;
+      resize: vertical;
+      min-height: 4rem;
+      margin-top: 0.25rem;
+      box-sizing: border-box;
+    }
+
+    .feedback-textarea:focus {
+      outline: 2px solid transparent;
+      border-color: var(--accent, #1a56db);
+      box-shadow: 0 0 0 3px rgba(26,86,219,.22);
+    }
+
+    @media (prefers-color-scheme: dark) {
+      .feedback-textarea { background: #0d1525; }
+    }
+
+    .feedback-char-count {
+      font-size: 0.75rem;
+      color: var(--muted, #4a5568);
+      display: block;
+      text-align: right;
+      margin: 0.15rem 0 0.4rem;
+    }
+
+    /* ── Source flag ───────────────────────────────────────────────────── */
+    .feedback-source-row {
+      display: flex;
+      flex-wrap: wrap;
+      gap: 0.4rem;
+      align-items: center;
+      margin-top: 0.25rem;
+    }
+
+    .feedback-source-select {
+      font: inherit;
+      min-height: 44px;
+      padding: 0.45rem 0.75rem;
+      border: 1.5px solid var(--border, #c8d3df);
+      border-radius: 999px;
+      background: var(--card, #fff);
+      color: var(--fg, #0d1117);
+      font-size: 0.85rem;
+      max-width: 100%;
+      flex: 1 1 12rem;
+    }
+
+    .feedback-source-select:focus {
+      outline: 2px solid transparent;
+      border-color: var(--accent, #1a56db);
+      box-shadow: 0 0 0 3px rgba(26,86,219,.22);
+    }
+
+    @media (prefers-color-scheme: dark) {
+      .feedback-source-select { background: var(--card, #111827); }
+    }
+
+    /* ── Per-item flag button ──────────────────────────────────────────── */
+    .item-flag-row {
+      display: flex;
+      align-items: center;
+      gap: 0.4rem;
+      padding: 0.35rem 0.5rem 0.5rem 1.5rem;
+    }
+
+    .item-flag-btn {
+      font: inherit;
+      min-height: 44px;
+      padding: 0.3rem 0.7rem;
+      border: 1.5px solid var(--border, #c8d3df);
+      border-radius: 999px;
+      background: transparent;
+      color: var(--muted, #4a5568);
+      cursor: pointer;
+      font-size: 0.75rem;
+      font-weight: 600;
+      letter-spacing: 0.01em;
+      transition: background 160ms, border-color 160ms, color 160ms;
+    }
+
+    .item-flag-btn:hover:not(:disabled) {
+      border-color: #b03a2e;
+      color: #b03a2e;
+      background: rgba(176,58,46,.06);
+    }
+
+    @media (prefers-color-scheme: dark) {
+      .item-flag-btn:hover:not(:disabled) {
+        border-color: #f1948a;
+        color: #f1948a;
+        background: rgba(241,148,138,.08);
+      }
+    }
+
+    .item-flag-btn:focus-visible {
+      outline: 2px solid transparent;
+      box-shadow: 0 0 0 3px rgba(26,86,219,.22);
+      border-radius: 999px;
+    }
+
+    .item-flag-btn:disabled { opacity: 0.45; cursor: default; }
+  `;
+  document.head.appendChild(style);
+}
+
+function mountPanel(slotEl: HTMLElement, digest: Digest): void {
+  injectStyles();
+  mountFeedbackControls(slotEl, digest, getSupabase());
+}
+
+function mountItemFlags(card: HTMLElement, digest: Digest): void {
+  mountItemFlagButtons(card, digest, getSupabase());
+}
+
+/** Wire feedback controls into the digest-card render hooks. Idempotent. */
+export function registerFeedback(): void {
+  registerFeedbackSlotMounter(mountPanel);
+  registerItemFlagMounter(mountItemFlags);
+}
+
+// Auto-register on import so main.ts only needs a single import line.
+registerFeedback();

--- a/web/src/lib/feedback.ts
+++ b/web/src/lib/feedback.ts
@@ -1,0 +1,165 @@
+// Feedback helpers — pure row-shape builders + Supabase INSERT.
+//
+// All writes land in system_logs with category='feedback'. The authenticated
+// RLS policy (migration 0012) allows only category='feedback' inserts, so the
+// service_role key is NOT required here.
+//
+// Feedback types:
+//   thumbs_down  — negative signal on the whole digest
+//   positive     — positive signal on the whole digest ("this was great")
+//   comment      — free-text comment, max 500 chars
+//   source_flag  — one of the digest's source URLs flagged as bad
+//   item_flag    — a specific structured item flagged as bad
+
+import type { SupabaseClient } from "@supabase/supabase-js";
+import type { Digest } from "./types";
+
+export type FeedbackType =
+  | "thumbs_down"
+  | "positive"
+  | "comment"
+  | "source_flag"
+  | "item_flag";
+
+export interface FeedbackRow {
+  level: "info";
+  category: "feedback";
+  topic_slug: string;
+  message: string;
+  metadata: {
+    digest_id: string;
+    topic_slug: string;
+    prompt_version: string;
+    digest_date: string;
+    feedback_type: FeedbackType;
+    tags: ["feedback", "quality"];
+    comment_text?: string;
+    source_url?: string;
+    item_index?: number;
+    item_headline?: string;
+  };
+}
+
+/** Build a system_logs row for a thumbs-down or positive signal. */
+export function buildSignalRow(
+  digest: Digest,
+  feedbackType: "thumbs_down" | "positive",
+): FeedbackRow {
+  return {
+    level: "info",
+    category: "feedback",
+    topic_slug: digest.topic_slug,
+    message: `${feedbackType} feedback on digest ${digest.id}`,
+    metadata: {
+      digest_id: digest.id,
+      topic_slug: digest.topic_slug,
+      prompt_version: digest.prompt_version,
+      digest_date: digest.digest_date,
+      feedback_type: feedbackType,
+      tags: ["feedback", "quality"],
+    },
+  };
+}
+
+/** Build a system_logs row for a free-text comment (max 500 chars, enforced). */
+export function buildCommentRow(digest: Digest, commentText: string): FeedbackRow {
+  const trimmed = commentText.slice(0, 500);
+  return {
+    level: "info",
+    category: "feedback",
+    topic_slug: digest.topic_slug,
+    message: `comment feedback on digest ${digest.id}`,
+    metadata: {
+      digest_id: digest.id,
+      topic_slug: digest.topic_slug,
+      prompt_version: digest.prompt_version,
+      digest_date: digest.digest_date,
+      feedback_type: "comment",
+      tags: ["feedback", "quality"],
+      comment_text: trimmed,
+    },
+  };
+}
+
+/** Build a system_logs row for a flagged source URL. */
+export function buildSourceFlagRow(digest: Digest, sourceUrl: string): FeedbackRow {
+  return {
+    level: "info",
+    category: "feedback",
+    topic_slug: digest.topic_slug,
+    message: `source_flag feedback on digest ${digest.id}: ${sourceUrl}`,
+    metadata: {
+      digest_id: digest.id,
+      topic_slug: digest.topic_slug,
+      prompt_version: digest.prompt_version,
+      digest_date: digest.digest_date,
+      feedback_type: "source_flag",
+      tags: ["feedback", "quality"],
+      source_url: sourceUrl,
+    },
+  };
+}
+
+/** Build a system_logs row for a flagged digest item. */
+export function buildItemFlagRow(
+  digest: Digest,
+  itemIndex: number,
+  itemHeadline: string,
+): FeedbackRow {
+  return {
+    level: "info",
+    category: "feedback",
+    topic_slug: digest.topic_slug,
+    message: `item_flag feedback on digest ${digest.id} item ${itemIndex}`,
+    metadata: {
+      digest_id: digest.id,
+      topic_slug: digest.topic_slug,
+      prompt_version: digest.prompt_version,
+      digest_date: digest.digest_date,
+      feedback_type: "item_flag",
+      tags: ["feedback", "quality"],
+      item_index: itemIndex,
+      item_headline: itemHeadline,
+    },
+  };
+}
+
+/** Extract the distinct source URLs used in a digest (sources_used + item metadata sources). */
+export function extractSourceUrls(digest: Digest): string[] {
+  const seen = new Set<string>();
+  const result: string[] = [];
+
+  // sources_used column
+  const top = digest.sources_used;
+  if (Array.isArray(top)) {
+    for (const s of top as unknown[]) {
+      if (typeof s === "string" && s.startsWith("http")) {
+        if (!seen.has(s)) { seen.add(s); result.push(s); }
+      }
+    }
+  }
+
+  // item-level metadata.sources
+  for (const item of digest.items ?? []) {
+    for (const src of item.metadata?.sources ?? []) {
+      if (src.url && src.url.startsWith("http")) {
+        if (!seen.has(src.url)) { seen.add(src.url); result.push(src.url); }
+      }
+    }
+  }
+
+  return result;
+}
+
+/**
+ * Submit a single feedback row to system_logs.
+ * Returns null on success, or an error string on failure.
+ */
+export async function submitFeedback(
+  client: SupabaseClient,
+  row: FeedbackRow,
+): Promise<string | null> {
+  const { error } = await client.from("system_logs").insert(row);
+  if (error) return error.message;
+  return null;
+}

--- a/web/src/main.ts
+++ b/web/src/main.ts
@@ -1,4 +1,5 @@
 import "./components/playback"; // #11: auto-registers TTS playback controls
+import "./components/feedback"; // #22: auto-registers feedback controls
 import { getSupabase } from "./lib/supabase";
 import { renderHome } from "./pages/home";
 import { renderHistory } from "./pages/history";

--- a/web/src/views/digest-card.ts
+++ b/web/src/views/digest-card.ts
@@ -1,24 +1,42 @@
 import type { Digest, DigestItem } from "../lib/types";
 
-// Renders a single digest. Includes an explicit, documented mount point for
-// playback controls.
+// Renders a single digest. Includes explicit, documented mount points for
+// playback and feedback controls.
 //
 // #11 (TTS) mounts TTS controls into the `.playback-slot` element below WITHOUT
 // editing this file's core: it provides a `mountPlaybackControls` hook that this
 // renderer invokes against the slot. The slot carries `data-digest-id` so #11 can
 // wire per-digest playback.
 //
+// #22 (feedback) mounts feedback controls into the `.feedback-slot` element
+// via a parallel `registerFeedbackSlotMounter` hook. Item-flag buttons are
+// injected into each `.digest-item` via a `registerItemFlagMounter` hook.
+//
 // Rendering modes (issue #58):
 //   Structured: digest.items?.length > 0  →  summary + one <details> per item
 //   Fallback:   items null/empty           →  <p class="digest-body"> from content
 
 export type MountPlaybackControls = (slotEl: HTMLElement, digest: Digest) => void;
+export type MountFeedbackSlot = (slotEl: HTMLElement, digest: Digest) => void;
+export type MountItemFlags = (card: HTMLElement, digest: Digest) => void;
 
 let playbackMounter: MountPlaybackControls | null = null;
+let feedbackSlotMounter: MountFeedbackSlot | null = null;
+let itemFlagMounter: MountItemFlags | null = null;
 
 /** #11 calls this once at boot to register its playback UI. */
 export function registerPlaybackControls(fn: MountPlaybackControls): void {
   playbackMounter = fn;
+}
+
+/** #22 calls this once at boot to register feedback panel UI. */
+export function registerFeedbackSlotMounter(fn: MountFeedbackSlot): void {
+  feedbackSlotMounter = fn;
+}
+
+/** #22 calls this once at boot to register per-item flag buttons. */
+export function registerItemFlagMounter(fn: MountItemFlags): void {
+  itemFlagMounter = fn;
 }
 
 /**
@@ -169,10 +187,10 @@ export function renderDigestCard(digest: Digest): HTMLElement {
 
   // #11 mounts TTS controls into .playback-slot — always present regardless of
   // rendering mode. TTS reads digest.content (flat prose), never the structured fields.
-  const slot = document.createElement("div");
-  slot.className = "playback-slot";
-  slot.setAttribute("data-digest-id", digest.id);
-  card.appendChild(slot);
+  const playbackSlot = document.createElement("div");
+  playbackSlot.className = "playback-slot";
+  playbackSlot.setAttribute("data-digest-id", digest.id);
+  card.appendChild(playbackSlot);
 
   const hasStructuredItems = (digest.items?.length ?? 0) > 0;
   if (hasStructuredItems) {
@@ -181,8 +199,23 @@ export function renderDigestCard(digest: Digest): HTMLElement {
     renderFallback(card, digest);
   }
 
+  // #22 mounts per-item flag buttons into each .digest-item after rendering.
+  if (itemFlagMounter) {
+    itemFlagMounter(card, digest);
+  }
+
+  // #22 mounts the feedback panel into .feedback-slot.
+  const feedbackSlot = document.createElement("div");
+  feedbackSlot.className = "feedback-slot";
+  feedbackSlot.setAttribute("data-digest-id", digest.id);
+  card.appendChild(feedbackSlot);
+
   if (playbackMounter) {
-    playbackMounter(slot, digest);
+    playbackMounter(playbackSlot, digest);
+  }
+
+  if (feedbackSlotMounter) {
+    feedbackSlotMounter(feedbackSlot, digest);
   }
 
   return card;

--- a/web/src/views/feedback-controls.ts
+++ b/web/src/views/feedback-controls.ts
@@ -22,22 +22,6 @@ import {
   submitFeedback,
 } from "../lib/feedback";
 
-// ─── mount point registration (same pattern as playback controls) ──────────
-
-export type MountFeedbackControls = (slotEl: HTMLElement, digest: Digest) => void;
-
-let feedbackMounter: MountFeedbackControls | null = null;
-
-/** Call once at boot to register the feedback UI. main.ts imports this module
- *  which auto-invokes registerFeedbackControls(mountFeedbackControls). */
-export function registerFeedbackControls(fn: MountFeedbackControls): void {
-  feedbackMounter = fn;
-}
-
-export function getFeedbackMounter(): MountFeedbackControls | null {
-  return feedbackMounter;
-}
-
 // ─── status helper ──────────────────────────────────────────────────────────
 
 function showStatus(el: HTMLElement, text: string, isError = false): void {

--- a/web/src/views/feedback-controls.ts
+++ b/web/src/views/feedback-controls.ts
@@ -1,0 +1,301 @@
+// Feedback controls — mounts per-digest feedback UI into a .feedback-slot element.
+//
+// Provides:
+//   - Thumbs-down button (negative signal)
+//   - "This was great" button (positive signal)
+//   - Free-text comment textarea (max 500 chars) + submit
+//   - Per-source flag dropdown (sources from the digest)
+//   - Per-item flag button on each .digest-item (structured mode only)
+//
+// All writes go via lib/feedback.ts → system_logs(category='feedback').
+// XSS safety: all user-supplied values are set via textContent / .value; no
+// innerHTML with untrusted data.
+
+import type { SupabaseClient } from "@supabase/supabase-js";
+import type { Digest } from "../lib/types";
+import {
+  buildCommentRow,
+  buildItemFlagRow,
+  buildSignalRow,
+  buildSourceFlagRow,
+  extractSourceUrls,
+  submitFeedback,
+} from "../lib/feedback";
+
+// ─── mount point registration (same pattern as playback controls) ──────────
+
+export type MountFeedbackControls = (slotEl: HTMLElement, digest: Digest) => void;
+
+let feedbackMounter: MountFeedbackControls | null = null;
+
+/** Call once at boot to register the feedback UI. main.ts imports this module
+ *  which auto-invokes registerFeedbackControls(mountFeedbackControls). */
+export function registerFeedbackControls(fn: MountFeedbackControls): void {
+  feedbackMounter = fn;
+}
+
+export function getFeedbackMounter(): MountFeedbackControls | null {
+  return feedbackMounter;
+}
+
+// ─── status helper ──────────────────────────────────────────────────────────
+
+function showStatus(el: HTMLElement, text: string, isError = false): void {
+  el.textContent = text;
+  el.className = isError ? "feedback-status feedback-status--error" : "feedback-status";
+}
+
+// ─── per-item flag button ───────────────────────────────────────────────────
+
+/**
+ * Append a flag button to each .digest-item <details> element inside the card.
+ * Called once after the card is rendered.
+ */
+export function mountItemFlagButtons(
+  card: HTMLElement,
+  digest: Digest,
+  client: SupabaseClient,
+): void {
+  const items = card.querySelectorAll<HTMLElement>("details.digest-item");
+  items.forEach((detailsEl, index) => {
+    const headlineEl = detailsEl.querySelector(".item-headline");
+    const headline = headlineEl?.textContent?.trim() ?? "";
+
+    const flagBtn = document.createElement("button");
+    flagBtn.type = "button";
+    flagBtn.className = "item-flag-btn";
+    flagBtn.setAttribute("aria-label", `Flag item: ${headline || `item ${index + 1}`}`);
+    flagBtn.setAttribute("data-item-index", String(index));
+    flagBtn.textContent = "Flag item";
+
+    const itemStatus = document.createElement("span");
+    itemStatus.className = "feedback-status";
+    itemStatus.setAttribute("role", "status");
+    itemStatus.setAttribute("aria-live", "polite");
+
+    const wrapper = document.createElement("div");
+    wrapper.className = "item-flag-row";
+    wrapper.appendChild(flagBtn);
+    wrapper.appendChild(itemStatus);
+
+    flagBtn.addEventListener("click", () => {
+      flagBtn.disabled = true;
+      showStatus(itemStatus, "Flagging…");
+      void (async () => {
+        const row = buildItemFlagRow(digest, index, headline);
+        const err = await submitFeedback(client, row);
+        flagBtn.disabled = false;
+        if (err) {
+          showStatus(itemStatus, `Could not flag: ${err}`, true);
+        } else {
+          flagBtn.textContent = "Flagged";
+          flagBtn.disabled = true;
+          showStatus(itemStatus, "Flagged.");
+        }
+      })();
+    });
+
+    detailsEl.appendChild(wrapper);
+  });
+}
+
+// ─── digest-level feedback panel ───────────────────────────────────────────
+
+/** Build and wire up the full feedback panel for a digest. */
+export function mountFeedbackControls(
+  slotEl: HTMLElement,
+  digest: Digest,
+  client: SupabaseClient,
+): void {
+  const panel = document.createElement("div");
+  panel.className = "feedback-panel";
+  panel.setAttribute("data-digest-id", digest.id);
+
+  const statusEl = document.createElement("p");
+  statusEl.className = "feedback-status";
+  statusEl.setAttribute("role", "status");
+  statusEl.setAttribute("aria-live", "polite");
+
+  // ── Signal row: thumbs-down + positive ─────────────────────────────────
+  const signalRow = document.createElement("div");
+  signalRow.className = "feedback-signal-row";
+
+  const thumbsBtn = document.createElement("button");
+  thumbsBtn.type = "button";
+  thumbsBtn.className = "feedback-btn feedback-btn--thumbs-down";
+  thumbsBtn.setAttribute("aria-label", "Thumbs down — this digest was not useful");
+  thumbsBtn.textContent = "👎 Not useful";
+
+  const positiveBtn = document.createElement("button");
+  positiveBtn.type = "button";
+  positiveBtn.className = "feedback-btn feedback-btn--positive";
+  positiveBtn.setAttribute("aria-label", "This was great");
+  positiveBtn.textContent = "👍 This was great";
+
+  function onSignal(type: "thumbs_down" | "positive", btn: HTMLButtonElement): void {
+    btn.disabled = true;
+    showStatus(statusEl, "Saving…");
+    void (async () => {
+      const row = buildSignalRow(digest, type);
+      const err = await submitFeedback(client, row);
+      btn.disabled = false;
+      if (err) {
+        showStatus(statusEl, `Could not save: ${err}`, true);
+      } else {
+        btn.textContent = type === "thumbs_down" ? "👎 Noted" : "👍 Thanks!";
+        btn.disabled = true;
+        showStatus(statusEl, "Feedback saved.");
+      }
+    })();
+  }
+
+  thumbsBtn.addEventListener("click", () => onSignal("thumbs_down", thumbsBtn));
+  positiveBtn.addEventListener("click", () => onSignal("positive", positiveBtn));
+
+  signalRow.appendChild(thumbsBtn);
+  signalRow.appendChild(positiveBtn);
+
+  // ── Comment section ─────────────────────────────────────────────────────
+  const commentDetails = document.createElement("details");
+  commentDetails.className = "feedback-comment-section";
+
+  const commentSummary = document.createElement("summary");
+  commentSummary.className = "feedback-comment-toggle";
+  commentSummary.textContent = "Add a comment";
+  commentDetails.appendChild(commentSummary);
+
+  const textarea = document.createElement("textarea");
+  textarea.className = "feedback-textarea";
+  textarea.setAttribute("aria-label", "Comment on this digest (max 500 characters)");
+  textarea.setAttribute("maxlength", "500");
+  textarea.placeholder = "What could be better? (max 500 chars)";
+  textarea.rows = 3;
+
+  const charCount = document.createElement("span");
+  charCount.className = "feedback-char-count";
+  charCount.setAttribute("aria-live", "polite");
+  charCount.textContent = "0 / 500";
+
+  textarea.addEventListener("input", () => {
+    const len = textarea.value.length;
+    charCount.textContent = `${len} / 500`;
+  });
+
+  const commentSubmit = document.createElement("button");
+  commentSubmit.type = "button";
+  commentSubmit.className = "feedback-btn feedback-btn--comment-submit";
+  commentSubmit.textContent = "Submit comment";
+
+  const commentStatus = document.createElement("p");
+  commentStatus.className = "feedback-status";
+  commentStatus.setAttribute("role", "status");
+  commentStatus.setAttribute("aria-live", "polite");
+
+  commentSubmit.addEventListener("click", () => {
+    const text = textarea.value.trim();
+    if (!text) {
+      showStatus(commentStatus, "Please enter a comment.", true);
+      return;
+    }
+    commentSubmit.disabled = true;
+    showStatus(commentStatus, "Saving…");
+    void (async () => {
+      const row = buildCommentRow(digest, text);
+      const err = await submitFeedback(client, row);
+      commentSubmit.disabled = false;
+      if (err) {
+        showStatus(commentStatus, `Could not save: ${err}`, true);
+      } else {
+        textarea.value = "";
+        charCount.textContent = "0 / 500";
+        showStatus(commentStatus, "Comment saved. Thank you.");
+        commentDetails.open = false;
+      }
+    })();
+  });
+
+  commentDetails.appendChild(textarea);
+  commentDetails.appendChild(charCount);
+  commentDetails.appendChild(commentSubmit);
+  commentDetails.appendChild(commentStatus);
+
+  // ── Source flag section ─────────────────────────────────────────────────
+  const sourceUrls = extractSourceUrls(digest);
+  if (sourceUrls.length > 0) {
+    const sourceDetails = document.createElement("details");
+    sourceDetails.className = "feedback-source-section";
+
+    const sourceSummary = document.createElement("summary");
+    sourceSummary.className = "feedback-comment-toggle";
+    sourceSummary.textContent = "Flag a source";
+    sourceDetails.appendChild(sourceSummary);
+
+    const sourceRow = document.createElement("div");
+    sourceRow.className = "feedback-source-row";
+
+    const select = document.createElement("select");
+    select.className = "feedback-source-select";
+    select.setAttribute("aria-label", "Select a source to flag");
+
+    const placeholder = document.createElement("option");
+    placeholder.value = "";
+    placeholder.textContent = "Choose a source…";
+    select.appendChild(placeholder);
+
+    for (const url of sourceUrls) {
+      const option = document.createElement("option");
+      // value and label are set via .value / .textContent (XSS-safe)
+      option.value = url;
+      option.textContent = url;
+      select.appendChild(option);
+    }
+
+    const sourceFlagBtn = document.createElement("button");
+    sourceFlagBtn.type = "button";
+    sourceFlagBtn.className = "feedback-btn feedback-btn--source-flag";
+    sourceFlagBtn.textContent = "Flag source";
+
+    const sourceStatus = document.createElement("p");
+    sourceStatus.className = "feedback-status";
+    sourceStatus.setAttribute("role", "status");
+    sourceStatus.setAttribute("aria-live", "polite");
+
+    sourceFlagBtn.addEventListener("click", () => {
+      const url = select.value;
+      if (!url) {
+        showStatus(sourceStatus, "Please select a source.", true);
+        return;
+      }
+      sourceFlagBtn.disabled = true;
+      showStatus(sourceStatus, "Flagging…");
+      void (async () => {
+        const row = buildSourceFlagRow(digest, url);
+        const err = await submitFeedback(client, row);
+        sourceFlagBtn.disabled = false;
+        if (err) {
+          showStatus(sourceStatus, `Could not flag: ${err}`, true);
+        } else {
+          showStatus(sourceStatus, "Source flagged. Thank you.");
+          select.value = "";
+          sourceDetails.open = false;
+        }
+      })();
+    });
+
+    sourceRow.appendChild(select);
+    sourceRow.appendChild(sourceFlagBtn);
+    sourceDetails.appendChild(sourceRow);
+    sourceDetails.appendChild(sourceStatus);
+
+    panel.appendChild(signalRow);
+    panel.appendChild(statusEl);
+    panel.appendChild(commentDetails);
+    panel.appendChild(sourceDetails);
+  } else {
+    panel.appendChild(signalRow);
+    panel.appendChild(statusEl);
+    panel.appendChild(commentDetails);
+  }
+
+  slotEl.appendChild(panel);
+}

--- a/web/tests/unit/feedback.test.ts
+++ b/web/tests/unit/feedback.test.ts
@@ -1,0 +1,278 @@
+// @vitest-environment jsdom
+import { describe, expect, it, vi, beforeEach, afterEach } from "vitest";
+import {
+  buildSignalRow,
+  buildCommentRow,
+  buildSourceFlagRow,
+  buildItemFlagRow,
+  extractSourceUrls,
+  submitFeedback,
+} from "../../src/lib/feedback";
+import { renderDigestCard, registerFeedbackSlotMounter, registerItemFlagMounter } from "../../src/views/digest-card";
+import type { Digest, DigestItem } from "../../src/lib/types";
+
+// ─── test helpers ────────────────────────────────────────────────────────────
+
+function makeDigest(partial: Partial<Digest> = {}): Digest {
+  return {
+    id: "d-abc123",
+    topic_slug: "ai_models",
+    content: "Some content here.",
+    cadence: "24h",
+    digest_date: "2026-06-11",
+    sources_used: ["https://example.com/feed"],
+    token_count: 200,
+    prompt_version: "sp-deadbeef1234",
+    created_at: "2026-06-11T10:00:00Z",
+    summary: null,
+    items: null,
+    ...partial,
+  };
+}
+
+const sampleItems: DigestItem[] = [
+  {
+    headline: "AI Corp ships v2",
+    blurb: "New model released.",
+    detail: "Full details here.",
+    metadata: {
+      sources: [{ title: "AI Blog", url: "https://aiblog.example.com/v2" }],
+    },
+  },
+  {
+    headline: "Open model emerges",
+    blurb: "Apache-licensed.",
+    detail: "Fine-tuning kits next week.",
+    metadata: {
+      sources: [{ title: "HN", url: "https://news.ycombinator.com/item?id=1" }],
+    },
+  },
+];
+
+// ─── buildSignalRow ───────────────────────────────────────────────────────────
+
+describe("buildSignalRow", () => {
+  it("thumbs_down: category, level, topic_slug, feedback_type", () => {
+    const row = buildSignalRow(makeDigest(), "thumbs_down");
+    expect(row.category).toBe("feedback");
+    expect(row.level).toBe("info");
+    expect(row.topic_slug).toBe("ai_models");
+    expect(row.metadata.feedback_type).toBe("thumbs_down");
+  });
+
+  it("positive: feedback_type is positive", () => {
+    const row = buildSignalRow(makeDigest(), "positive");
+    expect(row.metadata.feedback_type).toBe("positive");
+  });
+
+  it("metadata carries digest_id, prompt_version, digest_date", () => {
+    const row = buildSignalRow(makeDigest(), "thumbs_down");
+    expect(row.metadata.digest_id).toBe("d-abc123");
+    expect(row.metadata.prompt_version).toBe("sp-deadbeef1234");
+    expect(row.metadata.digest_date).toBe("2026-06-11");
+  });
+
+  it("tags are exactly [feedback, quality]", () => {
+    const row = buildSignalRow(makeDigest(), "positive");
+    expect(row.metadata.tags).toEqual(["feedback", "quality"]);
+  });
+
+  it("no comment_text, source_url, or item_index in metadata", () => {
+    const row = buildSignalRow(makeDigest(), "thumbs_down");
+    expect(row.metadata.comment_text).toBeUndefined();
+    expect(row.metadata.source_url).toBeUndefined();
+    expect(row.metadata.item_index).toBeUndefined();
+  });
+});
+
+// ─── buildCommentRow ──────────────────────────────────────────────────────────
+
+describe("buildCommentRow", () => {
+  it("feedback_type is comment", () => {
+    const row = buildCommentRow(makeDigest(), "Great digest!");
+    expect(row.metadata.feedback_type).toBe("comment");
+  });
+
+  it("stores comment_text in metadata", () => {
+    const row = buildCommentRow(makeDigest(), "Needs more detail.");
+    expect(row.metadata.comment_text).toBe("Needs more detail.");
+  });
+
+  it("enforces max 500 chars — truncates longer input", () => {
+    const long = "a".repeat(600);
+    const row = buildCommentRow(makeDigest(), long);
+    expect(row.metadata.comment_text!.length).toBe(500);
+  });
+
+  it("keeps comment under 500 chars unchanged", () => {
+    const short = "Short comment.";
+    const row = buildCommentRow(makeDigest(), short);
+    expect(row.metadata.comment_text).toBe(short);
+  });
+
+  it("has tags [feedback, quality]", () => {
+    const row = buildCommentRow(makeDigest(), "x");
+    expect(row.metadata.tags).toEqual(["feedback", "quality"]);
+  });
+});
+
+// ─── buildSourceFlagRow ───────────────────────────────────────────────────────
+
+describe("buildSourceFlagRow", () => {
+  it("feedback_type is source_flag", () => {
+    const row = buildSourceFlagRow(makeDigest(), "https://bad.example.com");
+    expect(row.metadata.feedback_type).toBe("source_flag");
+  });
+
+  it("stores source_url in metadata", () => {
+    const row = buildSourceFlagRow(makeDigest(), "https://bad.example.com");
+    expect(row.metadata.source_url).toBe("https://bad.example.com");
+  });
+
+  it("has tags [feedback, quality]", () => {
+    const row = buildSourceFlagRow(makeDigest(), "https://bad.example.com");
+    expect(row.metadata.tags).toEqual(["feedback", "quality"]);
+  });
+
+  it("carries digest_id and topic_slug", () => {
+    const row = buildSourceFlagRow(makeDigest(), "https://bad.example.com");
+    expect(row.metadata.digest_id).toBe("d-abc123");
+    expect(row.metadata.topic_slug).toBe("ai_models");
+  });
+});
+
+// ─── buildItemFlagRow ─────────────────────────────────────────────────────────
+
+describe("buildItemFlagRow", () => {
+  it("feedback_type is item_flag", () => {
+    const row = buildItemFlagRow(makeDigest(), 0, "AI Corp ships v2");
+    expect(row.metadata.feedback_type).toBe("item_flag");
+  });
+
+  it("stores item_index in metadata", () => {
+    const row = buildItemFlagRow(makeDigest(), 2, "Some headline");
+    expect(row.metadata.item_index).toBe(2);
+  });
+
+  it("stores item_headline in metadata", () => {
+    const row = buildItemFlagRow(makeDigest(), 0, "AI Corp ships v2");
+    expect(row.metadata.item_headline).toBe("AI Corp ships v2");
+  });
+
+  it("has tags [feedback, quality]", () => {
+    const row = buildItemFlagRow(makeDigest(), 0, "Headline");
+    expect(row.metadata.tags).toEqual(["feedback", "quality"]);
+  });
+
+  it("carries digest_id and prompt_version", () => {
+    const row = buildItemFlagRow(makeDigest(), 1, "H");
+    expect(row.metadata.digest_id).toBe("d-abc123");
+    expect(row.metadata.prompt_version).toBe("sp-deadbeef1234");
+  });
+});
+
+// ─── extractSourceUrls ────────────────────────────────────────────────────────
+
+describe("extractSourceUrls", () => {
+  it("extracts http(s) strings from sources_used array", () => {
+    const digest = makeDigest({ sources_used: ["https://a.com", "https://b.com"] });
+    expect(extractSourceUrls(digest)).toContain("https://a.com");
+    expect(extractSourceUrls(digest)).toContain("https://b.com");
+  });
+
+  it("extracts http(s) URLs from item metadata.sources", () => {
+    const digest = makeDigest({ items: sampleItems });
+    const urls = extractSourceUrls(digest);
+    expect(urls).toContain("https://aiblog.example.com/v2");
+    expect(urls).toContain("https://news.ycombinator.com/item?id=1");
+  });
+
+  it("deduplicates across sources_used and item sources", () => {
+    const digest = makeDigest({
+      sources_used: ["https://shared.example.com"],
+      items: [
+        {
+          headline: "H",
+          blurb: "B",
+          detail: "D",
+          metadata: { sources: [{ title: "S", url: "https://shared.example.com" }] },
+        },
+      ],
+    });
+    const urls = extractSourceUrls(digest);
+    expect(urls.filter((u) => u === "https://shared.example.com")).toHaveLength(1);
+  });
+
+  it("ignores non-http entries in sources_used", () => {
+    const digest = makeDigest({ sources_used: [null, 42, "ftp://old.example.com"] });
+    const urls = extractSourceUrls(digest);
+    expect(urls).not.toContain("ftp://old.example.com");
+    expect(urls.length).toBe(0);
+  });
+
+  it("returns empty array when no sources present", () => {
+    const digest = makeDigest({ sources_used: [], items: null });
+    expect(extractSourceUrls(digest)).toEqual([]);
+  });
+});
+
+// ─── submitFeedback ───────────────────────────────────────────────────────────
+
+describe("submitFeedback", () => {
+  it("returns null on success", async () => {
+    const client = { from: () => ({ insert: async () => ({ error: null }) }) } as never;
+    const row = buildSignalRow(makeDigest(), "positive");
+    const result = await submitFeedback(client, row);
+    expect(result).toBeNull();
+  });
+
+  it("returns error message string on failure", async () => {
+    const client = {
+      from: () => ({ insert: async () => ({ error: { message: "RLS violation" } }) }),
+    } as never;
+    const row = buildSignalRow(makeDigest(), "thumbs_down");
+    const result = await submitFeedback(client, row);
+    expect(result).toBe("RLS violation");
+  });
+});
+
+// ─── digest-card integration: feedback-slot is rendered ──────────────────────
+
+describe("renderDigestCard — feedback slot (issue #22)", () => {
+  beforeEach(() => { document.body.innerHTML = ""; });
+  afterEach(() => { document.body.innerHTML = ""; });
+
+  it(".feedback-slot[data-digest-id] is present", () => {
+    const card = renderDigestCard(makeDigest());
+    document.body.appendChild(card);
+    const slot = card.querySelector<HTMLElement>(".feedback-slot");
+    expect(slot).not.toBeNull();
+    expect(slot!.getAttribute("data-digest-id")).toBe("d-abc123");
+  });
+
+  it("feedback slot mounter is called when registered", () => {
+    const mounter = vi.fn();
+    registerFeedbackSlotMounter(mounter);
+    const digest = makeDigest();
+    renderDigestCard(digest);
+    expect(mounter).toHaveBeenCalledOnce();
+    expect(mounter.mock.calls[0][1]).toMatchObject({ id: "d-abc123" });
+    // Reset: deregister so other tests are unaffected
+    registerFeedbackSlotMounter(() => {});
+  });
+
+  it("item flag mounter is called for structured digest", () => {
+    const mounter = vi.fn();
+    registerItemFlagMounter(mounter);
+    const digest = makeDigest({ items: sampleItems });
+    renderDigestCard(digest);
+    expect(mounter).toHaveBeenCalledOnce();
+    registerItemFlagMounter(() => {});
+  });
+
+  it("feedback slot is present in fallback mode too", () => {
+    const card = renderDigestCard(makeDigest({ items: null }));
+    document.body.appendChild(card);
+    expect(card.querySelector(".feedback-slot")).not.toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary

- Feedback panel on each digest: thumbs-down button, "This was great" button (`feedback_type=positive`), optional 500-char comment textarea, per-source flag dropdown, and per-item flag button on each structured item
- All feedback stored in `system_logs` with `category='feedback'`, `tags=["feedback","quality"]`, and metadata containing `digest_id`, `topic_slug`, `prompt_version`, `feedback_type`, plus type-specific fields (`comment_text`, `source_url`, `item_index`/`item_headline`)
- Migration `0012_feedback_rls.sql`: adds a narrow `INSERT` policy on `system_logs` for the `authenticated` role, scoped to `with check (category = 'feedback')` only — no UPDATE/DELETE granted
- `prompt_version` verified end-to-end: `prompts.py:PROMPT_VERSION` → `push_to_supabase` row dict → `digests.prompt_version NOT NULL` column (migration 0001) → `Digest.prompt_version: string` TS type — no migration needed
- `docs/feedback-review.md`: weekly review SQL query template, per-topic clustering query, human-in-the-loop process description — explicitly no automated prompt regeneration
- 30 new unit tests covering row builders, `extractSourceUrls`, `submitFeedback`, and `digest-card` slot integration

## RLS finding

`system_logs` had SELECT-only for `authenticated` (migration 0006). Migration 0012 adds a minimal INSERT policy: `with check (category = 'feedback')`. The web app can only insert feedback rows; it cannot insert agent logs, errors, or other categories.

## `prompt_version` end-to-end status

All four links present before this PR — no additional migration required:
- `src/news_digest/prompts.py:68` — `PROMPT_VERSION`
- `src/news_digest/tools/publishing.py:217` — included in upsert row
- `supabase/migrations/0001_init.sql:24` — `prompt_version text not null`
- `web/src/lib/types.ts:33` — `prompt_version: string`

## Test evidence

```
Test Files  12 passed (12)
Tests       292 passed (292)
```

lint: exit 0, build: exit 0 (64 modules, no TS errors)

Closes #22