### PR TITLE
Harden digest publish-step reliability: retry-until-published + temperature=0

### DIFF
--- a/src/news_digest/agent.py
+++ b/src/news_digest/agent.py
@@ -232,6 +232,10 @@ class NewsDigestAgent(Agent, DatabaseMixin):
             base_url=settings.lemonade_base_url,
             **kwargs,
         )
+        # Deterministic output: temperature=0 reduces malformed-JSON rate on
+        # local 35B models. Set via AgentConfig (gaia/chat/sdk.py:27) which is
+        # read by send_messages / send_messages_stream before every completion.
+        self.chat.config.temperature = 0.0
         # GAIA drives tools via a JSON-in-content protocol. The loaded Lemonade
         # chat models otherwise emit "thinking" output with empty content, which
         # breaks tool parsing — force thinking off on every completion.

--- a/src/news_digest/prompts.py
+++ b/src/news_digest/prompts.py
@@ -50,17 +50,18 @@ no raw URLs. You may also include an optional "tags" array of short strings.
    Rank items by significance. Explain why each item matters in the detail field. \
 Stay factual and grounded in the gathered material. Never invent facts that \
 were not in the sources. Skip dead sources and continue with the others.
-5. When the digest is composed, return it as your FINAL ANSWER, written as a \
-single fenced ```json code block (open with three backticks and "json", close \
-with three backticks) so your answer is text. Inside the block put one JSON \
-object with exactly these keys:
-   - "topic_slug": the slug from fetch_topic_config.
-   - "summary": the short top-level overview.
-   - "items": the ranked list of items, using the same item shape described above \
+5. When the digest is composed, you MUST call push_to_supabase to publish it. \
+Call push_to_supabase with these arguments:
+   - topic_slug: the slug from fetch_topic_config.
+   - summary: the short top-level overview (one or two sentences).
+   - items: the ranked list of items using the same item shape above \
 (headline, blurb, detail, metadata.sources).
-   - "sources_used": the list of source URLs you actually used.
-   Do NOT call any tool to publish — put the whole digest in that code block as \
-your answer.
+   - sources_used: the list of source URLs you actually used.
+   - token_count: 0 (leave at zero; it will be updated automatically).
+   - content: the full digest as a single prose string (summary followed by each \
+item's headline, blurb, and detail joined with newlines). \
+You MUST call push_to_supabase — do NOT put the digest or the intent to publish \
+inside an answer field. The run is not complete until push_to_supabase succeeds.
 
 Writing guidelines:
 - Lead with the most significant item.

--- a/src/news_digest/prompts.py
+++ b/src/news_digest/prompts.py
@@ -50,18 +50,20 @@ no raw URLs. You may also include an optional "tags" array of short strings.
    Rank items by significance. Explain why each item matters in the detail field. \
 Stay factual and grounded in the gathered material. Never invent facts that \
 were not in the sources. Skip dead sources and continue with the others.
-5. When the digest is composed, you MUST call push_to_supabase to publish it. \
-Call push_to_supabase with these arguments:
-   - topic_slug: the slug from fetch_topic_config.
-   - summary: the short top-level overview (one or two sentences).
-   - items: the ranked list of items using the same item shape above \
+5. When the digest is composed, return it as your FINAL ANSWER, written as a \
+single fenced ```json code block (open with three backticks and "json", close \
+with three backticks) so your answer is text. Inside the block put one JSON \
+object with exactly these keys:
+   - "topic_slug": the slug from fetch_topic_config.
+   - "summary": the short top-level overview.
+   - "items": the ranked list of items, using the same item shape described above \
 (headline, blurb, detail, metadata.sources).
-   - sources_used: the list of source URLs you actually used.
-   - token_count: 0 (leave at zero; it will be updated automatically).
-   - content: the full digest as a single prose string (summary followed by each \
-item's headline, blurb, and detail joined with newlines). \
-You MUST call push_to_supabase — do NOT put the digest or the intent to publish \
-inside an answer field. The run is not complete until push_to_supabase succeeds.
+   - "sources_used": the list of source URLs you actually used.
+   Do NOT call any tool to publish — put the whole digest in that code block as \
+your answer. Your final answer MUST contain the complete digest inside that \
+fenced block: never an empty or partial answer, never the digest as a bare JSON \
+object outside the fence, and never just a statement that the digest is ready. \
+The run fails if the digest is missing from your final answer.
 
 Writing guidelines:
 - Lead with the most significant item.

--- a/src/news_digest/scheduler.py
+++ b/src/news_digest/scheduler.py
@@ -43,6 +43,10 @@ _CADENCE_MAP: dict[str, timedelta] = {
     "7d": timedelta(days=7),
 }
 
+# Maximum number of attempts (initial + retries) when a run finishes without
+# publishing.  Lemonade-down failures skip the retry loop entirely.
+_MAX_RUN_ATTEMPTS = 3
+
 
 def _client() -> Client:
     """Build a Supabase client authenticated as service_role.
@@ -121,12 +125,44 @@ def _is_topic_due(topic: dict[str, Any], now: datetime) -> bool:
     return (now - last_datetime) >= cadence
 
 
-def _run_topic(topic: dict[str, Any], agent: Any) -> None:
-    """Execute a single topic run via the agent wrapper.
+def _is_published_today(slug: str) -> bool:
+    """Return True when a digest for *slug* has already been written today (UTC).
 
-    Applies a 0–300 s random jitter before invoking
-    ``agent.generate_and_publish``.  All exceptions are caught so one failing
-    topic cannot stop the scheduler cycle.
+    Compares the most recent digest date against today's UTC date, matching the
+    timezone used by ``push_to_supabase`` (``datetime.now(UTC).date()``).
+
+    Args:
+        slug: The topic slug to check.
+
+    Returns:
+        True when a digest row exists for today's UTC date, False otherwise
+        (including on Supabase errors, where we conservatively assume not
+        published so the retry loop proceeds rather than silently skipping).
+    """
+    result = get_last_digest_date(slug)
+    last_date_str = result.get("last_date")
+    if last_date_str is None:
+        return False
+    try:
+        last_date = date.fromisoformat(last_date_str)
+    except ValueError:
+        return False
+    return last_date == datetime.now(UTC).date()
+
+
+def _run_topic(topic: dict[str, Any], agent: Any) -> None:
+    """Execute a single topic run via the agent wrapper, with retry-until-published.
+
+    Applies a 0–300 s random jitter before the first attempt.  After each
+    attempt, verifies whether a digest row actually landed in Supabase for
+    today's UTC date. If not:
+    - ``lemonade_down`` failures skip retries immediately (LLM is unreachable).
+    - Otherwise retries up to ``_MAX_RUN_ATTEMPTS`` total attempts.
+    - If still unpublished after all attempts, logs an error so monitoring
+      catches it (the run is NOT falsely reported as success).
+
+    All exceptions are caught so one failing topic cannot stop the scheduler
+    cycle.
 
     Args:
         topic: A ``digest_topics`` row with at least ``slug`` and ``name``.
@@ -145,34 +181,75 @@ def _run_topic(topic: dict[str, Any], agent: Any) -> None:
     )
     time.sleep(jitter)
 
-    try:
-        log(
-            "info",
-            "schedule",
-            f"_run_topic: starting run for {name!r} ({slug!r})",
-            topic_slug=slug,
-            metadata={"slug": slug, "name": name},
-        )
-        result = agent.generate_and_publish(f"Generate the {name} digest for today")
-        log(
-            "info",
-            "schedule",
-            f"_run_topic: finished {slug!r} — success={result.get('success')}",
-            topic_slug=slug,
-            metadata={"slug": slug, "result": result},
-        )
-    except Exception as exc:  # noqa: BLE001 — failure isolation
-        log(
-            "error",
-            "schedule",
-            f"_run_topic: unhandled exception for {slug!r}: {exc.__class__.__name__}: {exc}",
-            topic_slug=slug,
-            metadata={
-                "slug": slug,
-                "error": str(exc),
-                "exc_type": exc.__class__.__name__,
-            },
-        )
+    for attempt in range(1, _MAX_RUN_ATTEMPTS + 1):
+        try:
+            log(
+                "info",
+                "schedule",
+                f"_run_topic: starting run for {name!r} ({slug!r}) attempt {attempt}/{_MAX_RUN_ATTEMPTS}",
+                topic_slug=slug,
+                metadata={"slug": slug, "name": name, "attempt": attempt},
+            )
+            result = agent.generate_and_publish(f"Generate the {name} digest for today")
+            log(
+                "info",
+                "schedule",
+                f"_run_topic: finished {slug!r} attempt {attempt} — success={result.get('success')}",
+                topic_slug=slug,
+                metadata={"slug": slug, "result": result, "attempt": attempt},
+            )
+        except Exception as exc:  # noqa: BLE001 — failure isolation
+            log(
+                "error",
+                "schedule",
+                f"_run_topic: unhandled exception for {slug!r} attempt {attempt}: {exc.__class__.__name__}: {exc}",
+                topic_slug=slug,
+                metadata={
+                    "slug": slug,
+                    "error": str(exc),
+                    "exc_type": exc.__class__.__name__,
+                    "attempt": attempt,
+                },
+            )
+            result = {"success": False, "error": exc.__class__.__name__}
+
+        # Lemonade unreachable — retrying while the LLM is down is pointless.
+        if result.get("error") == "lemonade_down":
+            log(
+                "warn",
+                "schedule",
+                f"_run_topic: {slug!r} skipping retries — lemonade_down",
+                topic_slug=slug,
+                metadata={"slug": slug, "attempt": attempt},
+            )
+            return
+
+        # Verify that a digest row actually landed (GAIA returns status=success
+        # even when the final turn was malformed and nothing was published).
+        if _is_published_today(slug):
+            return
+
+        # Not published yet.
+        if attempt < _MAX_RUN_ATTEMPTS:
+            log(
+                "warn",
+                "schedule",
+                f"_run_topic: {slug!r} run finished without publishing, retrying {attempt + 1}/{_MAX_RUN_ATTEMPTS}",
+                topic_slug=slug,
+                metadata={
+                    "slug": slug,
+                    "attempt": attempt,
+                    "next_attempt": attempt + 1,
+                },
+            )
+        else:
+            log(
+                "error",
+                "schedule",
+                f"_run_topic: {slug!r} failed to publish after {_MAX_RUN_ATTEMPTS} attempts",
+                topic_slug=slug,
+                metadata={"slug": slug, "attempts": _MAX_RUN_ATTEMPTS},
+            )
 
 
 def run_cycle(agent: Any | None = None) -> None:

--- a/src/news_digest/scheduler.py
+++ b/src/news_digest/scheduler.py
@@ -125,8 +125,8 @@ def _is_topic_due(topic: dict[str, Any], now: datetime) -> bool:
     return (now - last_datetime) >= cadence
 
 
-def _is_published_today(slug: str) -> bool:
-    """Return True when a digest for *slug* has already been written today (UTC).
+def _is_published_today(slug: str) -> bool | None:
+    """Check whether a digest for *slug* has already been written today (UTC).
 
     Compares the most recent digest date against today's UTC date, matching the
     timezone used by ``push_to_supabase`` (``datetime.now(UTC).date()``).
@@ -135,11 +135,16 @@ def _is_published_today(slug: str) -> bool:
         slug: The topic slug to check.
 
     Returns:
-        True when a digest row exists for today's UTC date, False otherwise
-        (including on Supabase errors, where we conservatively assume not
-        published so the retry loop proceeds rather than silently skipping).
+        True when a digest row exists for today's UTC date, False when it does
+        not, and None when verification is unavailable because the Supabase
+        read failed (``get_last_digest_date`` swallowed an exception and
+        returned an ``error`` key). None lets the caller fall back to the
+        run's own publish result instead of burning retries — three full 35B
+        regenerations — on a transient read blip while publishes are landing.
     """
     result = get_last_digest_date(slug)
+    if "error" in result:
+        return None
     last_date_str = result.get("last_date")
     if last_date_str is None:
         return False
@@ -160,6 +165,11 @@ def _run_topic(topic: dict[str, Any], agent: Any) -> None:
     - Otherwise retries up to ``_MAX_RUN_ATTEMPTS`` total attempts.
     - If still unpublished after all attempts, logs an error so monitoring
       catches it (the run is NOT falsely reported as success).
+
+    When the verification read itself fails (Supabase unreachable for reads),
+    the run's own ``result["success"]`` is trusted instead — it reflects
+    ``_publish_from_result``'s verified write — and a warn is logged that
+    verification was skipped.
 
     All exceptions are caught so one failing topic cannot stop the scheduler
     cycle.
@@ -226,7 +236,24 @@ def _run_topic(topic: dict[str, Any], agent: Any) -> None:
 
         # Verify that a digest row actually landed (GAIA returns status=success
         # even when the final turn was malformed and nothing was published).
-        if _is_published_today(slug):
+        published = _is_published_today(slug)
+        if published is None:
+            # Verification read failed — trust the run's own publish result
+            # (it reflects _publish_from_result's verified write) rather than
+            # burning retries on a transient Supabase read blip.
+            log(
+                "warn",
+                "schedule",
+                f"_run_topic: {slug!r} publish verification skipped — Supabase read error; trusting run result",
+                topic_slug=slug,
+                metadata={
+                    "slug": slug,
+                    "attempt": attempt,
+                    "run_success": result.get("success"),
+                },
+            )
+            published = bool(result.get("success"))
+        if published:
             return
 
         # Not published yet.

--- a/tests/test_prompts.py
+++ b/tests/test_prompts.py
@@ -223,15 +223,21 @@ def test_system_prompt_step3_wires_fetch_reddit_as_secondary_signal():
     assert "never quote reddit" in sp_lower
 
 
-def test_system_prompt_instructs_final_answer_json_not_publish_tool():
+def test_system_prompt_instructs_publish_via_push_to_supabase_tool():
     sp = SYSTEM_PROMPT
     sp_lower = sp.lower()
-    # The model returns the digest as its FINAL ANSWER (JSON), not via a tool call.
-    assert "final answer" in sp_lower
+    # Step 5 must instruct the model to call push_to_supabase directly (#44).
+    assert "push_to_supabase" in sp
     assert "topic_slug" in sp
     assert "sources_used" in sp
-    # It must NOT instruct the model to publish via push_to_supabase anymore.
-    assert "push_to_supabase" not in sp
+    # The model must NOT bury the digest in an answer field.
+    assert (
+        "do not put the digest" in sp_lower
+        or "not put the digest" in sp_lower
+        or "must not" in sp_lower
+    )
+    # The run is not complete until push_to_supabase succeeds.
+    assert "push_to_supabase" in sp
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_prompts.py
+++ b/tests/test_prompts.py
@@ -223,21 +223,28 @@ def test_system_prompt_step3_wires_fetch_reddit_as_secondary_signal():
     assert "never quote reddit" in sp_lower
 
 
-def test_system_prompt_instructs_publish_via_push_to_supabase_tool():
+def test_system_prompt_instructs_final_answer_json_not_publish_tool():
     sp = SYSTEM_PROMPT
     sp_lower = sp.lower()
-    # Step 5 must instruct the model to call push_to_supabase directly (#44).
-    assert "push_to_supabase" in sp
+    # The model returns the digest as its FINAL ANSWER (JSON), not via a tool call.
+    assert "final answer" in sp_lower
     assert "topic_slug" in sp
     assert "sources_used" in sp
-    # The model must NOT bury the digest in an answer field.
-    assert (
-        "do not put the digest" in sp_lower
-        or "not put the digest" in sp_lower
-        or "must not" in sp_lower
-    )
-    # The run is not complete until push_to_supabase succeeds.
-    assert "push_to_supabase" in sp
+    # It must NOT instruct the model to publish via push_to_supabase anymore.
+    assert "push_to_supabase" not in sp
+
+
+def test_system_prompt_requires_complete_digest_in_final_answer():
+    """Reliability nudge for #44, within the #59 answer-JSON contract: the
+    model MUST end with the complete digest in the fenced JSON answer — never
+    empty/partial, never a bare unfenced object."""
+    sp = SYSTEM_PROMPT
+    sp_lower = sp.lower()
+    assert "must contain the complete digest" in sp_lower
+    assert "never an empty or partial answer" in sp_lower
+    assert "outside the fence" in sp_lower
+    # Still strictly answer-driven: no publish tool call.
+    assert "do not call any tool to publish" in sp_lower
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_scheduler.py
+++ b/tests/test_scheduler.py
@@ -516,6 +516,21 @@ def test_is_published_today_returns_false_on_bad_date_format(monkeypatch):
     assert _is_published_today("ai_models") is False
 
 
+def test_is_published_today_returns_none_on_supabase_read_error(monkeypatch):
+    """Returns None (verification unavailable) when the Supabase read failed.
+
+    get_last_digest_date swallows exceptions and returns an ``error`` key —
+    that must NOT read as "not published" or a transient read blip burns all
+    retries even when publishes are landing.
+    """
+    monkeypatch.setattr(
+        sched_module,
+        "get_last_digest_date",
+        lambda slug: {"last_date": None, "error": "ConnectionError"},
+    )
+    assert _is_published_today("ai_models") is None
+
+
 # ---------------------------------------------------------------------------
 # _run_topic retry loop — issue #44
 # ---------------------------------------------------------------------------
@@ -622,3 +637,48 @@ def test_run_topic_exception_is_treated_as_unpublished_and_retried(
     errors = [a for (a, _) in log_calls if a[0] == "error"]
     # At least one error per exception + one final "failed to publish" error.
     assert len(errors) >= _MAX_RUN_ATTEMPTS
+
+
+# ---------------------------------------------------------------------------
+# _run_topic verification fallback when the Supabase read fails — issue #44
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture()
+def _patch_verification_unavailable(monkeypatch):
+    """Make _is_published_today return None (Supabase read error)."""
+    monkeypatch.setattr(sched_module, "_is_published_today", lambda slug: None)
+
+
+def test_run_topic_read_error_trusts_successful_run_result(
+    monkeypatch, log_calls, _patch_verification_unavailable
+):
+    """Verification read error + successful run result: no retry, warn logged."""
+    agent = MagicMock()
+    agent.generate_and_publish.return_value = {
+        "success": True,
+        "id": "x",
+        "digest_date": "2026-06-11",
+    }
+
+    _run_topic(_topic_row(), agent)
+
+    assert agent.generate_and_publish.call_count == 1
+    warns = [a for (a, _) in log_calls if a[0] == "warn"]
+    assert any("verification skipped" in a[2] for a in warns)
+
+
+def test_run_topic_read_error_with_failed_run_result_still_retries(
+    monkeypatch, log_calls, _patch_verification_unavailable
+):
+    """Verification read error + failed run result: the retry loop still runs."""
+    from news_digest.scheduler import _MAX_RUN_ATTEMPTS
+
+    agent = MagicMock()
+    agent.generate_and_publish.return_value = {"success": False, "error": "parse_error"}
+
+    _run_topic(_topic_row(), agent)
+
+    assert agent.generate_and_publish.call_count == _MAX_RUN_ATTEMPTS
+    errors = [a for (a, _) in log_calls if a[0] == "error"]
+    assert any("failed to publish" in a[2] for a in errors)

--- a/tests/test_scheduler.py
+++ b/tests/test_scheduler.py
@@ -1,8 +1,9 @@
-"""Tests for src/news_digest/scheduler.py — issue #13.
+"""Tests for src/news_digest/scheduler.py — issue #13, #44.
 
 Tests are hermetic: no real APScheduler sleeps, no network.  Due-check logic,
-kill-switch behaviour, per-topic failure isolation, and cycle logging are all
-tested by calling ``run_cycle`` and the helper functions directly.
+kill-switch behaviour, per-topic failure isolation, cycle logging, and
+retry-until-published (#44) are all tested by calling ``run_cycle`` and the
+helper functions directly.
 """
 
 import signal
@@ -14,8 +15,10 @@ import pytest
 from news_digest import scheduler as sched_module
 from news_digest.scheduler import (
     _install_signal_handlers,
+    _is_published_today,
     _is_topic_due,
     _parse_cadence,
+    _run_topic,
     run_cycle,
 )
 from news_digest.scheduler import (
@@ -45,6 +48,15 @@ def log_calls(_silence_log):
 def _no_sleep(monkeypatch):
     """Skip actual jitter sleeps so tests run at full speed."""
     monkeypatch.setattr(sched_module.time, "sleep", lambda _: None)
+
+
+@pytest.fixture(autouse=True)
+def _assume_published(monkeypatch):
+    """Default: treat every run as published so existing tests are unaffected.
+
+    Retry-specific tests override this by patching _is_published_today directly.
+    """
+    monkeypatch.setattr(sched_module, "_is_published_today", lambda slug: True)
 
 
 # ---------------------------------------------------------------------------
@@ -453,3 +465,160 @@ def test_main_registers_interval_job_with_max_instances_one(monkeypatch):
     _, kwargs = fake_scheduler.add_job.call_args
     assert kwargs["minutes"] == 15
     assert kwargs["max_instances"] == 1
+
+
+# ---------------------------------------------------------------------------
+# _is_published_today — verification helper (issue #44)
+# ---------------------------------------------------------------------------
+
+
+def test_is_published_today_returns_true_when_date_matches_today(monkeypatch):
+    """Returns True when last_date equals today's UTC date."""
+    today_iso = datetime.now(UTC).date().isoformat()
+    monkeypatch.setattr(
+        sched_module,
+        "get_last_digest_date",
+        lambda slug: {"last_date": today_iso},
+    )
+    assert _is_published_today("ai_models") is True
+
+
+def test_is_published_today_returns_false_when_date_is_yesterday(monkeypatch):
+    """Returns False when last_date is before today."""
+    from datetime import timedelta
+
+    yesterday_iso = (datetime.now(UTC).date() - timedelta(days=1)).isoformat()
+    monkeypatch.setattr(
+        sched_module,
+        "get_last_digest_date",
+        lambda slug: {"last_date": yesterday_iso},
+    )
+    assert _is_published_today("ai_models") is False
+
+
+def test_is_published_today_returns_false_when_no_prior_digest(monkeypatch):
+    """Returns False when no digest has ever been published."""
+    monkeypatch.setattr(
+        sched_module,
+        "get_last_digest_date",
+        lambda slug: {"last_date": None},
+    )
+    assert _is_published_today("ai_models") is False
+
+
+def test_is_published_today_returns_false_on_bad_date_format(monkeypatch):
+    """Returns False (not an exception) when the stored date is malformed."""
+    monkeypatch.setattr(
+        sched_module,
+        "get_last_digest_date",
+        lambda slug: {"last_date": "not-a-date"},
+    )
+    assert _is_published_today("ai_models") is False
+
+
+# ---------------------------------------------------------------------------
+# _run_topic retry loop — issue #44
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture()
+def _patch_not_published(monkeypatch):
+    """Make _is_published_today always return False (digest never landed)."""
+    monkeypatch.setattr(sched_module, "_is_published_today", lambda slug: False)
+
+
+@pytest.fixture()
+def _patch_published(monkeypatch):
+    """Make _is_published_today always return True (digest confirmed)."""
+    monkeypatch.setattr(sched_module, "_is_published_today", lambda slug: True)
+
+
+def _topic_row(slug: str = "ai_models") -> dict:
+    return {"slug": slug, "name": "AI Models", "cadence": "24h", "enabled": True}
+
+
+def test_run_topic_succeeds_first_attempt_no_retry(
+    monkeypatch, log_calls, _patch_published
+):
+    """When the digest is confirmed on the first attempt, no retry happens."""
+    agent = MagicMock()
+    agent.generate_and_publish.return_value = {
+        "success": True,
+        "id": "x",
+        "digest_date": "2026-06-11",
+    }
+    _run_topic(_topic_row(), agent)
+    assert agent.generate_and_publish.call_count == 1
+
+
+def test_run_topic_retries_when_not_published_on_first_attempt(monkeypatch, log_calls):
+    """When the first attempt produces no publish, it retries and succeeds on the second."""
+    # First call: not published; second call: published.
+    published_state = {"published": False}
+
+    def _is_pub(slug):
+        result = published_state["published"]
+        published_state["published"] = True  # flip after first check
+        return result
+
+    monkeypatch.setattr(sched_module, "_is_published_today", _is_pub)
+
+    agent = MagicMock()
+    agent.generate_and_publish.return_value = {"success": True}
+
+    _run_topic(_topic_row(), agent)
+
+    assert agent.generate_and_publish.call_count == 2
+    # A warn log must have been emitted for the retry.
+    warns = [a for (a, _) in log_calls if a[0] == "warn"]
+    assert any("retrying" in a[2] for a in warns)
+
+
+def test_run_topic_gives_up_after_max_attempts_and_logs_error(
+    monkeypatch, log_calls, _patch_not_published
+):
+    """After _MAX_RUN_ATTEMPTS failures, an error is logged (not success)."""
+    from news_digest.scheduler import _MAX_RUN_ATTEMPTS
+
+    agent = MagicMock()
+    agent.generate_and_publish.return_value = {"success": False, "error": "parse_error"}
+
+    _run_topic(_topic_row(), agent)
+
+    assert agent.generate_and_publish.call_count == _MAX_RUN_ATTEMPTS
+    errors = [a for (a, _) in log_calls if a[0] == "error"]
+    assert any("failed to publish" in a[2] for a in errors)
+
+
+def test_run_topic_skips_retry_on_lemonade_down(
+    monkeypatch, log_calls, _patch_not_published
+):
+    """When generate_and_publish returns lemonade_down, no retry is attempted."""
+    agent = MagicMock()
+    agent.generate_and_publish.return_value = {
+        "success": False,
+        "error": "lemonade_down",
+    }
+
+    _run_topic(_topic_row(), agent)
+
+    assert agent.generate_and_publish.call_count == 1
+    warns = [a for (a, _) in log_calls if a[0] == "warn"]
+    assert any("lemonade_down" in a[2] for a in warns)
+
+
+def test_run_topic_exception_is_treated_as_unpublished_and_retried(
+    monkeypatch, log_calls, _patch_not_published
+):
+    """An unexpected exception from generate_and_publish is caught; the retry loop continues."""
+    from news_digest.scheduler import _MAX_RUN_ATTEMPTS
+
+    agent = MagicMock()
+    agent.generate_and_publish.side_effect = RuntimeError("unexpected crash")
+
+    _run_topic(_topic_row(), agent)
+
+    assert agent.generate_and_publish.call_count == _MAX_RUN_ATTEMPTS
+    errors = [a for (a, _) in log_calls if a[0] == "error"]
+    # At least one error per exception + one final "failed to publish" error.
+    assert len(errors) >= _MAX_RUN_ATTEMPTS


### PR DESCRIPTION
## Summary

- **Retry-until-published loop** in `_run_topic` (`scheduler.py`): after each `generate_and_publish` call, verifies a digest row landed in Supabase via `_is_published_today` (compares `get_last_digest_date` against today's UTC date — same timezone as `push_to_supabase`). Retries up to 3 total attempts; `lemonade_down` skips retries immediately; still-unpublished after all attempts logs an `error` (never falsely reports success).
- **Verification fallback on read errors**: when `get_last_digest_date` returns an `error` key (Supabase read failure), `_is_published_today` returns `None` instead of "not published". `_run_topic` then trusts the run's own `result["success"]` (which reflects `_publish_from_result`'s verified write) and logs a `warn` that verification was skipped — a transient read blip no longer burns all 3 retries (3 full 35B regenerations) while publishes are landing.
- **`temperature=0.0`** set via `self.chat.config.temperature` in `NewsDigestAgent.__init__` — uses the `AgentConfig.temperature` field (`gaia/chat/sdk.py:27`) which `AgentSDK.send_messages` / `send_messages_stream` reads before every completion. No monkey-patching; no GAIA internals touched.
- **SYSTEM_PROMPT step 5 strengthened within the #59 answer-JSON contract**: the model still returns the digest as a fenced-JSON final answer (Python publishes via `_publish_from_result` — the publish-tool contract is deliberately NOT used, see agent.py module docstring). Added tight imperative wording: the final answer MUST contain the complete digest in the fenced block — never empty/partial, never a bare unfenced object, never just a statement that the digest is ready. Composes cleanly with the fetch_reddit step from #21.

## Test evidence

```
231 passed, 6 deselected in 0.92s
ruff check: All checks passed
ruff format --check: 25 files already formatted
```

New tests (`tests/test_scheduler.py`):
- `test_is_published_today_*` — 5 cases: today match, yesterday, None, malformed date, Supabase read error returns None
- `test_run_topic_succeeds_first_attempt_no_retry` — no retry when published
- `test_run_topic_retries_when_not_published_on_first_attempt` — succeeds on 2nd, emits warn
- `test_run_topic_gives_up_after_max_attempts_and_logs_error` — 3 attempts, error logged
- `test_run_topic_skips_retry_on_lemonade_down` — single attempt, warn logged
- `test_run_topic_exception_is_treated_as_unpublished_and_retried` — exception retried
- `test_run_topic_read_error_trusts_successful_run_result` — read error + success: no retry, warn logged
- `test_run_topic_read_error_with_failed_run_result_still_retries` — read error + failure: retries continue

`tests/test_prompts.py`: `test_system_prompt_instructs_final_answer_json_not_publish_tool` kept as-is (answer-JSON contract preserved); added `test_system_prompt_requires_complete_digest_in_final_answer` pinning the strengthened wording.

Closes #44