### PR TITLE
fix: cache the Supabase client to stop per-call httpx pool leaks

### DIFF
--- a/src/news_digest/logging.py
+++ b/src/news_digest/logging.py
@@ -4,7 +4,7 @@ from datetime import UTC, datetime
 from pathlib import Path
 from typing import Any, Literal
 
-from supabase import create_client
+from news_digest.supabase_client import get_client
 
 Level = Literal["info", "warn", "error"]
 Category = Literal[
@@ -82,11 +82,7 @@ def log(
         "metadata": metadata,
     }
     try:
-        from news_digest.config import get_settings
-
-        settings = get_settings()
-        client = create_client(settings.supabase_url, settings.supabase_service_key)
-        client.table("system_logs").insert(row).execute()
+        get_client().table("system_logs").insert(row).execute()
     except Exception:
         try:
             _write_fallback(row)
@@ -108,10 +104,7 @@ def drain_fallback() -> int:
         return 0
 
     try:
-        from news_digest.config import get_settings
-
-        settings = get_settings()
-        client = create_client(settings.supabase_url, settings.supabase_service_key)
+        client = get_client()
 
         for r in rows:
             row_id, ts, level, category, topic_slug, message, metadata_json = r

--- a/src/news_digest/supabase_client.py
+++ b/src/news_digest/supabase_client.py
@@ -1,0 +1,40 @@
+"""Process-wide cached Supabase client.
+
+Every Supabase touchpoint (``news_digest.logging``, the publishing tools, and
+the scheduler) goes through :func:`get_client` so the process holds a single
+httpx connection pool. Building a fresh client per call leaks idle sockets:
+the scheduler daemon runs 24/7 with multiple ``log()`` calls per tick, and
+each ``create_client()`` allocates a pool that is never closed.
+
+The cache is keyed on the active settings values, so a settings change (tests
+swapping env vars) transparently yields a new client. ``cache_clear()`` is the
+explicit reset hook, mirroring ``config.get_settings.cache_clear``.
+"""
+
+from functools import lru_cache
+
+from news_digest.config import get_settings
+from supabase import Client, create_client
+
+
+@lru_cache(maxsize=1)
+def _cached_client(url: str, key: str) -> Client:
+    return create_client(url, key)
+
+
+def get_client() -> Client:
+    """Return the shared Supabase client authenticated as service_role.
+
+    The agent is a trusted backend process; it uses the service-role key for
+    all Supabase access. Reads previously used the anon key, but anon reads
+    return zero rows since read policies moved to the ``authenticated`` role
+    (migration 0006 / #57); service_role bypasses RLS. The service key never
+    leaves the host.
+    """
+    settings = get_settings()
+    return _cached_client(settings.supabase_url, settings.supabase_service_key)
+
+
+def cache_clear() -> None:
+    """Drop the cached client so the next get_client() builds a fresh one."""
+    _cached_client.cache_clear()

--- a/src/news_digest/tools/publishing.py
+++ b/src/news_digest/tools/publishing.py
@@ -19,10 +19,10 @@ from datetime import UTC, datetime
 
 from gaia.agents.base.tools import tool
 
-from news_digest.config import get_settings
 from news_digest.logging import log
 from news_digest.prompts import PROMPT_VERSION, flatten_digest
-from supabase import Client, create_client
+from news_digest.supabase_client import get_client
+from supabase import Client
 
 _CONFIG_CACHE_TTL: float = 300.0  # 5 minutes (issue #8)
 # slug -> (monotonic_timestamp, config_row)
@@ -35,15 +35,13 @@ def _now() -> float:
 
 
 def _client() -> Client:
-    """Build a Supabase client authenticated as service_role.
+    """Return the shared Supabase client (service_role).
 
-    The agent is a trusted backend process; it uses the service-role key for all
-    Supabase access. Reads previously used the anon key, but anon reads return
-    zero rows since read policies moved to the ``authenticated`` role (migration
-    0006 / #57); service_role bypasses RLS. The service key never leaves the host.
+    Thin wrapper over ``news_digest.supabase_client.get_client`` kept as the
+    monkeypatch seam for tests; see that module for the auth rationale and the
+    connection-pool caching.
     """
-    settings = get_settings()
-    return create_client(settings.supabase_url, settings.supabase_service_key)
+    return get_client()
 
 
 @tool

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,6 +2,7 @@
 
 import pytest
 
+from news_digest import supabase_client
 from news_digest.config import Settings, get_settings
 
 # Belt: stop pydantic-settings from reading a real .env file directly.
@@ -23,8 +24,10 @@ def isolate_settings_env(monkeypatch):
     for field in Settings.model_fields:
         monkeypatch.delenv(field.upper(), raising=False)
     get_settings.cache_clear()
+    supabase_client.cache_clear()
     yield
     get_settings.cache_clear()
+    supabase_client.cache_clear()
 
 
 @pytest.fixture

--- a/tests/test_logging.py
+++ b/tests/test_logging.py
@@ -24,7 +24,7 @@ def _mock_supabase_client():
 
 def test_log_writes_to_supabase_when_reachable(valid_env):
     mock_client = _mock_supabase_client()
-    with patch("news_digest.logging.create_client", return_value=mock_client):
+    with patch("news_digest.logging.get_client", return_value=mock_client):
         nd_logging.log("info", "scrape", "fetched 10 entries", topic_slug="ai_models")
 
     mock_client.table.assert_called_with("system_logs")
@@ -39,7 +39,7 @@ def test_log_writes_to_supabase_when_reachable(valid_env):
 
 def test_log_falls_back_to_sqlite_on_supabase_failure(valid_env, tmp_path):
     with patch(
-        "news_digest.logging.create_client", side_effect=Exception("network error")
+        "news_digest.logging.get_client", side_effect=Exception("network error")
     ):
         nd_logging.log("error", "publish", "supabase down", metadata={"retries": 3})
 
@@ -50,7 +50,7 @@ def test_log_falls_back_to_sqlite_on_supabase_failure(valid_env, tmp_path):
 
 
 def test_log_never_raises_on_any_failure(valid_env):
-    with patch("news_digest.logging.create_client", side_effect=RuntimeError("boom")):
+    with patch("news_digest.logging.get_client", side_effect=RuntimeError("boom")):
         with patch.object(
             nd_logging, "_write_fallback", side_effect=OSError("disk full")
         ):
@@ -58,7 +58,7 @@ def test_log_never_raises_on_any_failure(valid_env):
 
 
 def test_drain_fallback_pushes_rows_to_supabase(valid_env):
-    with patch("news_digest.logging.create_client", side_effect=Exception("down")):
+    with patch("news_digest.logging.get_client", side_effect=Exception("down")):
         nd_logging.log("info", "schedule", "msg1")
         nd_logging.log("info", "schedule", "msg2")
 
@@ -69,7 +69,7 @@ def test_drain_fallback_pushes_rows_to_supabase(valid_env):
     assert len(unsynced) == 2
 
     mock_client = _mock_supabase_client()
-    with patch("news_digest.logging.create_client", return_value=mock_client):
+    with patch("news_digest.logging.get_client", return_value=mock_client):
         drained = nd_logging.drain_fallback()
 
     assert drained == 2
@@ -80,7 +80,7 @@ def test_drain_fallback_pushes_rows_to_supabase(valid_env):
 
 
 def test_drain_fallback_returns_zero_when_supabase_still_down(valid_env):
-    with patch("news_digest.logging.create_client", side_effect=Exception("down")):
+    with patch("news_digest.logging.get_client", side_effect=Exception("down")):
         nd_logging.log("info", "schedule", "msg")
         result = nd_logging.drain_fallback()
     assert result == 0
@@ -88,7 +88,7 @@ def test_drain_fallback_returns_zero_when_supabase_still_down(valid_env):
 
 def test_drain_fallback_idempotent_on_already_synced_rows(valid_env):
     mock_client = _mock_supabase_client()
-    with patch("news_digest.logging.create_client", return_value=mock_client):
+    with patch("news_digest.logging.get_client", return_value=mock_client):
         nd_logging.log("info", "scrape", "already synced")
         nd_logging.drain_fallback()
         count = nd_logging.drain_fallback()

--- a/tests/test_logging_recovery.py
+++ b/tests/test_logging_recovery.py
@@ -67,7 +67,7 @@ def _mock_supabase_client():
 def test_supabase_down_logs_fall_back_to_sqlite(valid_env):
     """When Supabase is unreachable, log() must persist to SQLite without raising."""
     with patch(
-        "news_digest.logging.create_client", side_effect=Exception("connection refused")
+        "news_digest.logging.get_client", side_effect=Exception("connection refused")
     ):
         nd_logging.log(
             "error", "publish", "push_to_supabase failed", metadata={"retry": 1}
@@ -84,7 +84,7 @@ def test_supabase_down_logs_fall_back_to_sqlite(valid_env):
 def test_supabase_down_drain_on_recovery(valid_env):
     """drain_fallback() ships accumulated rows to Supabase when it comes back up."""
     # Phase 1: Supabase down — two log() calls go to SQLite.
-    with patch("news_digest.logging.create_client", side_effect=Exception("down")):
+    with patch("news_digest.logging.get_client", side_effect=Exception("down")):
         nd_logging.log("info", "schedule", "cycle start")
         nd_logging.log("error", "publish", "upsert failed")
 
@@ -96,7 +96,7 @@ def test_supabase_down_drain_on_recovery(valid_env):
 
     # Phase 2: Supabase recovers — drain_fallback ships both rows.
     mock_client = _mock_supabase_client()
-    with patch("news_digest.logging.create_client", return_value=mock_client):
+    with patch("news_digest.logging.get_client", return_value=mock_client):
         drained = nd_logging.drain_fallback()
 
     assert drained == 2
@@ -109,7 +109,7 @@ def test_supabase_down_drain_on_recovery(valid_env):
 def test_supabase_down_drain_idempotent(valid_env):
     """A second drain_fallback() call after all rows are synced returns 0."""
     mock_client = _mock_supabase_client()
-    with patch("news_digest.logging.create_client", return_value=mock_client):
+    with patch("news_digest.logging.get_client", return_value=mock_client):
         nd_logging.log("info", "scrape", "fetched 5 entries")
         nd_logging.drain_fallback()
         count = nd_logging.drain_fallback()
@@ -290,7 +290,7 @@ def test_generate_and_publish_drains_fallback_on_next_run(valid_env, monkeypatch
 
     # Phase 1: Supabase down — a publish-failure log lands in the fallback DB.
     with patch(
-        "news_digest.logging.create_client", side_effect=Exception("supabase down")
+        "news_digest.logging.get_client", side_effect=Exception("supabase down")
     ):
         nd_logging.log("error", "publish", "upsert failed during outage")
 
@@ -312,7 +312,7 @@ def test_generate_and_publish_drains_fallback_on_next_run(valid_env, monkeypatch
     )
 
     mock_client = _mock_supabase_client()
-    with patch("news_digest.logging.create_client", return_value=mock_client):
+    with patch("news_digest.logging.get_client", return_value=mock_client):
         nd_agent.NewsDigestAgent.generate_and_publish(fake_agent, "Generate digest")
 
     # The stranded row was upserted to Supabase and marked synced locally.

--- a/tests/test_publishing_tools.py
+++ b/tests/test_publishing_tools.py
@@ -125,6 +125,8 @@ def test_client_authenticates_as_service_role(monkeypatch):
     """The agent is a trusted backend and authenticates as service_role for ALL
     Supabase access, reads included. Anon reads return zero rows since read
     policies moved to the `authenticated` role (#57 / migration 0006)."""
+    from news_digest import supabase_client
+
     captured = {}
 
     def fake_create_client(url, key):
@@ -137,8 +139,8 @@ def test_client_authenticates_as_service_role(monkeypatch):
         supabase_service_key="SERVICE_KEY",
         supabase_anon_key="ANON_KEY",
     )
-    monkeypatch.setattr(publishing, "create_client", fake_create_client)
-    monkeypatch.setattr(publishing, "get_settings", lambda: settings)
+    monkeypatch.setattr(supabase_client, "create_client", fake_create_client)
+    monkeypatch.setattr(supabase_client, "get_settings", lambda: settings)
 
     publishing._client()
 

--- a/tests/test_supabase_client.py
+++ b/tests/test_supabase_client.py
@@ -1,0 +1,93 @@
+"""Tests for src/news_digest/supabase_client.py — shared cached Supabase client.
+
+The scheduler daemon runs 24/7 (~96 ticks/day, several log() calls per tick);
+building a fresh client — and a fresh httpx connection pool — per call leaks
+idle sockets over weeks. These tests lock the single-pool guarantee: one
+create_client per settings, reuse across modules, a resettable cache, and no
+caching of construction failures.
+"""
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from news_digest import supabase_client
+from news_digest.config import get_settings
+
+
+@pytest.fixture
+def counted_create(monkeypatch):
+    """Replace create_client with a counting fake returning distinct mocks."""
+    calls = {"count": 0}
+
+    def fake_create_client(url, key):
+        calls["count"] += 1
+        return MagicMock(name=f"client-{calls['count']}")
+
+    monkeypatch.setattr(supabase_client, "create_client", fake_create_client)
+    return calls
+
+
+def test_get_client_reuses_one_client(valid_env, counted_create):
+    first = supabase_client.get_client()
+    second = supabase_client.get_client()
+    assert first is second
+    assert counted_create["count"] == 1
+
+
+def test_cache_clear_builds_fresh_client(valid_env, counted_create):
+    first = supabase_client.get_client()
+    supabase_client.cache_clear()
+    second = supabase_client.get_client()
+    assert first is not second
+    assert counted_create["count"] == 2
+
+
+def test_client_rebuilt_when_settings_change(valid_env, counted_create, monkeypatch):
+    """The cache is keyed on settings values: a rotated key yields a new client
+    without an explicit cache_clear()."""
+    first = supabase_client.get_client()
+    monkeypatch.setenv("SUPABASE_SERVICE_KEY", "rotated-key")
+    get_settings.cache_clear()
+    second = supabase_client.get_client()
+    assert first is not second
+    assert counted_create["count"] == 2
+
+
+def test_construction_failure_is_not_cached(valid_env, monkeypatch):
+    """A transient create_client failure must not poison the cache —
+    lru_cache does not memoise exceptions, so the next call retries."""
+    attempts = {"count": 0}
+
+    def flaky_create_client(url, key):
+        attempts["count"] += 1
+        if attempts["count"] == 1:
+            raise RuntimeError("transient construction failure")
+        return MagicMock()
+
+    monkeypatch.setattr(supabase_client, "create_client", flaky_create_client)
+
+    with pytest.raises(RuntimeError):
+        supabase_client.get_client()
+    client = supabase_client.get_client()
+    assert client is supabase_client.get_client()
+    assert attempts["count"] == 2
+
+
+def test_all_call_sites_share_one_client(
+    valid_env, counted_create, monkeypatch, tmp_path
+):
+    """log(), the publishing tools, and the scheduler must all ride the same
+    pooled client — exactly one create_client for the whole process."""
+    from news_digest import logging as nd_logging
+    from news_digest import scheduler
+    from news_digest.tools import publishing
+
+    monkeypatch.setenv("FALLBACK_LOG_PATH", str(tmp_path / "fallback.sqlite"))
+
+    nd_logging.log("info", "system", "first")
+    nd_logging.log("info", "system", "second")
+    shared = supabase_client.get_client()
+    assert publishing._client() is shared
+    assert scheduler._client() is shared
+    assert counted_create["count"] == 1


### PR DESCRIPTION
## What

Introduces a process-wide cached Supabase client (`news_digest/supabase_client.py`) and routes all three call sites through it:

- `logging.log()` and `logging.drain_fallback()` call the shared `get_client()` instead of `create_client(...)` per call
- `publishing._client()` stays as the monkeypatch seam for tests but now returns the shared client
- `scheduler._client()` inherits the cache via its existing delegation to `publishing._client`

## Why

Every `log()` call, every publishing tool invocation, and the scheduler's topic fetch constructed a fresh Supabase client, each allocating an httpx connection pool that is never closed. The scheduler daemon runs 24/7 under systemd (~96 ticks/day, several `log()` calls per tick), so idle sockets and file descriptors accumulate over weeks of uptime.

## How

`get_client()` wraps an `lru_cache(maxsize=1)` keyed on `(supabase_url, supabase_service_key)`:

- a settings change (e.g. rotated key, test env swap) transparently builds a new client — no stale-client hazard
- `lru_cache` does not memoise exceptions, so a transient `create_client` failure cannot poison the cache
- `cache_clear()` is the explicit reset hook, mirroring `config.get_settings.cache_clear`; it's wired into conftest's autouse env-isolation fixture so every test stays hermetic

The fallback-to-SQLite behavior in `log()` is unchanged — client construction still happens inside the same `try/except`, so an unreachable Supabase lands rows in the local fallback DB exactly as before.

## Reviewer notes

- `test_logging.py` / `test_logging_recovery.py` patch targets moved from `news_digest.logging.create_client` to `news_digest.logging.get_client` (mechanical; mock shapes unchanged)
- the service-role auth test in `test_publishing_tools.py` now patches `news_digest.supabase_client` since `create_client`/`get_settings` no longer live in the publishing namespace
- new `tests/test_supabase_client.py` locks: client reuse, `cache_clear()` reset, settings-keyed rebuild, no caching of construction failures, and one shared client across logging/publishing/scheduler

## Verification

`ruff check src tests` → All checks passed
`pytest -m "not integration" -q` → 223 passed, 6 deselected