### PR TITLE
Make scheduler jitter sleep SIGTERM-interruptible

### DIFF
--- a/src/news_digest/scheduler.py
+++ b/src/news_digest/scheduler.py
@@ -19,7 +19,7 @@ See §2.6, §4, and §5.5 of docs/architecture.md for the design spec.
 
 import random
 import signal
-import time
+import threading
 from datetime import UTC, date, datetime, timedelta
 from typing import Any
 
@@ -28,6 +28,12 @@ from apscheduler.schedulers.blocking import BlockingScheduler
 from news_digest.logging import log
 from news_digest.tools.publishing import get_last_digest_date
 from supabase import Client
+
+# Set once when a SIGTERM/SIGINT arrives; never reset — this is a one-shot
+# daemon process.  Used by _run_topic and run_cycle to abort sleeps and
+# skip not-yet-started topics instead of letting the process drift minutes
+# past its shutdown deadline.
+_shutdown_event = threading.Event()
 
 # Tick every 15 minutes.
 _TICK_MINUTES = 15
@@ -189,7 +195,15 @@ def _run_topic(topic: dict[str, Any], agent: Any) -> None:
         topic_slug=slug,
         metadata={"slug": slug, "jitter_s": round(jitter, 1)},
     )
-    time.sleep(jitter)
+    if _shutdown_event.wait(jitter):
+        log(
+            "info",
+            "schedule",
+            f"_run_topic: shutdown requested during jitter — skipping {slug!r}",
+            topic_slug=slug,
+            metadata={"slug": slug},
+        )
+        return
 
     for attempt in range(1, _MAX_RUN_ATTEMPTS + 1):
         try:
@@ -258,6 +272,15 @@ def _run_topic(topic: dict[str, Any], agent: Any) -> None:
 
         # Not published yet.
         if attempt < _MAX_RUN_ATTEMPTS:
+            if _shutdown_event.is_set():
+                log(
+                    "info",
+                    "schedule",
+                    f"_run_topic: shutdown requested — stopping retries for {slug!r}",
+                    topic_slug=slug,
+                    metadata={"slug": slug, "attempt": attempt},
+                )
+                return
             log(
                 "warn",
                 "schedule",
@@ -362,8 +385,21 @@ def run_cycle(agent: Any | None = None) -> None:
 
     # Run due topics one at a time (max_instances=1 enforced by sequential loop).
     for topic in topics:
-        if topic.get("slug") in due_slugs:
-            _run_topic(topic, agent)
+        if topic.get("slug") not in due_slugs:
+            continue
+        if _shutdown_event.is_set():
+            log(
+                "info",
+                "schedule",
+                "run_cycle: shutdown requested — aborting cycle early",
+                metadata={
+                    "remaining": [
+                        t.get("slug") for t in topics if t.get("slug") in due_slugs
+                    ]
+                },
+            )
+            break
+        _run_topic(topic, agent)
 
     _log_cycle_end(cycle_start, due_slugs=due_slugs)
 
@@ -404,6 +440,7 @@ def _install_signal_handlers(scheduler: BlockingScheduler) -> None:
             f"received {signal.Signals(signum).name} — shutting down cleanly",
             metadata={"signal": signal.Signals(signum).name},
         )
+        _shutdown_event.set()
         scheduler.shutdown(wait=True)
 
     signal.signal(signal.SIGTERM, _handle)

--- a/tests/test_scheduler.py
+++ b/tests/test_scheduler.py
@@ -7,6 +7,7 @@ helper functions directly.
 """
 
 import signal
+import threading
 from datetime import UTC, datetime, timedelta
 from unittest.mock import MagicMock, patch
 
@@ -46,8 +47,15 @@ def log_calls(_silence_log):
 
 @pytest.fixture(autouse=True)
 def _no_sleep(monkeypatch):
-    """Skip actual jitter sleeps so tests run at full speed."""
-    monkeypatch.setattr(sched_module.time, "sleep", lambda _: None)
+    """Skip actual jitter sleeps so tests run at full speed.
+
+    Patches _shutdown_event.wait so the interruptible jitter returns immediately
+    with False (not set / no shutdown requested) in all tests that don't
+    explicitly test shutdown behaviour.  Also clears _shutdown_event before each
+    test so that tests which set it don't bleed into subsequent tests.
+    """
+    sched_module._shutdown_event.clear()
+    monkeypatch.setattr(sched_module._shutdown_event, "wait", lambda _: False)
 
 
 @pytest.fixture(autouse=True)
@@ -682,3 +690,106 @@ def test_run_topic_read_error_with_failed_run_result_still_retries(
     assert agent.generate_and_publish.call_count == _MAX_RUN_ATTEMPTS
     errors = [a for (a, _) in log_calls if a[0] == "error"]
     assert any("failed to publish" in a[2] for a in errors)
+
+
+# ---------------------------------------------------------------------------
+# Shutdown-event interruptibility — follow-up to #88
+# ---------------------------------------------------------------------------
+
+
+def test_run_topic_skips_when_shutdown_set_during_jitter(monkeypatch, log_calls):
+    """When _shutdown_event is set during the jitter wait, the topic is not run.
+
+    _shutdown_event.wait() returns True (event is set), simulating SIGTERM
+    arriving while sleeping.
+    """
+    monkeypatch.setattr(sched_module._shutdown_event, "wait", lambda _: True)
+
+    agent = MagicMock()
+    _run_topic(_topic_row(), agent)
+
+    agent.generate_and_publish.assert_not_called()
+    infos = [a for (a, _) in log_calls if a[0] == "info"]
+    assert any("shutdown requested during jitter" in a[2] for a in infos)
+    assert any("skipping" in a[2] for a in infos)
+
+
+def test_run_cycle_aborts_remaining_topics_when_shutdown_set_mid_cycle(
+    monkeypatch, log_calls, _patch_last_date_fn
+):
+    """run_cycle stops launching new topic runs once _shutdown_event is set.
+
+    The first topic runs; then the event is set; the second topic must be
+    skipped with an "aborting cycle early" log message.
+    """
+    _patch_last_date_fn(None)  # both topics due
+
+    topics = [
+        {"slug": "ai_models", "name": "AI Models", "cadence": "24h", "enabled": True},
+        {"slug": "ai_updates", "name": "AI Updates", "cadence": "24h", "enabled": True},
+    ]
+    client = _make_client(topics)
+
+    call_count = {"n": 0}
+
+    def _fake_run_topic(topic, agent_):
+        call_count["n"] += 1
+        # After first topic, simulate shutdown arriving.
+        sched_module._shutdown_event.set()
+
+    monkeypatch.setattr(sched_module, "_run_topic", _fake_run_topic)
+
+    agent = _make_agent()
+    with patch("news_digest.scheduler._client", return_value=client):
+        run_cycle(agent=agent)
+
+    assert call_count["n"] == 1
+    infos = [a for (a, _) in log_calls if a[0] == "info"]
+    assert any("aborting cycle early" in a[2] for a in infos)
+
+
+def test_run_topic_stops_retrying_when_shutdown_set_between_attempts(
+    monkeypatch, log_calls, _patch_not_published
+):
+    """Retry loop exits early when _shutdown_event is set between attempts.
+
+    First attempt fails to publish; shutdown arrives before the second retry;
+    generate_and_publish must only be called once.
+    """
+    call_count = {"n": 0}
+
+    def _fake_generate(query):
+        call_count["n"] += 1
+        # After first attempt, set the shutdown event.
+        sched_module._shutdown_event.set()
+        return {"success": False, "error": "parse_error"}
+
+    agent = MagicMock()
+    agent.generate_and_publish.side_effect = _fake_generate
+
+    _run_topic(_topic_row(), agent)
+
+    assert agent.generate_and_publish.call_count == 1
+    infos = [a for (a, _) in log_calls if a[0] == "info"]
+    assert any("shutdown requested" in a[2] and "retries" in a[2] for a in infos)
+
+
+def test_signal_handler_sets_shutdown_event(monkeypatch, log_calls):
+    """The installed signal handler sets _shutdown_event before scheduler.shutdown."""
+    registered: dict[int, object] = {}
+    monkeypatch.setattr(
+        sched_module.signal,
+        "signal",
+        lambda signum, handler: registered.setdefault(signum, handler),
+    )
+    # Restore a fresh event so we can observe it being set.
+    fresh_event = threading.Event()
+    monkeypatch.setattr(sched_module, "_shutdown_event", fresh_event)
+
+    scheduler = MagicMock()
+    _install_signal_handlers(scheduler)
+
+    assert not fresh_event.is_set()
+    registered[signal.SIGTERM](signal.SIGTERM, None)
+    assert fresh_event.is_set()
+    scheduler.shutdown.assert_called_once_with(wait=True)


### PR DESCRIPTION
Follow-up to #88.

## Problem

`_run_topic()` used `time.sleep(jitter)` (0–300 s). Two shutdown-latency paths existed:

1. **Startup `run_cycle()`** in `main()` runs before `scheduler.start()`, so `scheduler.shutdown(wait=True)` is a no-op if SIGTERM arrives during that cycle's jitter sleep — the process keeps sleeping and then continues running LLM jobs.
2. **APScheduler-executed ticks**: `shutdown(wait=True)` blocks until the in-flight job finishes, which means sleeping out the full remaining jitter and then starting LLM runs for any remaining due topics.

## Fix

- Added module-level `threading.Event _shutdown_event` (set-once, never reset — this is a one-shot daemon process).
- Replaced `time.sleep(jitter)` with `_shutdown_event.wait(jitter)`: returns `True` instantly when shutdown is signalled, logs "shutdown requested during jitter — skipping" and returns without running the topic.
- `run_cycle` checks `_shutdown_event.is_set()` before each topic and breaks with "aborting cycle early" if set.
- Retry loop checks `is_set()` between attempts and exits cleanly if set.
- Signal handler sets the event **before** calling `scheduler.shutdown(wait=True)`.

An in-flight LLM run still completes — that is intentional; we only skip sleeps and not-yet-started topics.

## Tests

4 new hermetic tests:
- `test_run_topic_skips_when_shutdown_set_during_jitter`
- `test_run_cycle_aborts_remaining_topics_when_shutdown_set_mid_cycle`
- `test_run_topic_stops_retrying_when_shutdown_set_between_attempts`
- `test_signal_handler_sets_shutdown_event`

The existing 35 scheduler tests pass unchanged. The `_no_sleep` autouse fixture now patches `_shutdown_event.wait` (→ `False`, instant) instead of `time.sleep` (which is no longer imported).

## Test results

```
243 passed, 6 deselected, 1 warning
ruff check: All checks passed
ruff format: 27 files already formatted
```