### PR TITLE
Raise agent completion max_tokens to 4096; bound world_news item count

### DIFF
--- a/src/news_digest/agent.py
+++ b/src/news_digest/agent.py
@@ -236,6 +236,12 @@ class NewsDigestAgent(Agent, DatabaseMixin):
         # local 35B models. Set via AgentConfig (gaia/chat/sdk.py:27) which is
         # read by send_messages / send_messages_stream before every completion.
         self.chat.config.temperature = 0.0
+        # GAIA's AgentConfig defaults max_tokens to 512 (gaia/chat/sdk.py:26),
+        # which truncates the final-answer JSON of multi-item digests (a 5-7
+        # item world_news answer needs 1,500-2,500 tokens) and cascades into a
+        # completion-loop deadlock and parse_error. 4096 gives ~2x headroom
+        # over the largest topic's final answer.
+        self.chat.config.max_tokens = 4096
         # GAIA drives tools via a JSON-in-content protocol. The loaded Lemonade
         # chat models otherwise emit "thinking" output with empty content, which
         # breaks tool parsing — force thinking off on every completion.

--- a/supabase/migrations/0014_world_news_concise_hint.sql
+++ b/supabase/migrations/0014_world_news_concise_hint.sql
@@ -1,0 +1,19 @@
+-- 0014_world_news_concise_hint.sql — bound the world_news digest size.
+--
+-- The first scheduled world_news runs (2026-06-12) failed to publish 3/3
+-- attempts: the topic's unbounded item list produced a final-answer JSON
+-- larger than the completion budget, truncating it mid-stream (parse_error).
+-- The primary fix raises the agent's max_tokens (src/news_digest/agent.py);
+-- this hint is defense-in-depth: it bounds the answer size so the heaviest
+-- topic stays comfortably inside the budget, and enforces editorial focus.
+--
+-- Idempotent: the `not like` guard makes re-running a no-op (re-run safety
+-- contract, supabase/README.md).
+
+update digest_topics
+set prompt_hint = prompt_hint || '
+
+Digest size limit (mandatory): select the 5 most significant stories only.
+Keep each item''s detail under 2 sentences. Concise output.'
+where slug = 'world_news'
+  and prompt_hint not like '%5 most significant stories%';

--- a/tests/test_prompts.py
+++ b/tests/test_prompts.py
@@ -341,7 +341,7 @@ def test_world_news_migration_contains_since_hours_72():
     import pathlib
 
     migrations = pathlib.Path(__file__).parent.parent / "supabase" / "migrations"
-    world_news_file = next(migrations.glob("*world_news*"))
+    world_news_file = next(migrations.glob("0010_*world_news*"))
     content = world_news_file.read_text()
     assert "since_hours=72" in content or "since_hours = 72" in content
 
@@ -352,7 +352,7 @@ def test_world_news_migration_instructs_self_dedup_limit_2():
     import pathlib
 
     migrations = pathlib.Path(__file__).parent.parent / "supabase" / "migrations"
-    world_news_file = next(migrations.glob("*world_news*"))
+    world_news_file = next(migrations.glob("0010_*world_news*"))
     content = world_news_file.read_text()
     assert "world_news" in content
     assert "limit=2" in content
@@ -364,7 +364,7 @@ def test_world_news_migration_instructs_english_output():
     import pathlib
 
     migrations = pathlib.Path(__file__).parent.parent / "supabase" / "migrations"
-    world_news_file = next(migrations.glob("*world_news*"))
+    world_news_file = next(migrations.glob("0010_*world_news*"))
     content = world_news_file.read_text()
     assert "english" in content.lower() or "English" in content
 
@@ -375,7 +375,7 @@ def test_world_news_migration_instructs_metadata_sentiment_key():
     import pathlib
 
     migrations = pathlib.Path(__file__).parent.parent / "supabase" / "migrations"
-    world_news_file = next(migrations.glob("*world_news*"))
+    world_news_file = next(migrations.glob("0010_*world_news*"))
     content = world_news_file.read_text()
     assert '"sentiment"' in content
     for tag in SENTIMENT_TAGS:
@@ -391,7 +391,7 @@ def test_world_news_migration_lists_six_rss_sources():
     import re
 
     migrations = pathlib.Path(__file__).parent.parent / "supabase" / "migrations"
-    world_news_file = next(migrations.glob("*world_news*"))
+    world_news_file = next(migrations.glob("0010_*world_news*"))
     content = world_news_file.read_text()
     # Extract the JSON array from between the single-quoted literals.
     match = re.search(r"'\s*(\[.*?\])\s*'::", content, re.DOTALL)
@@ -399,3 +399,16 @@ def test_world_news_migration_lists_six_rss_sources():
     sources = json.loads(match.group(1))
     rss_sources = [s for s in sources if s.get("type") == "rss"]
     assert len(rss_sources) == 6, f"Expected 6 RSS sources, found {len(rss_sources)}"
+
+
+def test_world_news_concise_hint_migration_is_guarded():
+    """0014 bounds the world_news digest size (truncation defense) and must be
+    idempotent: the not-like guard keys on the same phrase it appends."""
+    import pathlib
+
+    migrations = pathlib.Path(__file__).parent.parent / "supabase" / "migrations"
+    f = migrations / "0014_world_news_concise_hint.sql"
+    content = f.read_text()
+    assert "5 most significant stories" in content
+    assert "not like '%5 most significant stories%'" in content
+    assert "slug = 'world_news'" in content


### PR DESCRIPTION
## Problem

The first scheduled `world_news` runs (2026-06-12 01:53–01:55 UTC) failed to publish 3/3 attempts, each logged as `parse_error` by the #44 retry wrapper.

## Root cause (journal evidence on the Strix Halo)

GAIA's `AgentConfig.max_tokens` defaults to **512** (`gaia/chat/sdk.py:26`) and is applied to every completion (`sdk.py:230-231`). The agent sets `temperature=0.0` but never set `max_tokens`. A 5–7 item world_news final answer needs 1,500–2,500 tokens, so at the final-answer step the model emitted a truncated thought-only reply; GAIA's completion loop appended it and re-sent consecutive assistant messages → llama-server HTTP 400 → GAIA's prose fallback answer → `_publish_from_result` `parse_error`. The three failures are identical in the journal. Smaller topics (ai_models, ai_updates) fit inside 512 and published fine the same night.

## Fix

- `src/news_digest/agent.py`: `self.chat.config.max_tokens = 4096` via the same supported AgentConfig mechanism as the existing temperature setting (~2× headroom over the largest topic's answer; the 32k context window already requested at startup has room).
- `supabase/migrations/0014_world_news_concise_hint.sql` (defense-in-depth): bound world_news to the 5 most significant stories, details under 2 sentences. Idempotent.
- Tests: existing world_news migration tests pinned to the 0010 seed file (their `*world_news*` glob would otherwise match 0014 nondeterministically); new guard test for 0014.

## Gates

`ruff check` clean · `ruff format --check` clean · `pytest -m "not integration"` → **244 passed**

Follow-up to #19 / #44.