### PR TITLE
Fix Today-screen date heading rendering one day early (#92)

### DIFF
--- a/web/src/views/digest-list.ts
+++ b/web/src/views/digest-list.ts
@@ -2,15 +2,22 @@ import { groupDigestsByTopicAndDate } from "../lib/group";
 import type { Digest, Topic } from "../lib/types";
 import { renderDigestCard } from "./digest-card";
 
+// timeZone: "UTC" is required. digest_date is a calendar date (YYYY-MM-DD) with
+// no time-of-day or zone meaning. We build the Date at UTC midnight, so we must
+// also format it in UTC — otherwise Intl renders it in the viewer's local zone
+// and any viewer west of UTC sees the heading shift back a day (e.g. 2026-06-12
+// displayed as "Thu, Jun 11" in US Eastern). Must match the raw digest_date the
+// History view prints.
 const dateFmt = new Intl.DateTimeFormat(undefined, {
   weekday: "short",
   month: "short",
   day: "numeric",
   year: "numeric",
+  timeZone: "UTC",
 });
 
-function formatDate(iso: string): string {
-  // iso is YYYY-MM-DD; render in local-neutral form without TZ shifting.
+/** Format a YYYY-MM-DD calendar date for display, always in UTC (see dateFmt). */
+export function formatDate(iso: string): string {
   const [y, m, d] = iso.split("-").map(Number);
   if (!y || !m || !d) return iso;
   return dateFmt.format(new Date(Date.UTC(y, m - 1, d)));

--- a/web/tests/unit/digest-list.test.ts
+++ b/web/tests/unit/digest-list.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it } from "vitest";
+
+import { formatDate } from "../../src/views/digest-list";
+
+// Regression for the Today-screen date rendering one day early (issue #92):
+// a calendar digest_date must render the SAME day-of-month regardless of the
+// viewer's timezone, because dateFmt pins timeZone: "UTC". Assertions are
+// locale-independent (formatDate uses the system locale internally) — they
+// check the day token, not the exact formatted string.
+describe("formatDate", () => {
+  it("keeps the day-of-month for a mid-month date (no tz shift back)", () => {
+    const out = formatDate("2026-06-12");
+    expect(out).toContain("12");
+    expect(out).not.toContain("11"); // would appear if rendered in a UTC-behind zone
+    expect(out).not.toContain("13"); // would appear if rendered in a UTC-ahead zone
+  });
+
+  it("keeps the day across a month boundary (UTC midnight, not local)", () => {
+    const out = formatDate("2026-06-01");
+    expect(out).toContain("1");
+    expect(out).not.toContain("31"); // May 31 would appear if shifted back
+  });
+
+  it("returns the raw string for malformed input", () => {
+    expect(formatDate("not-a-date")).toBe("not-a-date");
+  });
+});


### PR DESCRIPTION
## Problem

The **Today** screen showed the current `ai_models` digest headed "THU, JUN 11, 2026" while **History** showed the same row as "2026-06-12" — making today's digest look like yesterday's. Both render the same DB row (`digest_date=2026-06-12`, written 01:23 UTC = 9:23 PM ET Jun 11); only the Today label was wrong.

## Root cause

`web/src/views/digest-list.ts` — `formatDate` builds `new Date(Date.UTC(y, m-1, d))` (UTC midnight) but the `Intl.DateTimeFormat` had **no `timeZone`**, so it formatted in the viewer's local zone. In US Eastern, UTC-midnight Jun 12 is 8 PM Jun 11 → "Thu, Jun 11". Every viewer west of UTC was affected. The code comment even claimed "without TZ shifting" — that was the bug.

## Fix

Add `timeZone: "UTC"` to the formatter so the UTC-midnight Date is also formatted in UTC, matching the raw `digest_date` History prints. `digest_date` is a calendar date with no zone meaning, so UTC formatting is correct for all viewers.

`formatDate` is now exported with a locale-independent regression test (asserts the day-of-month doesn't shift; covers a mid-month date and a month-boundary date).

## Gates
`eslint + tsc` clean · `test:unit` **356 passed** (+3) · `build` clean

Closes #92.