### PR TITLE
Fix stale missed-digest banner: compute overdue topics live

### DIFF
--- a/supabase/migrations/0015_missed_digest_live_view.sql
+++ b/supabase/migrations/0015_missed_digest_live_view.sql
@@ -1,0 +1,40 @@
+-- 0015_missed_digest_live_view.sql — Live missed-digest view.
+--
+-- The dashboard's "Missed digest alerts" banner previously read append-only
+-- warn rows written by fn_check_missed_digests() (0013). Those rows were
+-- correct at write time but never reconciled: once a digest published, the
+-- warn row lingered and kept the banner lit for its whole 48h read window
+-- (e.g. world_news warned at 01:58 UTC, published at 02:12 UTC, yet the banner
+-- stayed up). This view computes overdue topics LIVE from current state, so
+-- the banner reflects reality in both directions and cannot go stale.
+--
+-- Window logic mirrors fn_check_missed_digests() exactly:
+--   24h topics: overdue if no digest in the last 26h
+--    7d topics: overdue if no digest in the last 7d+2h (170h)
+-- The daily fn_check_missed_digests() cron is intentionally LEFT in place: its
+-- warn rows remain a historical audit trail in system_logs / the Logs page.
+--
+-- SELECT-only; authenticated role is granted SELECT (matches the 0013 views).
+-- Idempotent: re-applying is safe.
+
+create or replace view v_missed_digests as
+select
+  t.slug                                             as topic_slug,
+  t.cadence,
+  m.last_digest_date,
+  case when t.cadence = '24h' then 26 else 170 end   as window_hours
+from digest_topics t
+left join (
+  select topic_slug, max(digest_date) as last_digest_date
+  from digests
+  group by topic_slug
+) m on m.topic_slug = t.slug
+where t.enabled = true
+  and (
+    m.last_digest_date is null
+    or m.last_digest_date
+       < (now() - make_interval(hours => case when t.cadence = '24h' then 26 else 170 end))::date
+  )
+order by t.slug;
+
+grant select on v_missed_digests to authenticated;

--- a/web/src/lib/supabase.ts
+++ b/web/src/lib/supabase.ts
@@ -11,6 +11,7 @@ import {
 import type {
   Digest,
   ErrorsPerDay,
+  MissedDigest,
   RunDuration,
   SourceHealth,
   SystemLog,
@@ -209,26 +210,19 @@ export async function fetchTokenUsage(
   return (data ?? []) as unknown as TokenUsageDay[];
 }
 
-/** Fetch recent missed-digest warnings (last N hours). */
-export async function fetchMissedDigestWarnings(
+/**
+ * Fetch topics whose digest is currently overdue, computed live from the
+ * v_missed_digests view. Unlike the old log-based read, this reflects current
+ * state — a topic drops off the moment it publishes, so the banner never goes
+ * stale.
+ */
+export async function fetchMissedDigests(
   client: SupabaseClient,
-  hours = 48,
-): Promise<SystemLog[]> {
-  const since = new Date(Date.now() - hours * 3_600_000).toISOString();
+): Promise<MissedDigest[]> {
   const { data, error } = await client
-    .from("system_logs")
-    .select("id, timestamp, level, category, topic_slug, message, metadata, created_at")
-    .eq("category", "schedule")
-    .eq("level", "warn")
-    .gte("timestamp", since)
-    .order("timestamp", { ascending: false })
-    .limit(20);
+    .from("v_missed_digests")
+    .select("topic_slug, cadence, last_digest_date, window_hours")
+    .order("topic_slug", { ascending: true });
   if (error) throw error;
-  // Filter client-side for the missed_digest tag so non-missed-digest schedule
-  // warnings are excluded.
-  const rows = (data ?? []) as unknown as SystemLog[];
-  return rows.filter((r) => {
-    const m = r.metadata as Record<string, unknown> | null;
-    return m != null && m["missed_digest"] === true;
-  });
+  return (data ?? []) as unknown as MissedDigest[];
 }

--- a/web/src/lib/types.ts
+++ b/web/src/lib/types.ts
@@ -46,6 +46,17 @@ export interface Topic {
   enabled: boolean;
 }
 
+/**
+ * One overdue topic from the v_missed_digests view (computed live from current
+ * digest state, so it never goes stale once a digest publishes).
+ */
+export interface MissedDigest {
+  topic_slug: string;
+  cadence: string;
+  last_digest_date: string | null; // ISO date, or null if never published
+  window_hours: number;
+}
+
 /** One topic group, holding its digests bucketed by date (newest first). */
 export interface TopicGroup {
   slug: string;

--- a/web/src/pages/home.ts
+++ b/web/src/pages/home.ts
@@ -5,8 +5,8 @@ import {
   signOut,
   validatePassword,
 } from "../lib/auth";
-import { fetchDigests, fetchMissedDigestWarnings, fetchTopics } from "../lib/supabase";
-import type { SystemLog } from "../lib/types";
+import { fetchDigests, fetchMissedDigests, fetchTopics } from "../lib/supabase";
+import type { MissedDigest } from "../lib/types";
 import { renderAuthGate } from "../views/auth-gate";
 import { renderDigestList } from "../views/digest-list";
 
@@ -130,18 +130,18 @@ export async function renderHome(root: HTMLElement, client: SupabaseClient): Pro
   root.appendChild(renderAccount(client));
 
   try {
-    // Fetch digests, topics, and missed-digest warnings in parallel.
+    // Fetch digests, topics, and missed-digest alerts in parallel.
     // Missed-digest fetch failure is non-fatal — banner simply won't appear.
-    const [digests, topics, missedWarnings] = await Promise.all([
+    const [digests, topics, missed] = await Promise.all([
       fetchDigests(client),
       fetchTopics(client),
-      fetchMissedDigestWarnings(client, 48).catch((): SystemLog[] => []),
+      fetchMissedDigests(client).catch((): MissedDigest[] => []),
     ]);
 
     main.replaceChildren();
 
-    if (missedWarnings.length > 0) {
-      main.appendChild(renderMissedDigestBanner(missedWarnings));
+    if (missed.length > 0) {
+      main.appendChild(renderMissedDigestBanner(missed));
     }
 
     main.appendChild(renderDigestList(digests, topics));
@@ -155,7 +155,7 @@ export async function renderHome(root: HTMLElement, client: SupabaseClient): Pro
 }
 
 /** Render a warning banner listing topics with missed digests. */
-function renderMissedDigestBanner(warnings: SystemLog[]): HTMLElement {
+function renderMissedDigestBanner(missed: MissedDigest[]): HTMLElement {
   const banner = document.createElement("aside");
   banner.className = "missed-digest-banner";
   banner.setAttribute("role", "alert");
@@ -167,12 +167,10 @@ function renderMissedDigestBanner(warnings: SystemLog[]): HTMLElement {
 
   const list = document.createElement("ul");
   list.className = "missed-digest-list";
-  for (const w of warnings) {
+  for (const m of missed) {
     const li = document.createElement("li");
-    const meta = w.metadata as Record<string, unknown> | null;
-    const slug = (meta?.["topic_slug"] as string | undefined) ?? w.topic_slug ?? "unknown";
-    const cadence = (meta?.["cadence"] as string | undefined) ?? "";
-    li.textContent = cadence ? `${slug} (${cadence})` : slug;
+    const slug = m.topic_slug || "unknown";
+    li.textContent = m.cadence ? `${slug} (${m.cadence})` : slug;
     list.appendChild(li);
   }
   banner.appendChild(list);


### PR DESCRIPTION
## Problem

The dashboard's **"Missed digest alerts"** banner showed `world_news (24h)` as missed even though its digest had already published for today.

The banner was **log-based, not state-based**: `fetchMissedDigestWarnings` read append-only `system_logs` warn rows (written by `fn_check_missed_digests()`, migration 0013) within a 48h window. Those rows are never reconciled once a topic publishes, so a warning lingers for the full window.

Timeline (2026-06-12 UTC): `world_news` created 01:28 → first two publish attempts failed → missed-digest warn written 01:58 (`last_digest_date=null`, correct then) → **digest published 02:12** → banner stayed lit anyway.

## Fix

Compute overdue topics **live** from current state:
- New view `v_missed_digests` (migration `0015_missed_digest_live_view.sql`) computing overdue topics from `digest_topics × digests`. Window logic mirrors `fn_check_missed_digests()` exactly (26h for 24h cadence, 170h for 7d).
- Frontend reads the view via `fetchMissedDigests` instead of `system_logs`.
- The daily `fn_check_missed_digests()` cron stays in place as a historical audit trail.

A topic now drops off the banner the moment it publishes — no more staleness.

## Verification

- The view's exact SELECT, run read-only against prod, returns `[]` (zero overdue topics — `world_news` correctly excluded).
- `eslint` + `tsc --noEmit` clean; **356/356** unit tests pass.

## Deploy notes

- Migration `0015` already applied to the News Digest Supabase project.
- Once the web app deploys, the banner no longer reads `system_logs`, so the lingering `world_news` warn row becomes harmless history (no manual cleanup needed).

Closes #95