### PR TITLE
Scope source-health views to configured-source fetches

### DIFF
--- a/supabase/migrations/0015_source_health_scope_to_sources.sql
+++ b/supabase/migrations/0015_source_health_scope_to_sources.sql
@@ -1,0 +1,108 @@
+-- 0015_source_health_scope_to_sources.sql — Scope source-health views to
+-- *configured-source reachability* fetches only.
+--
+-- Problem: mv_source_health / v_source_success_rate (0013) aggregate EVERY
+-- scrape row by metadata->>'url'. That conflates two populations:
+--   (a) configured feed/page fetches — fetch_rss / fetch_html — keyed on a
+--       digest_topics source URL. These are what "source health" means.
+--   (b) per-article full-text fetches — parse_article / fetch_pdf_text — keyed
+--       on individual discovered article URLs. Paywalled / bot-blocked sites
+--       (nytimes.com, openai.com/index/*) routinely 403 these. They are not
+--       sources, are one-shot, and the headline+summary was already obtained
+--       from the working feed — so they should NOT count as a "stale source".
+--
+-- Fix: restrict both views to fetch_rss / fetch_html rows. Every scrape log
+-- message is prefixed with its tool name (scraping.py: fetch_rss:280+,
+-- fetch_html:480+, parse_article:565+, fetch_pdf_text), so a message-prefix
+-- predicate is an exact, source-introspected filter.
+--
+-- Outcome classification is unchanged from 0013 (see that header). Idempotent.
+
+-- ── v_source_success_rate ─────────────────────────────────────────────────────
+create or replace view v_source_success_rate as
+with scrape as (
+  select
+    timestamp,
+    metadata ->> 'url' as source_url,
+    (level = 'info' and metadata ? 'duration_ms')          as is_success,
+    (
+      level = 'warn'
+      and not metadata ? 'bozo_exception'
+      and not metadata ? 'truncated_chars'
+    )                                                       as is_failure
+  from system_logs
+  where
+    category = 'scrape'
+    and metadata ->> 'url' is not null
+    and (message like 'fetch_rss:%' or message like 'fetch_html:%')
+    and timestamp >= now() - interval '7 days'
+)
+select
+  source_url,
+  count(*) filter (where is_success)                       as success_count,
+  count(*) filter (where is_failure)                       as failure_count,
+  count(*) filter (where is_success or is_failure)         as total_count,
+  round(
+    count(*) filter (where is_success)::numeric
+    / nullif(count(*) filter (where is_success or is_failure), 0) * 100,
+    1
+  )                                                         as success_pct,
+  max(timestamp) filter (where is_success)                 as last_success_at,
+  max(timestamp) filter (where is_failure)                 as last_error_at
+from scrape
+group by source_url;
+
+grant select on v_source_success_rate to authenticated;
+
+-- ── mv_source_health ──────────────────────────────────────────────────────────
+-- Materialized view definition can't be altered in place; drop + recreate.
+-- The hourly pg_cron refresh job (0013) references it by name and survives.
+drop materialized view if exists mv_source_health;
+
+create materialized view mv_source_health as
+with scrape as (
+  select
+    timestamp,
+    message,
+    metadata ->> 'url' as source_url,
+    (level = 'info' and metadata ? 'duration_ms')          as is_success,
+    (
+      level = 'warn'
+      and not metadata ? 'bozo_exception'
+      and not metadata ? 'truncated_chars'
+    )                                                       as is_failure
+  from system_logs
+  where
+    category = 'scrape'
+    and metadata ->> 'url' is not null
+    and (message like 'fetch_rss:%' or message like 'fetch_html:%')
+    and timestamp >= now() - interval '7 days'
+)
+select
+  s.source_url,
+  count(*) filter (where s.is_success)                     as success_7d,
+  count(*) filter (where s.is_failure)                     as failure_7d,
+  count(*) filter (where s.is_success or s.is_failure)     as total_7d,
+  round(
+    count(*) filter (where s.is_success)::numeric
+    / nullif(count(*) filter (where s.is_success or s.is_failure), 0) * 100,
+    1
+  )                                                         as success_pct_7d,
+  max(s.timestamp) filter (where s.is_success)             as last_success_at,
+  max(s.timestamp) filter (where s.is_failure)             as last_error_at,
+  max(s.timestamp)                                          as last_fetch_at,
+  (
+    select s2.message
+    from scrape s2
+    where s2.source_url = s.source_url and s2.is_failure
+    order by s2.timestamp desc
+    limit 1
+  )                                                         as last_error
+from scrape s
+group by s.source_url
+with data;
+
+create unique index if not exists mv_source_health_url_idx
+  on mv_source_health (source_url);
+
+grant select on mv_source_health to authenticated;


### PR DESCRIPTION
Closes #96

## Why

The **Source Health** panel was showing 11 "stale sources", but 4 of them (`nytimes.com/*`, `openai.com/index/*`) weren't sources at all — they were individual articles `parse_article` tried to read in full and got 403'd on (paywall / bot-block). `mv_source_health` (0013) aggregated *every* scrape row by `metadata->>'url'`, so per-article fetches were counted alongside configured feed/page fetches.

These article rows are one-shot, age out of the 7-day window on their own, and the agent already had the headline + summary from the working feed — so flagging them as stale sources is noise that obscures the genuinely-broken feeds.

## What

Scope `v_source_success_rate` and `mv_source_health` to source-reachability fetches only — `fetch_rss` / `fetch_html` — via a `message like 'fetch_rss:%' or message like 'fetch_html:%'` predicate. Every scrape log message is prefixed with its tool name (`src/news_digest/tools/scraping.py`), so this is an exact, source-introspected filter.

The materialized view is dropped & recreated (matviews can't be `CREATE OR REPLACE`'d). Preserved:
- the unique index `mv_source_health_url_idx` required for the hourly `REFRESH ... CONCURRENTLY` cron job (0013)
- `SELECT` grants to `authenticated`
- the is_success / is_failure outcome classification and `last_error` correlated subquery (unchanged from 0013 except the added predicate)

Idempotent (`create or replace view`, `drop … if exists`, `create unique index if not exists`).

## Verification

Applied live; the rebuilt view returns the 4 article-403 rows **gone**, all working sources at 100%. Pre-commit code review: clean.

## Out of scope (already done in DB)

The genuinely-dead configured sources this panel surfaced were corrected directly in the `digest_topics` table (data, not schema): repointed dead Meta/Anthropic/AMD AI feeds to live pages, and rebuilt `local_news` (dropped NXDOMAIN/404 sources, added live Bucks County RSS feeds).