### PR TITLE
Home: show only the current date's digests, with a clear empty state

### DIFF
--- a/web/src/lib/dates.ts
+++ b/web/src/lib/dates.ts
@@ -1,0 +1,21 @@
+// Date utilities for the News Digest app.
+// All "today" comparisons use America/New_York — the agent runs on Eastern time,
+// so that is the canonical date boundary for digest publication.
+
+export const APP_TIMEZONE = "America/New_York";
+
+/**
+ * Return today's calendar date as a YYYY-MM-DD string in America/New_York.
+ * Accepts an optional `now` for testability; defaults to the current instant.
+ */
+export function appToday(now: Date = new Date()): string {
+  return new Intl.DateTimeFormat("en-CA", { timeZone: APP_TIMEZONE }).format(now);
+}
+
+/**
+ * Return true if `digestDate` (YYYY-MM-DD) matches today in America/New_York.
+ * Accepts an optional `now` for testability.
+ */
+export function isToday(digestDate: string, now: Date = new Date()): boolean {
+  return digestDate === appToday(now);
+}

--- a/web/src/pages/home.ts
+++ b/web/src/pages/home.ts
@@ -5,12 +5,53 @@ import {
   signOut,
   validatePassword,
 } from "../lib/auth";
+import { isToday } from "../lib/dates";
 import { fetchDigests, fetchMissedDigests, fetchTopics } from "../lib/supabase";
-import type { MissedDigest } from "../lib/types";
+import type { Digest, MissedDigest } from "../lib/types";
 import { renderAuthGate } from "../views/auth-gate";
 import { renderDigestList } from "../views/digest-list";
 
 // Home page: auth gate for unauthenticated/AAL1 users, grouped digest list otherwise.
+
+// ── Digest filtering helpers (exported for unit tests) ───────────────────────
+
+/**
+ * No-news sentinel patterns produced by the LLM when there is nothing to report.
+ * This heuristic will be superseded by issue #91 (structured filler detection).
+ * We drop a digest whose content matches any of these patterns.
+ */
+const FILLER_STARTS = ["no new", "no significant", "nothing", "there were no"] as const;
+const FILLER_CONTAINS = ["were reported by curated sources", "no news"] as const;
+
+/**
+ * Return true if the digest has content worth showing on the home screen.
+ *
+ * Priority:
+ *  1. A non-empty `items` array → always publishable (structured content wins).
+ *  2. Otherwise fall back to `content`: keep if non-empty and not a no-news sentinel.
+ *
+ * NOTE: issue #91 will supersede the sentinel heuristic with a structured flag.
+ */
+export function isPublishableDigest(d: Digest): boolean {
+  if (Array.isArray(d.items) && d.items.length > 0) return true;
+
+  const text = d.content.trim();
+  if (!text) return false;
+
+  const lower = text.toLowerCase();
+  if (FILLER_STARTS.some((prefix) => lower.startsWith(prefix))) return false;
+  if (FILLER_CONTAINS.some((phrase) => lower.includes(phrase))) return false;
+
+  return true;
+}
+
+/**
+ * Filter `digests` to only those for today (America/New_York) that are publishable.
+ * Accepts an optional `now` for testability.
+ */
+export function filterTodayDigests(digests: readonly Digest[], now: Date = new Date()): Digest[] {
+  return digests.filter((d) => isToday(d.digest_date, now) && isPublishableDigest(d));
+}
 
 /** Minimal authenticated Account control: change the (initially temporary) password. */
 function renderAccount(client: SupabaseClient): HTMLElement {
@@ -132,11 +173,14 @@ export async function renderHome(root: HTMLElement, client: SupabaseClient): Pro
   try {
     // Fetch digests, topics, and missed-digest alerts in parallel.
     // Missed-digest fetch failure is non-fatal — banner simply won't appear.
-    const [digests, topics, missed] = await Promise.all([
+    const [allDigests, topics, missed] = await Promise.all([
       fetchDigests(client),
       fetchTopics(client),
       fetchMissedDigests(client).catch((): MissedDigest[] => []),
     ]);
+
+    // Show only today's publishable digests on the home screen. History has the full set.
+    const digests = filterTodayDigests(allDigests);
 
     main.replaceChildren();
 

--- a/web/src/views/digest-list.ts
+++ b/web/src/views/digest-list.ts
@@ -32,7 +32,7 @@ export function renderDigestList(digests: readonly Digest[], topics: readonly To
   if (groups.length === 0) {
     const empty = document.createElement("p");
     empty.className = "empty-state";
-    empty.textContent = "No digests yet. Check back after the next run.";
+    empty.textContent = "No news items were found.";
     container.appendChild(empty);
     return container;
   }

--- a/web/tests/e2e/home-today.spec.ts
+++ b/web/tests/e2e/home-today.spec.ts
@@ -1,0 +1,87 @@
+import { expect, test } from "@playwright/test";
+import { LIVE_AUTH, LIVE_AUTH_SKIP, signInAal2 } from "./live-auth";
+
+// Live authenticated tests for the home page today-only filter (issue #100).
+// These specs read real digests from Supabase and require a genuine AAL2 session.
+// Run with:
+//   MFA_TEST_EMAIL=... MFA_TEST_PASSWORD=... MFA_TEST_TOTP_SECRET=... npx playwright test home-today
+test.describe("home today-only digest view (live authenticated reads)", () => {
+  test.skip(!LIVE_AUTH, LIVE_AUTH_SKIP);
+
+  test.beforeEach(async ({ page }) => {
+    await signInAal2(page);
+  });
+
+  // AC: Only today's digests are shown — no older digest dates appear.
+  test("home shows only today's digests (no older dates)", async ({ page }) => {
+    await page.goto("/");
+    await expect(page.getByTestId("digest-content")).toBeVisible();
+    await expect(page.getByTestId("auth-gate")).toHaveCount(0);
+
+    // Wait for digests to load (or empty state to appear).
+    await page.waitForSelector(".digest-list", { timeout: 15_000 });
+
+    const dateHeadings = page.locator(".date-heading");
+    const count = await dateHeadings.count();
+
+    // If there are date headings, every one must be today in Eastern time.
+    if (count > 0) {
+      const eastern = new Intl.DateTimeFormat("en-CA", {
+        timeZone: "America/New_York",
+      }).format(new Date());
+
+      const dates = await dateHeadings.evaluateAll((els) =>
+        els.map((el) => el.getAttribute("data-date") ?? ""),
+      );
+      for (const d of dates) {
+        expect(d).toBe(eastern);
+      }
+    }
+  });
+
+  // AC: When there are no today's digests, the clean empty state renders.
+  test("empty state shows 'No news items were found.' when no today digests", async ({
+    page,
+  }) => {
+    await page.goto("/");
+    await expect(page.getByTestId("digest-content")).toBeVisible();
+    await page.waitForSelector(".digest-list", { timeout: 15_000 });
+
+    const groups = page.locator(".topic-group");
+    const empty = page.locator(".empty-state");
+
+    // Either topic groups exist (today has digests) or the empty state shows.
+    const groupCount = await groups.count();
+    const emptyCount = await empty.count();
+    expect(groupCount + emptyCount).toBeGreaterThan(0);
+
+    if (groupCount === 0) {
+      await expect(empty).toHaveText("No news items were found.");
+    }
+  });
+
+  // AC: "Nothing to report" filler content does NOT appear on the home screen.
+  test("filler 'nothing to report' content is suppressed", async ({ page }) => {
+    await page.goto("/");
+    await expect(page.getByTestId("digest-content")).toBeVisible();
+    await page.waitForSelector(".digest-list", { timeout: 15_000 });
+
+    // No digest body should contain the known filler sentinel phrases.
+    const bodies = await page.locator(".digest-body").allTextContents();
+    for (const body of bodies) {
+      const lower = body.toLowerCase();
+      expect(lower).not.toContain("were reported by curated sources");
+      expect(lower).not.toMatch(/^no new /);
+      expect(lower).not.toMatch(/^nothing /);
+      expect(lower).not.toMatch(/^there were no /);
+    }
+  });
+
+  // Screenshot recipe for the orchestrator:
+  // 1. signInAal2(page)
+  // 2. await page.goto("/")
+  // 3. await page.waitForSelector(".digest-list", { timeout: 15_000 })
+  // 4. await page.screenshot({ path: "home-today.png", fullPage: true })
+  // Expected: digest cards with today's date, OR the "No news items were found." empty state.
+  // Must NOT contain any date heading other than today's Eastern date.
+});

--- a/web/tests/unit/dates.test.ts
+++ b/web/tests/unit/dates.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, it } from "vitest";
+import { appToday, isToday } from "../../src/lib/dates";
+
+describe("appToday", () => {
+  it("returns a YYYY-MM-DD string", () => {
+    const result = appToday();
+    expect(result).toMatch(/^\d{4}-\d{2}-\d{2}$/);
+  });
+
+  it("uses America/New_York timezone, not UTC", () => {
+    // 2026-06-15 02:00:00 UTC is 2026-06-14 22:00 Eastern (UTC-4 in summer)
+    // So appToday should return 2026-06-14, not 2026-06-15
+    const utcMidnightPlus2h = new Date("2026-06-15T02:00:00Z");
+    expect(appToday(utcMidnightPlus2h)).toBe("2026-06-14");
+  });
+
+  it("returns the UTC date for a mid-day UTC moment (same day in Eastern)", () => {
+    // 2026-06-15T15:00:00Z is 2026-06-15 11:00 Eastern — same calendar day
+    const midDayUtc = new Date("2026-06-15T15:00:00Z");
+    expect(appToday(midDayUtc)).toBe("2026-06-15");
+  });
+
+  it("handles a winter UTC offset (EST = UTC-5)", () => {
+    // 2026-01-10T03:00:00Z is 2026-01-09 22:00 EST (UTC-5)
+    const winterMoment = new Date("2026-01-10T03:00:00Z");
+    expect(appToday(winterMoment)).toBe("2026-01-09");
+  });
+});
+
+describe("isToday", () => {
+  it("returns true when digestDate matches Eastern date of given moment", () => {
+    const utcMidnightPlus2h = new Date("2026-06-15T02:00:00Z");
+    // Eastern date of this moment is 2026-06-14
+    expect(isToday("2026-06-14", utcMidnightPlus2h)).toBe(true);
+  });
+
+  it("returns false when digestDate is a UTC date but not the Eastern date", () => {
+    const utcMidnightPlus2h = new Date("2026-06-15T02:00:00Z");
+    // 2026-06-15 is the UTC date, but Eastern date is 2026-06-14
+    expect(isToday("2026-06-15", utcMidnightPlus2h)).toBe(false);
+  });
+
+  it("returns false for a past date", () => {
+    const now = new Date("2026-06-15T15:00:00Z");
+    expect(isToday("2026-06-01", now)).toBe(false);
+  });
+
+  it("returns false for a future date", () => {
+    const now = new Date("2026-06-15T15:00:00Z");
+    expect(isToday("2026-06-16", now)).toBe(false);
+  });
+
+  it("uses current time when no now is provided", () => {
+    // Just verifies it doesn't throw and returns a boolean
+    const result = isToday("2026-06-15");
+    expect(typeof result).toBe("boolean");
+  });
+});

--- a/web/tests/unit/digest-list.test.ts
+++ b/web/tests/unit/digest-list.test.ts
@@ -1,6 +1,8 @@
+// @vitest-environment jsdom
 import { describe, expect, it } from "vitest";
 
-import { formatDate } from "../../src/views/digest-list";
+import { formatDate, renderDigestList } from "../../src/views/digest-list";
+import type { Topic } from "../../src/lib/types";
 
 // Regression for the Today-screen date rendering one day early (issue #92):
 // a calendar digest_date must render the SAME day-of-month regardless of the
@@ -23,5 +25,26 @@ describe("formatDate", () => {
 
   it("returns the raw string for malformed input", () => {
     expect(formatDate("not-a-date")).toBe("not-a-date");
+  });
+});
+
+// ── renderDigestList empty state (issue #100) ─────────────────────────────────
+
+describe("renderDigestList empty state", () => {
+  const topics: Topic[] = [
+    { id: 1, name: "AI model releases", slug: "ai_models", cadence: "24h", enabled: true },
+  ];
+
+  it("shows 'No news items were found.' when given an empty array", () => {
+    const el = renderDigestList([], topics);
+    const empty = el.querySelector(".empty-state");
+    expect(empty).not.toBeNull();
+    expect(empty!.textContent).toBe("No news items were found.");
+  });
+
+  it("does NOT show the old placeholder message", () => {
+    const el = renderDigestList([], topics);
+    expect(el.textContent).not.toContain("No digests yet");
+    expect(el.textContent).not.toContain("Check back after the next run");
   });
 });

--- a/web/tests/unit/home.test.ts
+++ b/web/tests/unit/home.test.ts
@@ -1,0 +1,245 @@
+import { describe, expect, it } from "vitest";
+import { isPublishableDigest, filterTodayDigests } from "../../src/pages/home";
+import type { Digest } from "../../src/lib/types";
+
+/** Minimal digest factory for tests. */
+function digest(
+  partial: Partial<Digest> & { topic_slug: string; digest_date: string; content: string },
+): Digest {
+  return {
+    id: `${partial.topic_slug}-${partial.digest_date}`,
+    cadence: "24h",
+    sources_used: [],
+    token_count: null,
+    prompt_version: "v",
+    created_at: `${partial.digest_date}T12:00:00Z`,
+    summary: null,
+    items: null,
+    ...partial,
+  };
+}
+
+// ── isPublishableDigest ───────────────────────────────────────────────────────
+
+describe("isPublishableDigest", () => {
+  it("keeps a digest with a non-empty items array", () => {
+    const d = digest({
+      topic_slug: "ai_models",
+      digest_date: "2026-06-15",
+      content: "",
+      items: [
+        { headline: "GPT-5 launches", blurb: "Big news", detail: "Details here" },
+      ],
+    });
+    expect(isPublishableDigest(d)).toBe(true);
+  });
+
+  it("keeps a digest with non-filler content and null items", () => {
+    const d = digest({
+      topic_slug: "ai_models",
+      digest_date: "2026-06-15",
+      content: "Anthropic released Claude 4 today with major new capabilities.",
+      items: null,
+    });
+    expect(isPublishableDigest(d)).toBe(true);
+  });
+
+  it("drops the exact filler: 'No new AI model releases were reported by curated sources today.'", () => {
+    const d = digest({
+      topic_slug: "ai_models",
+      digest_date: "2026-06-15",
+      content: "No new AI model releases were reported by curated sources today.",
+      items: null,
+    });
+    expect(isPublishableDigest(d)).toBe(false);
+  });
+
+  it("drops content starting with 'no new' (case-insensitive)", () => {
+    const d = digest({
+      topic_slug: "ai_models",
+      digest_date: "2026-06-15",
+      content: "No new updates were found.",
+      items: null,
+    });
+    expect(isPublishableDigest(d)).toBe(false);
+  });
+
+  it("drops content starting with 'no significant'", () => {
+    const d = digest({
+      topic_slug: "penguins",
+      digest_date: "2026-06-15",
+      content: "No significant news today.",
+      items: null,
+    });
+    expect(isPublishableDigest(d)).toBe(false);
+  });
+
+  it("drops content starting with 'nothing'", () => {
+    const d = digest({
+      topic_slug: "local_news",
+      digest_date: "2026-06-15",
+      content: "Nothing to report this week.",
+      items: null,
+    });
+    expect(isPublishableDigest(d)).toBe(false);
+  });
+
+  it("drops content starting with 'there were no'", () => {
+    const d = digest({
+      topic_slug: "ai_models",
+      digest_date: "2026-06-15",
+      content: "There were no new releases today.",
+      items: null,
+    });
+    expect(isPublishableDigest(d)).toBe(false);
+  });
+
+  it("drops content containing 'were reported by curated sources'", () => {
+    const d = digest({
+      topic_slug: "ai_models",
+      digest_date: "2026-06-15",
+      content: "Only minor items were reported by curated sources this week.",
+      items: null,
+    });
+    expect(isPublishableDigest(d)).toBe(false);
+  });
+
+  it("drops content containing 'no news'", () => {
+    const d = digest({
+      topic_slug: "ai_models",
+      digest_date: "2026-06-15",
+      content: "There is no news to summarize today.",
+      items: null,
+    });
+    expect(isPublishableDigest(d)).toBe(false);
+  });
+
+  it("drops digest with empty content and null items", () => {
+    const d = digest({
+      topic_slug: "ai_models",
+      digest_date: "2026-06-15",
+      content: "",
+      items: null,
+    });
+    expect(isPublishableDigest(d)).toBe(false);
+  });
+
+  it("drops digest with only-whitespace content and null items", () => {
+    const d = digest({
+      topic_slug: "ai_models",
+      digest_date: "2026-06-15",
+      content: "   ",
+      items: null,
+    });
+    expect(isPublishableDigest(d)).toBe(false);
+  });
+
+  it("keeps digest with empty items array (treats it as no items — falls back to content)", () => {
+    // An empty array is not a non-empty array, so we check content
+    const d = digest({
+      topic_slug: "ai_models",
+      digest_date: "2026-06-15",
+      content: "Real content here.",
+      items: [],
+    });
+    expect(isPublishableDigest(d)).toBe(true);
+  });
+
+  it("drops digest with empty items array and filler content", () => {
+    const d = digest({
+      topic_slug: "ai_models",
+      digest_date: "2026-06-15",
+      content: "No new AI model releases were reported by curated sources today.",
+      items: [],
+    });
+    expect(isPublishableDigest(d)).toBe(false);
+  });
+});
+
+// ── filterTodayDigests ────────────────────────────────────────────────────────
+
+describe("filterTodayDigests", () => {
+  // Pin "now" to 2026-06-15T15:00:00Z → Eastern date 2026-06-15
+  const now = new Date("2026-06-15T15:00:00Z");
+
+  const todayReal = digest({
+    topic_slug: "ai_models",
+    digest_date: "2026-06-15",
+    content: "Anthropic shipped Claude 4.",
+    items: [{ headline: "Claude 4", blurb: "New model", detail: "Details" }],
+  });
+
+  const todayFiller = digest({
+    topic_slug: "penguins",
+    digest_date: "2026-06-15",
+    content: "No new AI model releases were reported by curated sources today.",
+    items: null,
+  });
+
+  const yesterdayReal = digest({
+    topic_slug: "ai_models",
+    digest_date: "2026-06-14",
+    content: "Yesterday's big news.",
+    items: null,
+  });
+
+  const oldReal = digest({
+    topic_slug: "local_news",
+    digest_date: "2026-06-01",
+    content: "Old news.",
+    items: null,
+  });
+
+  it("keeps today's real digest", () => {
+    const out = filterTodayDigests([todayReal], now);
+    expect(out).toHaveLength(1);
+    expect(out[0]).toBe(todayReal);
+  });
+
+  it("drops today's filler digest", () => {
+    const out = filterTodayDigests([todayFiller], now);
+    expect(out).toHaveLength(0);
+  });
+
+  it("drops yesterday's digest even if it has real content", () => {
+    const out = filterTodayDigests([yesterdayReal], now);
+    expect(out).toHaveLength(0);
+  });
+
+  it("drops old digests", () => {
+    const out = filterTodayDigests([oldReal], now);
+    expect(out).toHaveLength(0);
+  });
+
+  it("returns only today's real digests from a mixed list", () => {
+    const all = [todayReal, todayFiller, yesterdayReal, oldReal];
+    const out = filterTodayDigests(all, now);
+    expect(out).toHaveLength(1);
+    expect(out[0]).toBe(todayReal);
+  });
+
+  it("uses Eastern time: UTC midnight+2h is still yesterday in Eastern", () => {
+    // 2026-06-15T02:00:00Z → Eastern = 2026-06-14 (UTC-4 in summer)
+    const earlyUtc = new Date("2026-06-15T02:00:00Z");
+    const eastYesterday = digest({
+      topic_slug: "ai_models",
+      digest_date: "2026-06-14",
+      content: "Real content.",
+      items: null,
+    });
+    const eastToday = digest({
+      topic_slug: "ai_models",
+      digest_date: "2026-06-15",
+      content: "This is the UTC date but not Eastern date.",
+      items: null,
+    });
+    const out = filterTodayDigests([eastYesterday, eastToday], earlyUtc);
+    // Eastern date is 2026-06-14 at this moment, so only eastYesterday should pass
+    expect(out).toHaveLength(1);
+    expect(out[0]).toBe(eastYesterday);
+  });
+
+  it("returns empty array when given no digests", () => {
+    expect(filterTodayDigests([], now)).toHaveLength(0);
+  });
+});


### PR DESCRIPTION
Closes #100

## Summary
- Home now shows **only the current date's** digests, with "today" defined in **America/New_York** via a new `web/src/lib/dates.ts` (`appToday`/`isToday`).
- Empty-state message changed to **"No news items were found."**
- Suppresses "no news / filler" digests on Home (conservative heuristic in `isPublishableDigest`; issue #91 will supersede this with structured quality scoring).

## Test Evidence
- Lint (eslint + tsc --noEmit): **PASS**
- Unit (vitest): **PASS — 397 tests, 0 failures**
- Build (tsc + vite build): **PASS**
- E2E (`web/tests/e2e/home-today.spec.ts`): runs in CI; the live-auth specs execute when `MFA_TEST_*` secrets are present.

## Notes for review
- **Timezone:** "today" is America/New_York. The backend currently stamps `digest_date` in UTC; full day-boundary coherence lands with **#102**, which moves stamping to Eastern. Until #102 deploys, a digest generated in the late-Eastern-evening UTC-rollover window could display under the wrong day.
- **Retention interpretation (confirm):** the companion issues treat the retained window as **3 calendar days total** (today + 2 prior); Home = today, History (#101) = the prior retained days. If you meant "today + 3 prior," it's a one-line constant.
- `fetchDigests` still fetches all rows and filters client-side — fine at current volumes.