### PR TITLE
TTS: eliminate mid-sentence stutter (gapless playback + abbreviation-aware splitting)

### DIFF
--- a/web/src/lib/tts-neural.ts
+++ b/web/src/lib/tts-neural.ts
@@ -8,6 +8,10 @@
 // Responsibilities:
 //   - Synthesize one chunk per request, play via a SINGLE long-lived
 //     HTMLAudioElement (src is swapped per chunk — never a new element).
+//   - Double-buffer (#103): prefetch() ALSO preloads the object URL into a
+//     second HTMLAudioElement so speak() can swap and play() synchronously,
+//     eliminating the inter-chunk gap (~3s) that comes from awaiting an async
+//     fetch even on a cache hit.
 //   - Attach caller-provided headers (Supabase JWT) to every request — the
 //     function is deployed with JWT verification on.
 //   - In-memory cache keyed `${voice}|${rate}|hash(text)` -> object URL so a
@@ -25,7 +29,7 @@ const MAX_CACHE_ENTRIES = 64;
 // Google Chirp 3 HD synthesis costs ~9 ms/char, so first-audio latency is set
 // by the FIRST chunk's size: ~240 chars measures ~2.3s (vs ~6.6s at 700, ~36s
 // at 4000). Each chunk's audio runs ~3x longer than its own synth time, so the
-// player's prefetch (Fix #2) keeps every later chunk ready with no gap; only
+// player's prefetch (Fix #103) keeps every later chunk ready with no gap; only
 // the first chunk is unavoidably synchronous. ~240 chars is also 1–3 whole
 // sentences, so per-chunk prosody stays natural.
 const NEURAL_MAX_CHUNK_CHARS = 240;
@@ -46,8 +50,8 @@ export interface NeuralHttpBackendOptions {
   fetchImpl?: typeof fetch;
   /**
    * Injectable for tests; called at most once to create the single long-lived
-   * HTMLAudioElement.  Subsequent speaks reassign .src on the same element.
-   * Defaults to `new Audio()`.
+   * primary HTMLAudioElement.  Subsequent speaks reassign .src on the same
+   * element.  Defaults to `new Audio()`.
    */
   audioFactory?: () => HTMLAudioElement;
   /** Cache size cap; defaults to 64. */
@@ -65,6 +69,16 @@ function hashText(text: string): string {
   return h.toString(36);
 }
 
+/** Double-buffer slot: a second audio element preloaded and ready to swap in. */
+interface PreloadSlot {
+  /** Cache key (voice|rate|hash) identifying which chunk is preloaded. */
+  key: string;
+  /** Object URL already assigned to the slot element's .src. */
+  url: string;
+  /** A second HTMLAudioElement with .src = url; ready for immediate play(). */
+  element: HTMLAudioElement;
+}
+
 export class NeuralHttpBackend implements TtsBackend {
   readonly supportsRealSeek = true;
   readonly maxChunkChars = NEURAL_MAX_CHUNK_CHARS;
@@ -78,7 +92,7 @@ export class NeuralHttpBackend implements TtsBackend {
   // key -> object URL. Map preserves insertion order, so the first key is the
   // oldest entry when we need to evict.
   private readonly cache = new Map<string, string>();
-  // The single long-lived audio element, created lazily on first use.
+  // The single long-lived PRIMARY audio element, created lazily on first use.
   private audioEl: HTMLAudioElement | null = null;
   // The object URL actually assigned to audioEl.src right now. Tracked so cache
   // eviction never revokes a URL the element is still streaming. Survives
@@ -92,6 +106,12 @@ export class NeuralHttpBackend implements TtsBackend {
   // Monotonic token: cancel() bumps it, so an in-flight speak() whose token no
   // longer matches must not start playback or report an end.
   private session = 0;
+
+  // Double-buffer slot (#103): when prefetch() completes, the next chunk's
+  // audio is loaded into a second element here. speak() checks this slot first;
+  // on a key match it swaps the slot in as the primary element and plays
+  // immediately with no async round-trip, eliminating the inter-chunk gap.
+  private preloadSlot: PreloadSlot | null = null;
 
   constructor(baseUrl: string, opts: NeuralHttpBackendOptions = {}) {
     this.baseUrl = baseUrl.replace(/\/+$/, "");
@@ -141,48 +161,28 @@ export class NeuralHttpBackend implements TtsBackend {
     opts: { rate: number; voiceURI: string | null },
     onEnd: () => void,
   ): void {
+    // Capture the preloaded slot BEFORE cancel() clears it.
+    const pendingSlot = this.preloadSlot;
     this.cancel();
     const session = this.session;
-    // Empty voice -> the proxy applies its server-side default.
     const voice = opts.voiceURI ?? "";
+    const key = `${voice}|${opts.rate}|${hashText(text)}`;
 
+    // --- Double-buffer fast path (#103) -----------------------------------
+    // If prefetch() has fully loaded this chunk into the slot element, swap it
+    // in as the primary and play() immediately — no async wait at all.
+    if (pendingSlot && pendingSlot.key === key) {
+      // Slot was already cleared by cancel(); nothing more to clean up.
+      this.playFromElement(pendingSlot.element, pendingSlot.url, session, onEnd);
+      return;
+    }
+    // Stale slot (different key — user skipped): already cleared by cancel().
+
+    // --- Async fallback: fetch (or cache hit) then play -------------------
     void this.getAudioUrl(text, voice, opts.rate)
       .then((url) => {
         if (session !== this.session) return; // superseded while fetching
-        const audio = this.getOrCreateElement();
-        // Detach any handlers from a previous chunk before reassigning.
-        audio.onended = null;
-        audio.onerror = null;
-        const previousSrc = this.elementSrc;
-        // Swap the SAME element's source to this chunk. elementSrc records the
-        // URL the element is now streaming so eviction never revokes it.
-        this.elementSrc = url;
-        this.hasCurrentTrack = true;
-        audio.src = url;
-        // The element has moved on from previousSrc. If that URL was evicted
-        // from the cache while it was the live src (its revocation deferred),
-        // revoke it now — nothing references it anymore, so it would otherwise
-        // leak. Done AFTER reassigning src so we never revoke the live source.
-        if (previousSrc && previousSrc !== url && !this.cacheHasUrl(previousSrc)) {
-          URL.revokeObjectURL(previousSrc);
-        }
-        const finish = (): void => {
-          if (session !== this.session) return;
-          this.hasCurrentTrack = false;
-          onEnd();
-        };
-        audio.onended = finish;
-        audio.onerror = finish;
-        const p = audio.play();
-        // play() returns a promise in browsers; a rejection (autoplay policy,
-        // decode failure) must advance the queue, not wedge it.
-        if (p && typeof p.catch === "function") {
-          p.catch(() => {
-            if (session !== this.session) return;
-            this.hasCurrentTrack = false;
-            onEnd();
-          });
-        }
+        this.playFromElement(this.getOrCreateElement(), url, session, onEnd);
       })
       .catch(() => {
         // Synthesis failed (network/server). Report the end so the player
@@ -207,6 +207,10 @@ export class NeuralHttpBackend implements TtsBackend {
 
   cancel(): void {
     this.session += 1;
+    // Discard any preloaded slot — it was for the chunk sequence that is now
+    // being cancelled (skip / stop). The slot element holds an object URL
+    // that remains in the cache, so it is safe to just drop the reference.
+    this.preloadSlot = null;
     const audio = this.audioEl;
     // Stop reporting progress/seek for this track, but keep the element alive
     // for reuse and keep elementSrc set — the src stays loaded until the next
@@ -252,14 +256,26 @@ export class NeuralHttpBackend implements TtsBackend {
   }
 
   /**
-   * Warm the cache for `text` without playing it. Call this while the current
-   * chunk is playing so the next chunk is ready when its turn arrives.
+   * Warm the cache for `text` AND preload the object URL into a second
+   * HTMLAudioElement (the double-buffer slot).  When speak() is called with
+   * the same text next, it finds the slot ready and plays with no async wait.
    * All failures are swallowed — a cache miss is the only side-effect.
    */
   prefetch(text: string, opts: { rate: number; voiceURI: string | null }): Promise<void> {
     const voice = opts.voiceURI ?? "";
+    const key = `${voice}|${opts.rate}|${hashText(text)}`;
+
     return this.getAudioUrl(text, voice, opts.rate).then(
-      () => { /* cached; no playback */ },
+      (url) => {
+        // Build the slot element and assign .src so the browser can buffer it
+        // while the current chunk is still playing. We do NOT call play() here
+        // so that no audio output occurs and so we don't need to be inside a
+        // user gesture (the primary element's unlock() already covered that).
+        const element = this.audioFactory();
+        element.src = url;
+        // Overwrite any previous slot (only one next-chunk is relevant).
+        this.preloadSlot = { key, url, element };
+      },
       () => { /* silently ignore fetch errors */ },
     );
   }
@@ -278,7 +294,70 @@ export class NeuralHttpBackend implements TtsBackend {
 
   // --- internals ------------------------------------------------------------
 
-  /** Lazily create and return the single reused audio element. */
+  /**
+   * Wire up `element` as the live playing element, swap it in as the primary
+   * (if it differs), set handlers, and start playback.
+   * This is the single place speak() and the double-buffer fast path converge.
+   */
+  private playFromElement(
+    element: HTMLAudioElement,
+    url: string,
+    session: number,
+    onEnd: () => void,
+  ): void {
+    // If the incoming element is different from the current primary (double-
+    // buffer fast path), tear down the old primary and swap.
+    if (element !== this.audioEl) {
+      const oldEl = this.audioEl;
+      if (oldEl) {
+        oldEl.onended = null;
+        oldEl.onerror = null;
+        try { oldEl.pause(); } catch { /* ignore */ }
+      }
+      this.audioEl = element;
+    }
+
+    const audio = this.audioEl!;
+    // Detach any handlers from a previous chunk before reassigning.
+    audio.onended = null;
+    audio.onerror = null;
+    const previousSrc = this.elementSrc;
+    // Record the URL the element is now streaming so eviction never revokes it.
+    this.elementSrc = url;
+    this.hasCurrentTrack = true;
+    // Only reassign .src if it has changed — in the double-buffer path the
+    // slot element's .src is already set, so we skip the assignment to avoid
+    // resetting the browser's buffer position.
+    if (audio.src !== url) {
+      audio.src = url;
+    }
+    // The element has moved on from previousSrc. If that URL was evicted
+    // from the cache while it was the live src (its revocation deferred),
+    // revoke it now — nothing references it anymore, so it would otherwise
+    // leak. Done AFTER reassigning src so we never revoke the live source.
+    if (previousSrc && previousSrc !== url && !this.cacheHasUrl(previousSrc)) {
+      URL.revokeObjectURL(previousSrc);
+    }
+    const finish = (): void => {
+      if (session !== this.session) return;
+      this.hasCurrentTrack = false;
+      onEnd();
+    };
+    audio.onended = finish;
+    audio.onerror = finish;
+    const p = audio.play();
+    // play() returns a promise in browsers; a rejection (autoplay policy,
+    // decode failure) must advance the queue, not wedge it.
+    if (p && typeof p.catch === "function") {
+      p.catch(() => {
+        if (session !== this.session) return;
+        this.hasCurrentTrack = false;
+        onEnd();
+      });
+    }
+  }
+
+  /** Lazily create and return the single reused primary audio element. */
   private getOrCreateElement(): HTMLAudioElement {
     if (!this.audioEl) {
       this.audioEl = this.audioFactory();

--- a/web/src/lib/tts.ts
+++ b/web/src/lib/tts.ts
@@ -276,17 +276,90 @@ export function stripFormatting(text: string): string {
 
 // --- chunking -------------------------------------------------------------
 
+// Sentinel used to protect abbreviation periods during sentence splitting.
+// Must never appear in real input text.
+const PERIOD_SENTINEL = "\x00P\x00";
+
+/**
+ * Common abbreviations whose trailing period must never be treated as a
+ * sentence boundary. The replacement protects the period through the
+ * sentence-splitting regex and is restored afterwards.
+ *
+ * Pattern: word-boundary-anchored, case-sensitive where capitalization
+ * matters (Dr./Mr./Mrs. etc.), followed by the literal period.
+ */
+const ABBREV_PATTERNS: [RegExp, string][] = [
+  // Geographical / political
+  [/\bU\.S\./g, `U${PERIOD_SENTINEL}S${PERIOD_SENTINEL}`],
+  [/\bU\.K\./g, `U${PERIOD_SENTINEL}K${PERIOD_SENTINEL}`],
+  // Latin / connective
+  [/\be\.g\./g, `e${PERIOD_SENTINEL}g${PERIOD_SENTINEL}`],
+  [/\bi\.e\./g, `i${PERIOD_SENTINEL}e${PERIOD_SENTINEL}`],
+  [/\betc\./g, `etc${PERIOD_SENTINEL}`],
+  [/\bvs\./g, `vs${PERIOD_SENTINEL}`],
+  // Corporate suffixes
+  [/\bInc\./g, `Inc${PERIOD_SENTINEL}`],
+  [/\bLtd\./g, `Ltd${PERIOD_SENTINEL}`],
+  [/\bCorp\./g, `Corp${PERIOD_SENTINEL}`],
+  [/\bCo\./g, `Co${PERIOD_SENTINEL}`],
+  // Honorifics
+  [/\bDr\./g, `Dr${PERIOD_SENTINEL}`],
+  [/\bMr\./g, `Mr${PERIOD_SENTINEL}`],
+  [/\bMrs\./g, `Mrs${PERIOD_SENTINEL}`],
+  [/\bMs\./g, `Ms${PERIOD_SENTINEL}`],
+  [/\bProf\./g, `Prof${PERIOD_SENTINEL}`],
+  [/\bSt\./g, `St${PERIOD_SENTINEL}`],
+  [/\bJr\./g, `Jr${PERIOD_SENTINEL}`],
+  [/\bSr\./g, `Sr${PERIOD_SENTINEL}`],
+  // Time
+  [/\ba\.m\./g, `a${PERIOD_SENTINEL}m${PERIOD_SENTINEL}`],
+  [/\bp\.m\./g, `p${PERIOD_SENTINEL}m${PERIOD_SENTINEL}`],
+];
+
+/** Protect decimal numbers: digit.digit must not trigger sentence splitting. */
+const DECIMAL_RE = /(\d)\.(\d)/g;
+const DECIMAL_SENTINEL_L = `\x00DL\x00`;
+const DECIMAL_SENTINEL_R = `\x00DR\x00`;
+
+function protectAbbreviations(text: string): string {
+  let out = text;
+  // Protect known abbreviations
+  for (const [re, replacement] of ABBREV_PATTERNS) {
+    out = out.replace(re, replacement);
+  }
+  // Protect decimal numbers (e.g. "3.5")
+  out = out.replace(DECIMAL_RE, `$1${DECIMAL_SENTINEL_L}${DECIMAL_SENTINEL_R}$2`);
+  return out;
+}
+
+function restoreAbbreviations(text: string): string {
+  return text
+    .split(PERIOD_SENTINEL).join(".")
+    .split(DECIMAL_SENTINEL_L).join(".")
+    .split(DECIMAL_SENTINEL_R).join("");
+}
+
 /**
  * Split `text` into chunks no longer than `max` chars, breaking on sentence
  * boundaries where possible. A single sentence longer than `max` is split on
  * whitespace so no chunk exceeds the limit.
+ *
+ * Abbreviation-aware: periods in common abbreviations (U.S., Dr., etc.) and
+ * decimal numbers (3.5) are protected so they are never treated as sentence
+ * boundaries.
  */
 export function chunkText(text: string, max = 200): string[] {
   const clean = text.trim();
   if (!clean) return [];
 
+  // Protect abbreviation and decimal periods before splitting.
+  const protected_ = protectAbbreviations(clean);
+
   // Split into sentences, keeping terminal punctuation.
-  const sentences = clean.match(/[^.!?]+[.!?]+(?:["')\]]+)?|\S[^.!?]*$/g) ?? [clean];
+  const rawSentences = protected_.match(/[^.!?]+[.!?]+(?:["')\]]+)?|\S[^.!?]*$/g) ?? [protected_];
+
+  // Restore sentinels in each sentence fragment.
+  const sentences = rawSentences.map(restoreAbbreviations);
 
   const chunks: string[] = [];
   let buffer = "";

--- a/web/tests/unit/tts-neural.test.ts
+++ b/web/tests/unit/tts-neural.test.ts
@@ -60,20 +60,25 @@ function makeFetch(opts: { failSpeech?: boolean; failVoices?: boolean } = {}) {
 }
 
 /**
- * Build a backend with an injectable audioFactory that returns a single
- * FakeAudio.  The factory is called at most once (lazy element creation);
- * subsequent speaks just reassign .src on the same element.
+ * Build a backend with an injectable audioFactory.
+ *
+ * `audioRef.ref` always points to the FIRST element created (the primary
+ * playing element).  With the double-buffer fix, prefetch() creates additional
+ * elements; those are tracked in `audioRef.all` but do NOT overwrite `.ref`.
+ * Tests that don't call prefetch() continue to work unchanged.
  */
 function makeBackend(
   fetchImpl: typeof fetch,
-  singleAudio: { ref: FakeAudio | null },
+  audioRef: { ref: FakeAudio | null; all?: FakeAudio[] },
   cacheCap?: number,
 ): NeuralHttpBackend {
   return new NeuralHttpBackend("http://tts.local:8880", {
     fetchImpl,
     audioFactory: () => {
       const a = new FakeAudio();
-      singleAudio.ref = a;
+      // Only the first element becomes the canonical ref (primary element).
+      if (!audioRef.ref) audioRef.ref = a;
+      (audioRef.all ??= []).push(a);
       return a as unknown as HTMLAudioElement;
     },
     maxCacheEntries: cacheCap,
@@ -759,6 +764,126 @@ describe("NeuralHttpBackend.prefetch", () => {
     // current audio still active; simulating end fires our onEnd
     audioRef.ref!.onended?.();
     expect(ended).toBe(1);
+  });
+});
+
+// --- double-buffer gapless playback (Fix #103) ----------------------------------------
+
+describe("NeuralHttpBackend double-buffer (gapless)", () => {
+  it("after prefetch(next), speak(next) plays without a new fetch", async () => {
+    const { fetchImpl, calls } = makeFetch();
+    const audioRef: { ref: FakeAudio | null; all: FakeAudio[] } = { ref: null, all: [] };
+    const backend = makeBackend(fetchImpl, audioRef);
+
+    // Prefetch the next chunk — this creates a slot element (all[0])
+    await backend.prefetch("Next chunk text.", { rate: 1.2, voiceURI: null });
+
+    const speechCallsAfterPrefetch = calls.filter((c) =>
+      c.url.endsWith("/v1/audio/speech"),
+    ).length;
+    expect(speechCallsAfterPrefetch).toBe(1); // prefetch did one fetch
+
+    // Now speak the same text — must use the preloaded slot, no new fetch
+    backend.speak("Next chunk text.", { rate: 1.2, voiceURI: null }, () => {});
+    // speak() uses the slot synchronously, so no flush() needed — but flush anyway
+    // to ensure any async fallback path would have also completed
+    await flush();
+
+    const speechCallsAfterSpeak = calls.filter((c) =>
+      c.url.endsWith("/v1/audio/speech"),
+    ).length;
+    // No new fetch — the double-buffer slot was consumed
+    expect(speechCallsAfterSpeak).toBe(1);
+    // The slot element (all[0]) was swapped in as primary — it was played
+    const slotEl = audioRef.all[0];
+    expect(slotEl).not.toBeNull();
+    expect(slotEl.playCalls).toBeGreaterThanOrEqual(1);
+  });
+
+  it("onended on current chunk plays next chunk with no awaited fetch round-trip", async () => {
+    const { fetchImpl, calls } = makeFetch();
+    const audioRef: { ref: FakeAudio | null; all: FakeAudio[] } = { ref: null, all: [] };
+    const backend = makeBackend(fetchImpl, audioRef);
+
+    // Simulate TtsPlayer: speak chunk 1 (creates primary = all[0] = ref),
+    // prefetch chunk 2 (creates slot = all[1]), then on chunk 1 end speak chunk 2
+    const ends: string[] = [];
+    backend.speak("Chunk one.", { rate: 1, voiceURI: null }, () => {
+      ends.push("one");
+    });
+    await flush();
+    // all[0] is primary element
+    const primaryEl = audioRef.ref!;
+    expect(primaryEl).not.toBeNull();
+
+    // Prefetch chunk 2 while chunk 1 plays (as TtsPlayer does) — creates slot = all[1]
+    await backend.prefetch("Chunk two.", { rate: 1, voiceURI: null });
+
+    const callsBeforeEnd = calls.filter((c) => c.url.endsWith("/v1/audio/speech")).length;
+    // 2 calls so far: chunk 1 + chunk 2 prefetch
+    expect(callsBeforeEnd).toBe(2);
+
+    // Simulate chunk 1 ending: fire onended on the primary, then TtsPlayer calls speak(chunk 2)
+    primaryEl.onended?.();
+    backend.speak("Chunk two.", { rate: 1, voiceURI: null }, () => {
+      ends.push("two");
+    });
+    // The slot is ready synchronously — no additional fetch needed
+    await flush();
+
+    const callsAfterEnd = calls.filter((c) => c.url.endsWith("/v1/audio/speech")).length;
+    // Still 2 — chunk 2 speak consumed the slot, no new fetch
+    expect(callsAfterEnd).toBe(callsBeforeEnd);
+    expect(ends[0]).toBe("one");
+    // The slot element (all[1]) is now active and was played
+    const slotEl = audioRef.all[1];
+    expect(slotEl.playCalls).toBeGreaterThanOrEqual(1);
+  });
+
+  it("cancel() then speak() still works correctly (no stale slot)", async () => {
+    const { fetchImpl, calls } = makeFetch();
+    const audioRef: { ref: FakeAudio | null; all: FakeAudio[] } = { ref: null, all: [] };
+    const backend = makeBackend(fetchImpl, audioRef);
+
+    // Prefetch something, then cancel (skip) before it's consumed
+    await backend.prefetch("Abandoned chunk.", { rate: 1, voiceURI: null });
+    backend.cancel();
+
+    // speak an entirely different chunk — must fetch fresh (slot was cleared)
+    backend.speak("Fresh chunk.", { rate: 1, voiceURI: null }, () => {});
+    await flush();
+
+    // Fresh chunk needed a new fetch (not the abandoned preload)
+    const speechCalls = calls.filter((c) => c.url.endsWith("/v1/audio/speech"));
+    const freshFetch = speechCalls.find((c) => {
+      const body = JSON.parse(String(c.init?.body));
+      return body.input === "Fresh chunk.";
+    });
+    expect(freshFetch).toBeTruthy();
+    // play() was called for fresh chunk — on whichever element is current primary
+    const totalPlays = audioRef.all.reduce((sum, el) => sum + el.playCalls, 0);
+    expect(totalPlays).toBeGreaterThanOrEqual(1);
+  });
+
+  it("speak() with a mismatched text (skip case) falls back to fetch-then-play", async () => {
+    const { fetchImpl, calls } = makeFetch();
+    const audioRef: { ref: FakeAudio | null; all: FakeAudio[] } = { ref: null, all: [] };
+    const backend = makeBackend(fetchImpl, audioRef);
+
+    // Prefetch chunk A
+    await backend.prefetch("Prefetched chunk A.", { rate: 1, voiceURI: null });
+    const callsAfterPrefetch = calls.filter((c) => c.url.endsWith("/v1/audio/speech")).length;
+
+    // But then we speak chunk B (user skipped) — not in slot, must fetch
+    backend.speak("Completely different chunk B.", { rate: 1, voiceURI: null }, () => {});
+    await flush();
+
+    // B was not prefetched — it required a fetch
+    const callsAfterB = calls.filter((c) => c.url.endsWith("/v1/audio/speech")).length;
+    expect(callsAfterB).toBeGreaterThan(callsAfterPrefetch);
+    // play() was called on some element
+    const totalPlays = audioRef.all.reduce((sum, el) => sum + el.playCalls, 0);
+    expect(totalPlays).toBeGreaterThanOrEqual(1);
   });
 });
 

--- a/web/tests/unit/tts.test.ts
+++ b/web/tests/unit/tts.test.ts
@@ -144,6 +144,59 @@ describe("chunkText", () => {
     expect(chunkText("", 200)).toEqual([]);
     expect(chunkText("   ", 200)).toEqual([]);
   });
+
+  // Fix #1 — abbreviation-aware segmentation
+  it("does not split on U.S. abbreviation mid-sentence", () => {
+    const text =
+      "Anthropic was ordered by the U.S. government to cut access to its Fable 5 model.";
+    const chunks = chunkText(text, 200);
+    // Entire sentence is under 200 chars — must remain ONE chunk
+    expect(chunks).toHaveLength(1);
+    expect(chunks[0]).toBe(text);
+  });
+
+  it("does not split on decimal numbers", () => {
+    const text = "The score was 3.5 to 2.";
+    const chunks = chunkText(text, 200);
+    expect(chunks).toHaveLength(1);
+    expect(chunks[0]).toBe(text);
+  });
+
+  it("does not split on common honorifics and abbreviations", () => {
+    const cases = [
+      "Dr. Smith confirmed the results.",
+      "Mr. Jones and Mrs. Clark arrived.",
+      "The meeting starts at 9 a.m. sharp.",
+      "We spoke to Prof. Lee about the study.",
+      "Inc. filings are due Friday.",
+    ];
+    for (const text of cases) {
+      const chunks = chunkText(text, 200);
+      expect(chunks).toHaveLength(1);
+    }
+  });
+
+  it("still splits on real sentence boundaries between distinct sentences", () => {
+    // Each sentence is > 50 chars so they should land in separate chunks at max=60
+    const text =
+      "The company reported losses this quarter. Revenue fell sharply for the period.";
+    const chunks = chunkText(text, 60);
+    expect(chunks.length).toBeGreaterThan(1);
+  });
+
+  it("handles U.S. and U.K. mid-sentence with a real split boundary after", () => {
+    // Two distinct sentences; at max=120 they should each fit in their own chunk
+    const text =
+      "The U.S. market recovered strongly this week. The U.K. market also saw gains.";
+    // Both sentences are ~45 chars — at max=80 they should each be in their own chunk
+    const chunks = chunkText(text, 80);
+    // Neither chunk should contain both "U.S." and "U.K." as that would mean no split
+    // But more importantly no chunk should break the sentence at the abbrev period
+    for (const c of chunks) {
+      // A chunk boundary must not fall inside "U.S" or "U.K"
+      expect(c).not.toMatch(/U\.[SK]\.?$/);
+    }
+  });
 });
 
 // --- prefs ----------------------------------------------------------------


### PR DESCRIPTION
Closes #103

## Summary
Two compounding causes of the ~3s mid-sentence audio pauses, both fixed:
1. **Mid-sentence splits** — the sentence splitter broke on every `.`/`!`/`?`, including abbreviations ("U.S."), decimals, and honorifics. Now those periods are protected before splitting, so chunk boundaries fall only on real sentence ends.
2. **Inter-chunk gap** — each ~240-char chunk was synthesized as a separate request and played on one reused `<audio>` element, leaving a load gap. The next chunk is now preloaded into a second audio element during prefetch and swapped in on chunk-end (double-buffering), so playback is gapless.

Session-token cancel semantics, real seek, Web Speech fallback, and object-URL cache safety are all preserved.

## Test Evidence
- Lint (eslint + tsc --noEmit): **PASS**
- Unit (vitest): **PASS — 375 tests** (incl. new tests: "U.S."/decimals stay one chunk; prefetched next chunk plays with no awaited fetch)
- Build: **PASS**
- E2E: runs in CI. Objective gap-elimination is covered by the prefetch/no-refetch unit tests; subjective fluidity is best confirmed by a manual listen.

## Note
Independent re-run of lint/unit/build by the orchestrator confirmed green before merge.