### PR TITLE
History: group by date first, then topic; show previous days only

### DIFF
--- a/web/src/lib/group.ts
+++ b/web/src/lib/group.ts
@@ -1,4 +1,4 @@
-import type { DateGroup, Digest, Topic, TopicGroup } from "./types";
+import type { DateGroup, DateTopicBucket, DateTopicGroup, Digest, Topic, TopicGroup } from "./types";
 
 // Pure grouping: digests -> [topic][date] buckets, newest first throughout.
 
@@ -34,6 +34,51 @@ export function groupDigestsByTopicAndDate(
     const bMax = b.dates[0]?.date ?? "";
     return aMax < bMax ? 1 : aMax > bMax ? -1 : 0;
   });
+
+  return groups;
+}
+
+/**
+ * Date-first grouping: bucket digests by calendar date (newest date first),
+ * then nest topics within each date (ordered by topics array position).
+ * Topics absent from the topics list fall back to their slug as the name.
+ */
+export function groupDigestsByDateAndTopic(
+  digests: readonly Digest[],
+  topics: readonly Topic[],
+): DateTopicGroup[] {
+  const nameBySlug = new Map(topics.map((t) => [t.slug, t.name]));
+  // Preserve topic array order for stable per-date topic ordering.
+  const topicOrder = new Map(topics.map((t, i) => [t.slug, i]));
+
+  // date → slug → Digest[]
+  const byDate = new Map<string, Map<string, Digest[]>>();
+  for (const d of digests) {
+    let slugMap = byDate.get(d.digest_date);
+    if (!slugMap) {
+      slugMap = new Map();
+      byDate.set(d.digest_date, slugMap);
+    }
+    const bucket = slugMap.get(d.topic_slug) ?? [];
+    bucket.push(d);
+    slugMap.set(d.topic_slug, bucket);
+  }
+
+  const groups: DateTopicGroup[] = [];
+  for (const [date, slugMap] of byDate) {
+    const topicBuckets: DateTopicBucket[] = [...slugMap.entries()]
+      .map(([slug, ds]) => ({ slug, name: nameBySlug.get(slug) ?? slug, digests: ds }))
+      .sort((a, b) => {
+        const ai = topicOrder.get(a.slug) ?? Number.MAX_SAFE_INTEGER;
+        const bi = topicOrder.get(b.slug) ?? Number.MAX_SAFE_INTEGER;
+        if (ai !== bi) return ai - bi;
+        return a.slug < b.slug ? -1 : a.slug > b.slug ? 1 : 0;
+      });
+    groups.push({ date, topics: topicBuckets });
+  }
+
+  // Newest date first.
+  groups.sort((a, b) => (a.date < b.date ? 1 : a.date > b.date ? -1 : 0));
 
   return groups;
 }

--- a/web/src/lib/types.ts
+++ b/web/src/lib/types.ts
@@ -69,6 +69,22 @@ export interface DateGroup {
   digests: Digest[];
 }
 
+/** One topic bucket within a DateTopicGroup. */
+export interface DateTopicBucket {
+  slug: string;
+  name: string;
+  digests: Digest[];
+}
+
+/**
+ * Date-first grouping: one entry per calendar date (newest date first), with
+ * topics nested within each date. Used by History and Home views (issue #101).
+ */
+export interface DateTopicGroup {
+  date: string;
+  topics: DateTopicBucket[];
+}
+
 /** One row from the system_logs table (read-only, authenticated role). */
 export interface SystemLog {
   id: string;

--- a/web/src/pages/history.ts
+++ b/web/src/pages/history.ts
@@ -1,10 +1,12 @@
 import type { SupabaseClient } from "@supabase/supabase-js";
 import { isAuthenticatedAtRequiredLevel, signOut } from "../lib/auth";
-import { groupDigestsByTopicAndDate } from "../lib/group";
+import { appToday } from "../lib/dates";
+import { groupDigestsByDateAndTopic } from "../lib/group";
 import { fetchAllDigests, fetchTopics } from "../lib/supabase";
 import type { Digest, Topic } from "../lib/types";
 import { renderAuthGate } from "../views/auth-gate";
 import { renderDigestCard } from "../views/digest-card";
+import { formatDate } from "../views/digest-list";
 
 // Issue #12 — Digest history view and navigation.
 //
@@ -17,8 +19,14 @@ import { renderDigestCard } from "../views/digest-card";
 //
 // Filtering, searching and grouping are all client-side: the dataset is tiny
 // (~5 topics x 30 days = 150 rows), so server-side FTS is unnecessary.
-
-const DEFAULT_WINDOW_DAYS = 7;
+//
+// Issue #101 — History shows PREVIOUS days only (date-first grouping).
+// Today's digests live on Home. History excludes today via excludeToday() so
+// both views stay coherent regardless of how many days the backend retains.
+// We deliberately do NOT use a fixed window size here: the backend retention
+// contract (#102) is ≤3 calendar days (today + 2 prior), so History shows at
+// most 2 prior days. Applying a window filter on top of that would be redundant
+// and would silently hide data if retention ever increases.
 
 // --- Pure, DOM-free helpers (unit-tested) ----------------------------------
 
@@ -112,6 +120,16 @@ export function filterDigests(digests: readonly Digest[], state: HistoryState): 
   if (state.date) out = out.filter((d) => d.digest_date === state.date);
   out = searchDigests(out, state.q);
   return out;
+}
+
+/**
+ * Remove digests whose digest_date matches today in America/New_York.
+ * Accepts an optional `now` for testability; defaults to the current instant.
+ * Today's digests belong on the Home view, not in History.
+ */
+export function excludeToday(digests: readonly Digest[], now: Date = new Date()): Digest[] {
+  const today = appToday(now);
+  return digests.filter((d) => d.digest_date !== today);
 }
 
 /** Keep digests within N days of the newest digest's date (inclusive). */
@@ -222,7 +240,7 @@ function renderList(
   topics: readonly Topic[],
 ): void {
   container.replaceChildren();
-  const groups = groupDigestsByTopicAndDate(digests, topics);
+  const groups = groupDigestsByDateAndTopic(digests, topics);
 
   if (groups.length === 0) {
     const empty = document.createElement("p");
@@ -232,24 +250,25 @@ function renderList(
     return;
   }
 
-  for (const group of groups) {
+  for (const dateGroup of groups) {
     const section = document.createElement("section");
-    section.className = "topic-group";
-    section.setAttribute("data-topic-slug", group.slug);
+    section.className = "date-group";
+    section.setAttribute("data-date", dateGroup.date);
 
-    const heading = document.createElement("h2");
-    heading.className = "topic-heading";
-    heading.textContent = group.name;
-    section.appendChild(heading);
+    const dateHeading = document.createElement("h2");
+    dateHeading.className = "date-heading";
+    dateHeading.setAttribute("data-date", dateGroup.date);
+    dateHeading.textContent = formatDate(dateGroup.date);
+    section.appendChild(dateHeading);
 
-    for (const dateGroup of group.dates) {
-      const dateHeading = document.createElement("h3");
-      dateHeading.className = "date-heading";
-      dateHeading.setAttribute("data-date", dateGroup.date);
-      dateHeading.textContent = dateGroup.date;
-      section.appendChild(dateHeading);
+    for (const topicBucket of dateGroup.topics) {
+      const topicHeading = document.createElement("h3");
+      topicHeading.className = "topic-heading";
+      topicHeading.setAttribute("data-topic-slug", topicBucket.slug);
+      topicHeading.textContent = topicBucket.name;
+      section.appendChild(topicHeading);
 
-      for (const digest of dateGroup.digests) {
+      for (const digest of topicBucket.digests) {
         const card = renderDigestCard(digest);
         card.appendChild(metaLine(digestMeta(digest, topics)));
         section.appendChild(card);
@@ -400,10 +419,11 @@ export async function renderHistory(root: HTMLElement, client: SupabaseClient): 
   listContainer.setAttribute("data-testid", "history-list");
 
   const apply = (state: HistoryState) => {
-    // Default view: when no explicit filters, scope to the last 7 days.
-    const hasFilter = !!(state.topic || state.date || state.q.trim());
-    const scoped = hasFilter ? allDigests : withinLastDays(allDigests, DEFAULT_WINDOW_DAYS);
-    renderList(listContainer, filterDigests(scoped, state), topics);
+    // Always exclude today — today's digests belong on Home, not History.
+    // Explicit filters (topic/date/search) operate on the already-scoped set
+    // so users can't accidentally surface today's content via search either.
+    const withoutToday = excludeToday(allDigests);
+    renderList(listContainer, filterDigests(withoutToday, state), topics);
   };
 
   const onChange = (next: HistoryState) => {

--- a/web/src/views/digest-list.ts
+++ b/web/src/views/digest-list.ts
@@ -1,4 +1,4 @@
-import { groupDigestsByTopicAndDate } from "../lib/group";
+import { groupDigestsByDateAndTopic } from "../lib/group";
 import type { Digest, Topic } from "../lib/types";
 import { renderDigestCard } from "./digest-card";
 
@@ -23,12 +23,17 @@ export function formatDate(iso: string): string {
   return dateFmt.format(new Date(Date.UTC(y, m - 1, d)));
 }
 
-/** Renders all digests grouped by topic, then by date (newest first). */
+/**
+ * Renders all digests grouped by date (newest first), then by topic within
+ * each date (issue #101). On Home the caller passes only today's digests so
+ * there is at most one date section; the same grouping as History keeps the
+ * two views structurally consistent.
+ */
 export function renderDigestList(digests: readonly Digest[], topics: readonly Topic[]): HTMLElement {
   const container = document.createElement("div");
   container.className = "digest-list";
 
-  const groups = groupDigestsByTopicAndDate(digests, topics);
+  const groups = groupDigestsByDateAndTopic(digests, topics);
   if (groups.length === 0) {
     const empty = document.createElement("p");
     empty.className = "empty-state";
@@ -37,24 +42,25 @@ export function renderDigestList(digests: readonly Digest[], topics: readonly To
     return container;
   }
 
-  for (const group of groups) {
+  for (const dateGroup of groups) {
     const section = document.createElement("section");
-    section.className = "topic-group";
-    section.setAttribute("data-topic-slug", group.slug);
+    section.className = "date-group";
+    section.setAttribute("data-date", dateGroup.date);
 
-    const heading = document.createElement("h2");
-    heading.className = "topic-heading";
-    heading.textContent = group.name;
-    section.appendChild(heading);
+    const dateHeading = document.createElement("h2");
+    dateHeading.className = "date-heading";
+    dateHeading.textContent = formatDate(dateGroup.date);
+    dateHeading.setAttribute("data-date", dateGroup.date);
+    section.appendChild(dateHeading);
 
-    for (const dateGroup of group.dates) {
-      const dateHeading = document.createElement("h3");
-      dateHeading.className = "date-heading";
-      dateHeading.textContent = formatDate(dateGroup.date);
-      dateHeading.setAttribute("data-date", dateGroup.date);
-      section.appendChild(dateHeading);
+    for (const topicBucket of dateGroup.topics) {
+      const topicHeading = document.createElement("h3");
+      topicHeading.className = "topic-heading";
+      topicHeading.setAttribute("data-topic-slug", topicBucket.slug);
+      topicHeading.textContent = topicBucket.name;
+      section.appendChild(topicHeading);
 
-      for (const digest of dateGroup.digests) {
+      for (const digest of topicBucket.digests) {
         section.appendChild(renderDigestCard(digest));
       }
     }

--- a/web/tests/e2e/history.spec.ts
+++ b/web/tests/e2e/history.spec.ts
@@ -5,8 +5,9 @@ import { seedSession } from "./session";
 const SUPABASE_URL = process.env.VITE_SUPABASE_URL ?? "https://eedfyviypptfpghyffip.supabase.co";
 const ANON_KEY = process.env.VITE_SUPABASE_ANON_KEY ?? "sb_publishable_CCE4uRqvWCAonhnDis0BZQ_ixrd0jl2";
 
-// AC1: Past digests browsable, grouped by date descending — over the LIVE data path.
-// Reads real digests from Supabase, so it needs a genuine authenticated (AAL2) session
+// AC1 (issue #101): Past digests browsable, grouped DATE-FIRST then by topic,
+// dates descending, and TODAY is excluded (today lives on Home). Reads real
+// digests from Supabase, so it needs a genuine authenticated (AAL2) session
 // (RLS gates reads to the `authenticated` role).
 test.describe("history (live authenticated reads)", () => {
   test.skip(!LIVE_AUTH, LIVE_AUTH_SKIP);
@@ -15,21 +16,34 @@ test.describe("history (live authenticated reads)", () => {
     await signInAal2(page);
   });
 
-  test("history renders grouped by topic with date headings descending", async ({ page }) => {
+  test("history renders date-first headings descending with today excluded", async ({ page }) => {
     await page.goto("/#/history");
     await expect(page.getByTestId("history-content")).toBeVisible();
     await expect(page.getByTestId("auth-gate")).toHaveCount(0);
 
-    const groups = page.locator(".topic-group");
-    await expect(groups.first()).toBeVisible({ timeout: 15_000 });
+    // Top-level groups are now DATES (issue #101 changed topic-first -> date-first).
+    const dateGroups = page.locator("section.date-group");
+    await expect(dateGroups.first()).toBeVisible({ timeout: 15_000 });
 
+    // Each date section carries its calendar date on data-date; collect descending.
     const dates = await page
-      .locator(".topic-group")
-      .first()
-      .locator(".date-heading")
+      .locator("section.date-group")
       .evaluateAll((els) => els.map((el) => el.getAttribute("data-date") ?? ""));
     const sortedDesc = [...dates].sort().reverse();
     expect(dates).toEqual(sortedDesc);
+
+    // Today must NOT appear in History — it is shown on Home instead. The app's
+    // canonical "today" is America/New_York (see src/lib/dates.ts).
+    const todayET = new Intl.DateTimeFormat("en-CA", {
+      timeZone: "America/New_York",
+    }).format(new Date());
+    expect(dates).not.toContain(todayET);
+
+    // Topics are nested beneath each date as h3 headings.
+    const topicHeadings = page.locator("section.date-group h3.topic-heading");
+    if ((await dateGroups.count()) > 0) {
+      await expect(topicHeadings.first()).toBeVisible();
+    }
   });
 });
 
@@ -53,19 +67,19 @@ test.describe("history (fixture data)", () => {
   });
 
   // AC4 + AC1: 150-row fixture renders all rows within a sane time budget.
+  // The fixture spans 2026-06-01 back ~30 days, none of which is the wall-clock
+  // "today", so excludeToday() drops nothing here and all 30 rows for a topic show.
   test("renders 150 fixture rows quickly", async ({ page }) => {
     const start = Date.now();
     await page.goto("/?fixture=150#/history");
     await expect(page.getByTestId("history-list")).toBeVisible();
-    // Fixture spans 30 days; with no filter the default 7-day window applies.
-    // Switch to "All topics" + clear-window by selecting a topic to force full set,
-    // then assert the full dataset can render. First measure default-view interactive.
-    await expect(page.locator(".topic-group").first()).toBeVisible();
+    // Top-level grouping is date-first (issue #101): assert a date section renders.
+    await expect(page.locator("section.date-group").first()).toBeVisible();
     const interactive = Date.now() - start;
     expect(interactive).toBeLessThan(1000);
 
-    // Force the entire 150-row set via a topic filter (bypasses 7-day window) and
-    // confirm every card for that topic renders. 150 rows total / 5 topics = 30 each.
+    // Filter to a single topic and confirm every card for that topic renders.
+    // 150 rows total / 5 topics = 30 each (across 30 distinct dates).
     await page.getByTestId("filter-topic").selectOption("ai_models");
     await expect(page.locator(".digest-card")).toHaveCount(30);
   });
@@ -76,12 +90,14 @@ test.describe("history (fixture data)", () => {
     await expect(page.getByTestId("history-list")).toBeVisible();
 
     await page.getByTestId("filter-topic").selectOption("penguins");
-    // Only the penguins group remains.
-    await expect(page.locator(".topic-group")).toHaveCount(1);
-    await expect(page.locator(".topic-group").first()).toHaveAttribute(
-      "data-topic-slug",
-      "penguins",
+    // Every nested topic heading is the penguins topic (date-first grouping).
+    const topicHeadings = page.locator("section.date-group h3.topic-heading");
+    await expect(topicHeadings.first()).toBeVisible();
+    const slugs = await topicHeadings.evaluateAll((els) =>
+      els.map((el) => el.getAttribute("data-topic-slug") ?? ""),
     );
+    expect(slugs.length).toBeGreaterThan(0);
+    expect(slugs.every((s) => s === "penguins")).toBe(true);
     // URL search reflects the selection (shareable).
     await expect.poll(() => new URL(page.url()).search).toContain("topic=penguins");
   });
@@ -90,11 +106,13 @@ test.describe("history (fixture data)", () => {
   test("shareable ?topic= URL loads pre-filtered", async ({ page }) => {
     await page.goto("/?fixture=150&topic=ai_models#/history");
     await expect(page.getByTestId("history-list")).toBeVisible();
-    await expect(page.locator(".topic-group")).toHaveCount(1);
-    await expect(page.locator(".topic-group").first()).toHaveAttribute(
-      "data-topic-slug",
-      "ai_models",
+    const topicHeadings = page.locator("section.date-group h3.topic-heading");
+    await expect(topicHeadings.first()).toBeVisible();
+    const slugs = await topicHeadings.evaluateAll((els) =>
+      els.map((el) => el.getAttribute("data-topic-slug") ?? ""),
     );
+    expect(slugs.length).toBeGreaterThan(0);
+    expect(slugs.every((s) => s === "ai_models")).toBe(true);
     // The topic control reflects the URL state.
     await expect(page.getByTestId("filter-topic")).toHaveValue("ai_models");
   });

--- a/web/tests/e2e/home-today.spec.ts
+++ b/web/tests/e2e/home-today.spec.ts
@@ -47,10 +47,10 @@ test.describe("home today-only digest view (live authenticated reads)", () => {
     await expect(page.getByTestId("digest-content")).toBeVisible();
     await page.waitForSelector(".digest-list", { timeout: 15_000 });
 
-    const groups = page.locator(".topic-group");
+    const groups = page.locator(".date-group");
     const empty = page.locator(".empty-state");
 
-    // Either topic groups exist (today has digests) or the empty state shows.
+    // Either date groups exist (today has digests) or the empty state shows.
     const groupCount = await groups.count();
     const emptyCount = await empty.count();
     expect(groupCount + emptyCount).toBeGreaterThan(0);

--- a/web/tests/unit/digest-list.test.ts
+++ b/web/tests/unit/digest-list.test.ts
@@ -2,7 +2,22 @@
 import { describe, expect, it } from "vitest";
 
 import { formatDate, renderDigestList } from "../../src/views/digest-list";
-import type { Topic } from "../../src/lib/types";
+import type { Digest, Topic } from "../../src/lib/types";
+
+function digest(partial: Partial<Digest> & { topic_slug: string; digest_date: string }): Digest {
+  return {
+    id: `${partial.topic_slug}-${partial.digest_date}`,
+    content: "x",
+    cadence: "24h",
+    sources_used: [],
+    token_count: null,
+    prompt_version: "v",
+    created_at: `${partial.digest_date}T00:00:00Z`,
+    summary: null,
+    items: null,
+    ...partial,
+  };
+}
 
 // Regression for the Today-screen date rendering one day early (issue #92):
 // a calendar digest_date must render the SAME day-of-month regardless of the
@@ -46,5 +61,53 @@ describe("renderDigestList empty state", () => {
     const el = renderDigestList([], topics);
     expect(el.textContent).not.toContain("No digests yet");
     expect(el.textContent).not.toContain("Check back after the next run");
+  });
+});
+
+// ── renderDigestList date-first grouping (issue #101) ─────────────────────────
+
+describe("renderDigestList date-first grouping", () => {
+  const topics: Topic[] = [
+    { id: 1, name: "AI model releases", slug: "ai_models", cadence: "24h", enabled: true },
+    { id: 2, name: "Local news", slug: "local_news", cadence: "7d", enabled: true },
+  ];
+
+  it("renders a date h2 at the top level", () => {
+    const digests = [digest({ topic_slug: "ai_models", digest_date: "2026-06-14" })];
+    const el = renderDigestList(digests, topics);
+    const dateHeadings = el.querySelectorAll("section.date-group > h2.date-heading");
+    expect(dateHeadings).toHaveLength(1);
+    expect(dateHeadings[0].getAttribute("data-date")).toBe("2026-06-14");
+  });
+
+  it("renders topic h3 nested beneath the date heading", () => {
+    const digests = [digest({ topic_slug: "ai_models", digest_date: "2026-06-14" })];
+    const el = renderDigestList(digests, topics);
+    const topicHeadings = el.querySelectorAll("section.date-group h3.topic-heading");
+    expect(topicHeadings).toHaveLength(1);
+    expect(topicHeadings[0].textContent).toBe("AI model releases");
+  });
+
+  it("lists multiple topics under the same date group", () => {
+    const digests = [
+      digest({ topic_slug: "ai_models", digest_date: "2026-06-14" }),
+      digest({ topic_slug: "local_news", digest_date: "2026-06-14" }),
+    ];
+    const el = renderDigestList(digests, topics);
+    const dateGroups = el.querySelectorAll("section.date-group");
+    expect(dateGroups).toHaveLength(1);
+    const topicHeadings = dateGroups[0].querySelectorAll("h3.topic-heading");
+    expect(topicHeadings).toHaveLength(2);
+  });
+
+  it("renders multiple dates newest first", () => {
+    const digests = [
+      digest({ topic_slug: "ai_models", digest_date: "2026-06-13" }),
+      digest({ topic_slug: "ai_models", digest_date: "2026-06-14" }),
+    ];
+    const el = renderDigestList(digests, topics);
+    const dateHeadings = el.querySelectorAll("section.date-group h2.date-heading");
+    const dates = Array.from(dateHeadings).map((h) => h.getAttribute("data-date"));
+    expect(dates).toEqual(["2026-06-14", "2026-06-13"]);
   });
 });

--- a/web/tests/unit/group.test.ts
+++ b/web/tests/unit/group.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { groupDigestsByTopicAndDate } from "../../src/lib/group";
+import { groupDigestsByDateAndTopic, groupDigestsByTopicAndDate } from "../../src/lib/group";
 import type { Digest, Topic } from "../../src/lib/types";
 
 function digest(partial: Partial<Digest> & { topic_slug: string; digest_date: string }): Digest {
@@ -64,5 +64,66 @@ describe("groupDigestsByTopicAndDate", () => {
     ];
     const groups = groupDigestsByTopicAndDate(digests, topics);
     expect(groups.map((g) => g.slug)).toEqual(["local_news", "ai_models"]);
+  });
+});
+
+describe("groupDigestsByDateAndTopic", () => {
+  it("returns an empty array for no digests", () => {
+    expect(groupDigestsByDateAndTopic([], topics)).toEqual([]);
+  });
+
+  it("groups by date (newest first), then topics nested within each date", () => {
+    const digests = [
+      digest({ topic_slug: "ai_models", digest_date: "2026-06-10" }),
+      digest({ topic_slug: "local_news", digest_date: "2026-06-10" }),
+      digest({ topic_slug: "ai_models", digest_date: "2026-06-09" }),
+    ];
+
+    const groups = groupDigestsByDateAndTopic(digests, topics);
+
+    // Two distinct dates, newest first.
+    expect(groups.map((g) => g.date)).toEqual(["2026-06-10", "2026-06-09"]);
+
+    // June 10 has both topics.
+    const june10 = groups[0];
+    expect(june10.topics.map((t) => t.slug).sort()).toEqual(["ai_models", "local_news"]);
+
+    // June 9 has only ai_models.
+    const june9 = groups[1];
+    expect(june9.topics).toHaveLength(1);
+    expect(june9.topics[0].slug).toBe("ai_models");
+    expect(june9.topics[0].digests).toHaveLength(1);
+  });
+
+  it("attaches the correct topic name from the topics list", () => {
+    const digests = [digest({ topic_slug: "ai_models", digest_date: "2026-06-10" })];
+    const groups = groupDigestsByDateAndTopic(digests, topics);
+    expect(groups[0].topics[0].name).toBe("AI model releases");
+  });
+
+  it("falls back to slug when no topic metadata matches", () => {
+    const digests = [digest({ topic_slug: "mystery", digest_date: "2026-06-10" })];
+    const groups = groupDigestsByDateAndTopic(digests, []);
+    expect(groups[0].topics[0].name).toBe("mystery");
+  });
+
+  it("orders topics within a date by the topics array order", () => {
+    // topics = [ai_models (id:1), local_news (id:2)]
+    const digests = [
+      digest({ topic_slug: "local_news", digest_date: "2026-06-10" }),
+      digest({ topic_slug: "ai_models", digest_date: "2026-06-10" }),
+    ];
+    const groups = groupDigestsByDateAndTopic(digests, topics);
+    // topics list order: ai_models first, local_news second
+    expect(groups[0].topics.map((t) => t.slug)).toEqual(["ai_models", "local_news"]);
+  });
+
+  it("places all digests for a given topic+date in the nested digests array", () => {
+    const digests = [
+      digest({ topic_slug: "ai_models", digest_date: "2026-06-10", id: "a1" }),
+      digest({ topic_slug: "ai_models", digest_date: "2026-06-10", id: "a2" }),
+    ];
+    const groups = groupDigestsByDateAndTopic(digests, topics);
+    expect(groups[0].topics[0].digests).toHaveLength(2);
   });
 });

--- a/web/tests/unit/history.test.ts
+++ b/web/tests/unit/history.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 import {
   digestMeta,
+  excludeToday,
   filterDigests,
   generateFixtureDigests,
   parseHistoryState,
@@ -176,6 +177,34 @@ describe("withinLastDays", () => {
 
   it("returns an empty array unchanged", () => {
     expect(withinLastDays([], 7)).toEqual([]);
+  });
+});
+
+describe("excludeToday", () => {
+  // Pin "now" so isToday is deterministic: 2026-06-15 Eastern is the pinned today.
+  const pinnedNow = new Date("2026-06-15T12:00:00-04:00");
+
+  it("removes digests whose digest_date is today", () => {
+    const digests = [
+      digest({ topic_slug: "ai_models", digest_date: "2026-06-15" }), // today — excluded
+      digest({ topic_slug: "ai_models", digest_date: "2026-06-14" }), // yesterday — kept
+      digest({ topic_slug: "ai_models", digest_date: "2026-06-13" }), // 2 days ago — kept
+    ];
+    const out = excludeToday(digests, pinnedNow);
+    expect(out.map((d) => d.digest_date)).toEqual(["2026-06-14", "2026-06-13"]);
+  });
+
+  it("returns all digests when none are today", () => {
+    const digests = [
+      digest({ topic_slug: "ai_models", digest_date: "2026-06-14" }),
+      digest({ topic_slug: "ai_models", digest_date: "2026-06-13" }),
+    ];
+    const out = excludeToday(digests, pinnedNow);
+    expect(out).toHaveLength(2);
+  });
+
+  it("returns an empty array unchanged", () => {
+    expect(excludeToday([], pinnedNow)).toEqual([]);
   });
 });
 


### PR DESCRIPTION
Closes #101

> Stacked on #100 (`feat/issue-100-home-today`). Review this PR's diff in isolation; it will be retargeted to `main` once #100 merges.

## Summary
- **Date-first grouping:** new `groupDigestsByDateAndTopic` in `group.ts`. History now renders **date heading (h2) → topic heading (h3) → cards** (was topic→date). Home uses the same grouping for consistency.
- **Previous days only:** History excludes today (shown on Home) via `isToday` (America/New_York), showing the prior retained days newest-first. Window aligned to the 3-day retention contract (#102).
- Date headings now use the human-readable `formatDate()` (e.g. "Sat, Jun 14, 2026"), matching Home; the raw ISO date is retained in `data-date` for selectors/sorting.

## Test Evidence
- Lint (eslint + tsc): **PASS**
- Unit (vitest): **PASS — 410 tests** (new: date-first grouping order, topic nesting, today-exclusion boundary)
- Build: **PASS**
- E2E (`history.spec.ts` updated for date-first structure + today-exclusion): runs in CI (live-auth specs require MFA secrets, which are not set in CI — see orchestrator's manual validation note).
- Orchestrator independently re-ran lint/unit/build: green.

## Note
Same retention interpretation as #100/#102: 3 calendar days total (today on Home + 2 prior in History). Confirm if you intended a different window.