### PR TITLE
Retention: keep today + 3 prior days (4 total)

### DIFF
--- a/src/news_digest/config.py
+++ b/src/news_digest/config.py
@@ -51,7 +51,7 @@ class Settings(BaseSettings):
     # "published today" checks). The scheduler tick remains UTC; only the date
     # label shifts to Eastern so digests group by the listener's calendar day.
     app_timezone: str = "America/New_York"  # APP_TIMEZONE
-    retention_days: int = 3  # RETENTION_DAYS — keep today + N-1 prior days
+    retention_days: int = 4  # RETENTION_DAYS — keep today + N-1 prior days
     schedule_retention_hour: int = 5  # SCHEDULE_RETENTION_HOUR (UTC)
 
     @field_validator("supabase_url", "supabase_anon_key", "supabase_service_key")

--- a/src/news_digest/retention.py
+++ b/src/news_digest/retention.py
@@ -1,7 +1,7 @@
 """Daily hard-purge of stale digests — issue #102.
 
 Deletes ``digests`` rows whose ``digest_date`` is older than the retention
-window.  With the default ``retention_days=3``, today's digest plus the two
+window.  With the default ``retention_days=4``, today's digest plus the three
 prior days are kept; anything older is deleted.
 
 Public API
@@ -14,9 +14,9 @@ _cutoff_date(today, retention_days) -> datetime.date
     Pure helper exposed for tests.  Returns the *inclusive* lower boundary:
     rows *on* the cutoff date are retained; rows *before* it are deleted.
 
-Retention window example (retention_days=3, today=2026-06-15):
-    Kept:    2026-06-13, 2026-06-14, 2026-06-15
-    Deleted: 2026-06-12 and older (digest_date < '2026-06-13')
+Retention window example (retention_days=4, today=2026-06-15):
+    Kept:    2026-06-12, 2026-06-13, 2026-06-14, 2026-06-15
+    Deleted: 2026-06-11 and older (digest_date < '2026-06-12')
 """
 
 from datetime import date, timedelta

--- a/tests/test_retention.py
+++ b/tests/test_retention.py
@@ -74,6 +74,15 @@ class TestCutoffMath:
         cutoff = _cutoff_date(today, retention_days=3)
         assert date(2026, 6, 12) < cutoff  # 2026-06-12 < 2026-06-13 → deleted
 
+    def test_cutoff_with_retention_4_default(self):
+        """Default retention_days=4 → cutoff today-3; keeps today + 3 prior."""
+        from news_digest.retention import _cutoff_date
+
+        today = date(2026, 6, 15)
+        cutoff = _cutoff_date(today, retention_days=4)
+        # cutoff = today - 3 = 2026-06-12; keeps 06-12..06-15, deletes 06-11+
+        assert cutoff == date(2026, 6, 12)
+
     def test_cutoff_with_retention_1_keeps_only_today(self):
         """retention_days=1 → cutoff is today; keeps only today."""
         from news_digest.retention import _cutoff_date
@@ -89,6 +98,13 @@ class TestCutoffMath:
         today = date(2026, 6, 15)
         cutoff = _cutoff_date(today, retention_days=7)
         assert cutoff == date(2026, 6, 9)
+
+
+def test_default_retention_days_is_4():
+    """The shipped default keeps today + 3 prior calendar days."""
+    from news_digest.config import Settings
+
+    assert Settings.model_fields["retention_days"].default == 4
 
 
 # ---------------------------------------------------------------------------

--- a/web/src/pages/history.ts
+++ b/web/src/pages/history.ts
@@ -24,8 +24,8 @@ import { formatDate } from "../views/digest-list";
 // Today's digests live on Home. History excludes today via excludeToday() so
 // both views stay coherent regardless of how many days the backend retains.
 // We deliberately do NOT use a fixed window size here: the backend retention
-// contract (#102) is ≤3 calendar days (today + 2 prior), so History shows at
-// most 2 prior days. Applying a window filter on top of that would be redundant
+// contract (#102) is ≤4 calendar days (today + 3 prior), so History shows at
+// most 3 prior days. Applying a window filter on top of that would be redundant
 // and would silently hide data if retention ever increases.
 
 // --- Pure, DOM-free helpers (unit-tested) ----------------------------------


### PR DESCRIPTION
Follow-up to #102 (per owner request).

## Change
- `retention_days` default **3 → 4**: the daily purge now keeps **today + 3 prior** calendar days (was today + 2 prior).
- Updated `retention.py` docstrings and the `history.ts` retention-contract comment to match.
- Added tests: `_cutoff_date(retention_days=4)` → cutoff = today−3, and a guard that the shipped default is 4.

## Verification
- `py_compile` clean locally; ruff + pytest run in CI (env-complete there).
- No web logic change (History already uses no fixed window — it shows whatever the backend retains, minus today).