### PR TITLE
Agent failure diagnostics: capture tracebacks + classify upstream LLM errors honestly

### DIFF
--- a/src/news_digest/agent.py
+++ b/src/news_digest/agent.py
@@ -86,6 +86,30 @@ def _is_lemonade_down(error_history: list[Any] | None) -> bool:
     return False
 
 
+def _is_llm_error_response(text: str) -> bool:
+    """Return True when *text* is a GAIA error-fallback string, not a digest.
+
+    GAIA wraps certain upstream LLM failures (e.g. HTTP 400 "2+ assistant
+    messages") into a user-facing apology string rather than raising.  These
+    strings must be classified as ``llm_error`` upstream failures, not as
+    ``parse_error`` (which would imply the model produced garbled JSON).
+
+    Conservative match (case-insensitive, on the stripped text):
+    - Starts with ``"sorry, i ran into an unexpected problem"``
+    - OR contains ``"error in chat completions"``
+
+    Args:
+        text: The stripped raw final-answer string from process_query.
+
+    Returns:
+        True when the text matches a known GAIA error-fallback pattern.
+    """
+    lowered = text.strip().lower()
+    return lowered.startswith("sorry, i ran into an unexpected problem") or (
+        "error in chat completions" in lowered
+    )
+
+
 def _strip_code_fences(text: str) -> str:
     """Strip leading/trailing markdown code fences from a model answer.
 
@@ -149,8 +173,19 @@ def _publish_from_result(result: dict[str, Any]) -> dict[str, Any]:
         )
         return {"success": False, "error": "no_answer"}
 
+    stripped = _strip_code_fences(raw)
+    if _is_llm_error_response(stripped):
+        log(
+            "error",
+            "publish",
+            "generate_and_publish: LLM returned an error response, not a digest"
+            " (upstream LLM failure)",
+            metadata={"raw": raw[:300]},
+        )
+        return {"success": False, "error": "llm_error"}
+
     try:
-        parsed = json.loads(_strip_code_fences(raw))
+        parsed = json.loads(stripped)
     except (ValueError, TypeError) as exc:
         log(
             "error",

--- a/src/news_digest/scheduler.py
+++ b/src/news_digest/scheduler.py
@@ -20,6 +20,7 @@ See §2.6, §4, and §5.5 of docs/architecture.md for the design spec.
 import random
 import signal
 import threading
+import traceback
 from datetime import UTC, date, datetime, timedelta
 from typing import Any
 
@@ -237,6 +238,7 @@ def _run_topic(topic: dict[str, Any], agent: Any) -> None:
                     "error": str(exc),
                     "exc_type": exc.__class__.__name__,
                     "attempt": attempt,
+                    "traceback": traceback.format_exc(),
                 },
             )
             result = {"success": False, "error": exc.__class__.__name__}

--- a/tests/test_generate_and_publish.py
+++ b/tests/test_generate_and_publish.py
@@ -37,8 +37,19 @@ def _capture_push(monkeypatch):
 
 @pytest.fixture(autouse=True)
 def _silence_log(monkeypatch):
-    """Keep the parser's error logging from touching Supabase/SQLite in tests."""
-    monkeypatch.setattr(agent_module, "log", lambda *a, **k: None)
+    """Keep the parser's error logging from touching Supabase/SQLite in tests.
+
+    Returns the captured log call list so individual tests can assert on it.
+    """
+    calls = []
+    monkeypatch.setattr(agent_module, "log", lambda *a, **k: calls.append((a, k)))
+    return calls
+
+
+@pytest.fixture()
+def log_calls(_silence_log):
+    """Expose captured log calls to tests that inspect them."""
+    return _silence_log
 
 
 _ITEMS = [
@@ -296,3 +307,85 @@ def test_publish_answer_is_fenced_json_string(_capture_push):
     assert _capture_push[0]["topic_slug"] == "ai_models"
     assert _capture_push[0]["summary"] == "Top AI news today."
     assert _capture_push[0]["token_count"] == 7
+
+
+# ---------------------------------------------------------------------------
+# LLM error-fallback detection — Change 2 (GAIA 400 "2+ assistant messages")
+# ---------------------------------------------------------------------------
+
+# The exact string GAIA emits when the LLM call returns HTTP 400 and the
+# conversation has two consecutive assistant turns.
+_GAIA_400_FALLBACK = (
+    "Sorry, I ran into an unexpected problem. This might be a temporary issue"
+    " — try again in a moment.\n\n"
+    "*Technical details: Error in chat completions (status 400):"
+    " ...Cannot have 2 or more assistant messages..."
+)
+
+
+def test_llm_error_response_returns_llm_error_not_parse_error(_capture_push, log_calls):
+    """GAIA error-fallback string → error='llm_error', not 'parse_error'.
+
+    When the LLM returns a 400 "2+ assistant messages" error, GAIA wraps it in a
+    user-facing "Sorry, I ran into an unexpected problem" string.  This must be
+    classified as llm_error (upstream LLM failure) rather than parse_error
+    (which would imply the model produced garbled JSON).
+    """
+    result = {
+        "status": "failed",
+        "result": _GAIA_400_FALLBACK,
+        "output_tokens": 0,
+    }
+    out = _publish_from_result(result)
+
+    assert out == {"success": False, "error": "llm_error"}
+    assert _capture_push == [], "push_to_supabase must not be called on llm_error"
+
+    # Log message must mention the new classification, NOT "could not parse final answer"
+    logged_messages = [a[2] for (a, _) in log_calls if len(a) >= 3]
+    assert any("LLM returned an error response" in m for m in logged_messages), (
+        f"expected llm_error log message, got: {logged_messages}"
+    )
+    assert not any("could not parse final answer" in m for m in logged_messages), (
+        "must not emit the parse_error message for a GAIA error-fallback string"
+    )
+
+
+def test_llm_error_response_case_insensitive_match(_capture_push):
+    """Match is case-insensitive on the stripped text."""
+    # All-caps variant — unlikely in practice but the spec says case-insensitive.
+    raw = "SORRY, I RAN INTO AN UNEXPECTED PROBLEM — Error in chat completions (status 400)"
+    result = {"status": "failed", "result": raw, "output_tokens": 0}
+    out = _publish_from_result(result)
+    assert out == {"success": False, "error": "llm_error"}
+    assert _capture_push == []
+
+
+def test_llm_error_match_by_contains_error_in_chat_completions(_capture_push):
+    """Also matches when the string contains 'Error in chat completions' anywhere."""
+    raw = "Something went wrong. Error in chat completions (status 400): bad request."
+    result = {"status": "failed", "result": raw, "output_tokens": 0}
+    out = _publish_from_result(result)
+    assert out == {"success": False, "error": "llm_error"}
+    assert _capture_push == []
+
+
+def test_non_matching_malformed_json_still_returns_parse_error(
+    _capture_push, log_calls
+):
+    """Regression guard: a genuine bad-JSON string (no GAIA error pattern) → parse_error.
+
+    This must not regress: any non-matching string that fails json.loads must still
+    go through the existing path and return error='parse_error'.
+    """
+    result = {"status": "success", "result": "{bad json", "output_tokens": 0}
+    out = _publish_from_result(result)
+
+    assert out == {"success": False, "error": "parse_error"}
+    assert _capture_push == []
+
+    logged_messages = [a[2] for (a, _) in log_calls if len(a) >= 3]
+    assert any("could not parse final answer" in m for m in logged_messages), (
+        "parse_error path must still log 'could not parse final answer'"
+    )
+    assert not any("LLM returned an error response" in m for m in logged_messages)

--- a/tests/test_scheduler.py
+++ b/tests/test_scheduler.py
@@ -872,3 +872,52 @@ def test_retention_job_registered(monkeypatch, valid_env):
     assert retention_job["max_instances"] == 1
     # Default hour is 5 UTC (settings.schedule_retention_hour default)
     assert retention_job["hour"] == 5
+
+
+# ---------------------------------------------------------------------------
+# Traceback capture in crash path — Change 1
+# ---------------------------------------------------------------------------
+
+
+def test_run_topic_exception_log_includes_traceback_key(monkeypatch, log_calls):
+    """When generate_and_publish raises, the error log metadata includes 'traceback'.
+
+    The traceback key must contain the full stack trace string so that diagnosis
+    is possible from system_logs without needing to reproduce the failure.
+    """
+    # Arrange: agent that raises with a real Python exception (so traceback is real).
+    agent = MagicMock()
+    agent.generate_and_publish.side_effect = RuntimeError(
+        "unexpected crash for traceback test"
+    )
+
+    # Override _is_published_today so the retry loop stops after _MAX_RUN_ATTEMPTS
+    # (the autouse _assume_published fixture already defaults to True, but the
+    # exception path short-circuits before the publish check; so we override here
+    # to False to let all attempts exercise the except block).
+    monkeypatch.setattr(sched_module, "_is_published_today", lambda slug: False)
+
+    _run_topic(_topic_row(), agent)
+
+    # Find error log entries that came from the exception path
+    error_logs = [
+        (a, k)
+        for (a, k) in log_calls
+        if a[0] == "error" and "unhandled exception" in a[2]
+    ]
+    assert error_logs, "Expected at least one 'unhandled exception' error log"
+
+    # Every exception log must carry metadata with a 'traceback' key
+    for _, kwargs in error_logs:
+        meta = kwargs.get("metadata", {})
+        assert "traceback" in meta, (
+            f"metadata missing 'traceback' key; got keys: {list(meta.keys())}"
+        )
+        tb = meta["traceback"]
+        assert isinstance(tb, str) and len(tb) > 0, (
+            "traceback must be a non-empty string"
+        )
+        # The traceback should reference the actual exception
+        assert "RuntimeError" in tb or "unexpected crash" in tb, (
+            f"traceback does not mention the exception: {tb[:200]}"
+        )


### PR DESCRIPTION
Follow-up to production validation of #100-#103. Mitigation + observability for the intermittent digest failures whose **root cause is upstream** ([amd/gaia#1667](https://github.com/amd/gaia/issues/1667) — llama-server rejects 2+ trailing assistant messages). This does NOT fix the upstream LLM failure; it makes it diagnosable and stops mislabeling it.

## Changes
1. **`scheduler.py`** — `_run_topic` now includes `traceback.format_exc()` in the error-log metadata, so unhandled exceptions (e.g. the rare `'dict'.lower()` AttributeError) land in `system_logs` with a full stack instead of just the message.
2. **`agent.py`** — `_publish_from_result` detects GAIA error-fallback strings ("Sorry, I ran into an unexpected problem" / "Error in chat completions") and returns `error="llm_error"` with a clear log, instead of treating them as JSON `parse_error`. Genuinely malformed JSON still returns `parse_error` (regression-guarded).

## Test Evidence
- ruff check + format: **PASS**
- pytest -m "not integration": **PASS — 333 tests** (4 new for the llm_error classification incl. a parse_error regression guard; 1 new asserting the traceback metadata key)
- Orchestrator independently re-ran ruff + pytest: green.

## Why
36h of logs showed ~51 "could not parse final answer" failures across all topics — most were actually upstream LLM 400s mislabeled as parse errors. This restores honest signal and captures stacks for the rare true crashes.