### PR TITLE
Fix: TTS audio not playing on prod — revert #103 double-buffering (autoplay regression)

### DIFF
--- a/web/src/lib/tts-neural.ts
+++ b/web/src/lib/tts-neural.ts
@@ -8,10 +8,6 @@
 // Responsibilities:
 //   - Synthesize one chunk per request, play via a SINGLE long-lived
 //     HTMLAudioElement (src is swapped per chunk — never a new element).
-//   - Double-buffer (#103): prefetch() ALSO preloads the object URL into a
-//     second HTMLAudioElement so speak() can swap and play() synchronously,
-//     eliminating the inter-chunk gap (~3s) that comes from awaiting an async
-//     fetch even on a cache hit.
 //   - Attach caller-provided headers (Supabase JWT) to every request — the
 //     function is deployed with JWT verification on.
 //   - In-memory cache keyed `${voice}|${rate}|hash(text)` -> object URL so a
@@ -29,7 +25,7 @@ const MAX_CACHE_ENTRIES = 64;
 // Google Chirp 3 HD synthesis costs ~9 ms/char, so first-audio latency is set
 // by the FIRST chunk's size: ~240 chars measures ~2.3s (vs ~6.6s at 700, ~36s
 // at 4000). Each chunk's audio runs ~3x longer than its own synth time, so the
-// player's prefetch (Fix #103) keeps every later chunk ready with no gap; only
+// player's prefetch (Fix #2) keeps every later chunk ready with no gap; only
 // the first chunk is unavoidably synchronous. ~240 chars is also 1–3 whole
 // sentences, so per-chunk prosody stays natural.
 const NEURAL_MAX_CHUNK_CHARS = 240;
@@ -50,8 +46,8 @@ export interface NeuralHttpBackendOptions {
   fetchImpl?: typeof fetch;
   /**
    * Injectable for tests; called at most once to create the single long-lived
-   * primary HTMLAudioElement.  Subsequent speaks reassign .src on the same
-   * element.  Defaults to `new Audio()`.
+   * HTMLAudioElement.  Subsequent speaks reassign .src on the same element.
+   * Defaults to `new Audio()`.
    */
   audioFactory?: () => HTMLAudioElement;
   /** Cache size cap; defaults to 64. */
@@ -69,16 +65,6 @@ function hashText(text: string): string {
   return h.toString(36);
 }
 
-/** Double-buffer slot: a second audio element preloaded and ready to swap in. */
-interface PreloadSlot {
-  /** Cache key (voice|rate|hash) identifying which chunk is preloaded. */
-  key: string;
-  /** Object URL already assigned to the slot element's .src. */
-  url: string;
-  /** A second HTMLAudioElement with .src = url; ready for immediate play(). */
-  element: HTMLAudioElement;
-}
-
 export class NeuralHttpBackend implements TtsBackend {
   readonly supportsRealSeek = true;
   readonly maxChunkChars = NEURAL_MAX_CHUNK_CHARS;
@@ -92,7 +78,7 @@ export class NeuralHttpBackend implements TtsBackend {
   // key -> object URL. Map preserves insertion order, so the first key is the
   // oldest entry when we need to evict.
   private readonly cache = new Map<string, string>();
-  // The single long-lived PRIMARY audio element, created lazily on first use.
+  // The single long-lived audio element, created lazily on first use.
   private audioEl: HTMLAudioElement | null = null;
   // The object URL actually assigned to audioEl.src right now. Tracked so cache
   // eviction never revokes a URL the element is still streaming. Survives
@@ -106,12 +92,6 @@ export class NeuralHttpBackend implements TtsBackend {
   // Monotonic token: cancel() bumps it, so an in-flight speak() whose token no
   // longer matches must not start playback or report an end.
   private session = 0;
-
-  // Double-buffer slot (#103): when prefetch() completes, the next chunk's
-  // audio is loaded into a second element here. speak() checks this slot first;
-  // on a key match it swaps the slot in as the primary element and plays
-  // immediately with no async round-trip, eliminating the inter-chunk gap.
-  private preloadSlot: PreloadSlot | null = null;
 
   constructor(baseUrl: string, opts: NeuralHttpBackendOptions = {}) {
     this.baseUrl = baseUrl.replace(/\/+$/, "");
@@ -161,28 +141,48 @@ export class NeuralHttpBackend implements TtsBackend {
     opts: { rate: number; voiceURI: string | null },
     onEnd: () => void,
   ): void {
-    // Capture the preloaded slot BEFORE cancel() clears it.
-    const pendingSlot = this.preloadSlot;
     this.cancel();
     const session = this.session;
+    // Empty voice -> the proxy applies its server-side default.
     const voice = opts.voiceURI ?? "";
-    const key = `${voice}|${opts.rate}|${hashText(text)}`;
 
-    // --- Double-buffer fast path (#103) -----------------------------------
-    // If prefetch() has fully loaded this chunk into the slot element, swap it
-    // in as the primary and play() immediately — no async wait at all.
-    if (pendingSlot && pendingSlot.key === key) {
-      // Slot was already cleared by cancel(); nothing more to clean up.
-      this.playFromElement(pendingSlot.element, pendingSlot.url, session, onEnd);
-      return;
-    }
-    // Stale slot (different key — user skipped): already cleared by cancel().
-
-    // --- Async fallback: fetch (or cache hit) then play -------------------
     void this.getAudioUrl(text, voice, opts.rate)
       .then((url) => {
         if (session !== this.session) return; // superseded while fetching
-        this.playFromElement(this.getOrCreateElement(), url, session, onEnd);
+        const audio = this.getOrCreateElement();
+        // Detach any handlers from a previous chunk before reassigning.
+        audio.onended = null;
+        audio.onerror = null;
+        const previousSrc = this.elementSrc;
+        // Swap the SAME element's source to this chunk. elementSrc records the
+        // URL the element is now streaming so eviction never revokes it.
+        this.elementSrc = url;
+        this.hasCurrentTrack = true;
+        audio.src = url;
+        // The element has moved on from previousSrc. If that URL was evicted
+        // from the cache while it was the live src (its revocation deferred),
+        // revoke it now — nothing references it anymore, so it would otherwise
+        // leak. Done AFTER reassigning src so we never revoke the live source.
+        if (previousSrc && previousSrc !== url && !this.cacheHasUrl(previousSrc)) {
+          URL.revokeObjectURL(previousSrc);
+        }
+        const finish = (): void => {
+          if (session !== this.session) return;
+          this.hasCurrentTrack = false;
+          onEnd();
+        };
+        audio.onended = finish;
+        audio.onerror = finish;
+        const p = audio.play();
+        // play() returns a promise in browsers; a rejection (autoplay policy,
+        // decode failure) must advance the queue, not wedge it.
+        if (p && typeof p.catch === "function") {
+          p.catch(() => {
+            if (session !== this.session) return;
+            this.hasCurrentTrack = false;
+            onEnd();
+          });
+        }
       })
       .catch(() => {
         // Synthesis failed (network/server). Report the end so the player
@@ -207,10 +207,6 @@ export class NeuralHttpBackend implements TtsBackend {
 
   cancel(): void {
     this.session += 1;
-    // Discard any preloaded slot — it was for the chunk sequence that is now
-    // being cancelled (skip / stop). The slot element holds an object URL
-    // that remains in the cache, so it is safe to just drop the reference.
-    this.preloadSlot = null;
     const audio = this.audioEl;
     // Stop reporting progress/seek for this track, but keep the element alive
     // for reuse and keep elementSrc set — the src stays loaded until the next
@@ -256,26 +252,14 @@ export class NeuralHttpBackend implements TtsBackend {
   }
 
   /**
-   * Warm the cache for `text` AND preload the object URL into a second
-   * HTMLAudioElement (the double-buffer slot).  When speak() is called with
-   * the same text next, it finds the slot ready and plays with no async wait.
+   * Warm the cache for `text` without playing it. Call this while the current
+   * chunk is playing so the next chunk is ready when its turn arrives.
    * All failures are swallowed — a cache miss is the only side-effect.
    */
   prefetch(text: string, opts: { rate: number; voiceURI: string | null }): Promise<void> {
     const voice = opts.voiceURI ?? "";
-    const key = `${voice}|${opts.rate}|${hashText(text)}`;
-
     return this.getAudioUrl(text, voice, opts.rate).then(
-      (url) => {
-        // Build the slot element and assign .src so the browser can buffer it
-        // while the current chunk is still playing. We do NOT call play() here
-        // so that no audio output occurs and so we don't need to be inside a
-        // user gesture (the primary element's unlock() already covered that).
-        const element = this.audioFactory();
-        element.src = url;
-        // Overwrite any previous slot (only one next-chunk is relevant).
-        this.preloadSlot = { key, url, element };
-      },
+      () => { /* cached; no playback */ },
       () => { /* silently ignore fetch errors */ },
     );
   }
@@ -294,70 +278,7 @@ export class NeuralHttpBackend implements TtsBackend {
 
   // --- internals ------------------------------------------------------------
 
-  /**
-   * Wire up `element` as the live playing element, swap it in as the primary
-   * (if it differs), set handlers, and start playback.
-   * This is the single place speak() and the double-buffer fast path converge.
-   */
-  private playFromElement(
-    element: HTMLAudioElement,
-    url: string,
-    session: number,
-    onEnd: () => void,
-  ): void {
-    // If the incoming element is different from the current primary (double-
-    // buffer fast path), tear down the old primary and swap.
-    if (element !== this.audioEl) {
-      const oldEl = this.audioEl;
-      if (oldEl) {
-        oldEl.onended = null;
-        oldEl.onerror = null;
-        try { oldEl.pause(); } catch { /* ignore */ }
-      }
-      this.audioEl = element;
-    }
-
-    const audio = this.audioEl!;
-    // Detach any handlers from a previous chunk before reassigning.
-    audio.onended = null;
-    audio.onerror = null;
-    const previousSrc = this.elementSrc;
-    // Record the URL the element is now streaming so eviction never revokes it.
-    this.elementSrc = url;
-    this.hasCurrentTrack = true;
-    // Only reassign .src if it has changed — in the double-buffer path the
-    // slot element's .src is already set, so we skip the assignment to avoid
-    // resetting the browser's buffer position.
-    if (audio.src !== url) {
-      audio.src = url;
-    }
-    // The element has moved on from previousSrc. If that URL was evicted
-    // from the cache while it was the live src (its revocation deferred),
-    // revoke it now — nothing references it anymore, so it would otherwise
-    // leak. Done AFTER reassigning src so we never revoke the live source.
-    if (previousSrc && previousSrc !== url && !this.cacheHasUrl(previousSrc)) {
-      URL.revokeObjectURL(previousSrc);
-    }
-    const finish = (): void => {
-      if (session !== this.session) return;
-      this.hasCurrentTrack = false;
-      onEnd();
-    };
-    audio.onended = finish;
-    audio.onerror = finish;
-    const p = audio.play();
-    // play() returns a promise in browsers; a rejection (autoplay policy,
-    // decode failure) must advance the queue, not wedge it.
-    if (p && typeof p.catch === "function") {
-      p.catch(() => {
-        if (session !== this.session) return;
-        this.hasCurrentTrack = false;
-        onEnd();
-      });
-    }
-  }
-
-  /** Lazily create and return the single reused primary audio element. */
+  /** Lazily create and return the single reused audio element. */
   private getOrCreateElement(): HTMLAudioElement {
     if (!this.audioEl) {
       this.audioEl = this.audioFactory();

--- a/web/tests/unit/tts-neural.test.ts
+++ b/web/tests/unit/tts-neural.test.ts
@@ -60,25 +60,20 @@ function makeFetch(opts: { failSpeech?: boolean; failVoices?: boolean } = {}) {
 }
 
 /**
- * Build a backend with an injectable audioFactory.
- *
- * `audioRef.ref` always points to the FIRST element created (the primary
- * playing element).  With the double-buffer fix, prefetch() creates additional
- * elements; those are tracked in `audioRef.all` but do NOT overwrite `.ref`.
- * Tests that don't call prefetch() continue to work unchanged.
+ * Build a backend with an injectable audioFactory that returns a single
+ * FakeAudio.  The factory is called at most once (lazy element creation);
+ * subsequent speaks just reassign .src on the same element.
  */
 function makeBackend(
   fetchImpl: typeof fetch,
-  audioRef: { ref: FakeAudio | null; all?: FakeAudio[] },
+  singleAudio: { ref: FakeAudio | null },
   cacheCap?: number,
 ): NeuralHttpBackend {
   return new NeuralHttpBackend("http://tts.local:8880", {
     fetchImpl,
     audioFactory: () => {
       const a = new FakeAudio();
-      // Only the first element becomes the canonical ref (primary element).
-      if (!audioRef.ref) audioRef.ref = a;
-      (audioRef.all ??= []).push(a);
+      singleAudio.ref = a;
       return a as unknown as HTMLAudioElement;
     },
     maxCacheEntries: cacheCap,
@@ -765,125 +760,36 @@ describe("NeuralHttpBackend.prefetch", () => {
     audioRef.ref!.onended?.();
     expect(ended).toBe(1);
   });
-});
 
-// --- double-buffer gapless playback (Fix #103) ----------------------------------------
-
-describe("NeuralHttpBackend double-buffer (gapless)", () => {
-  it("after prefetch(next), speak(next) plays without a new fetch", async () => {
-    const { fetchImpl, calls } = makeFetch();
-    const audioRef: { ref: FakeAudio | null; all: FakeAudio[] } = { ref: null, all: [] };
-    const backend = makeBackend(fetchImpl, audioRef);
-
-    // Prefetch the next chunk — this creates a slot element (all[0])
-    await backend.prefetch("Next chunk text.", { rate: 1.2, voiceURI: null });
-
-    const speechCallsAfterPrefetch = calls.filter((c) =>
-      c.url.endsWith("/v1/audio/speech"),
-    ).length;
-    expect(speechCallsAfterPrefetch).toBe(1); // prefetch did one fetch
-
-    // Now speak the same text — must use the preloaded slot, no new fetch
-    backend.speak("Next chunk text.", { rate: 1.2, voiceURI: null }, () => {});
-    // speak() uses the slot synchronously, so no flush() needed — but flush anyway
-    // to ensure any async fallback path would have also completed
-    await flush();
-
-    const speechCallsAfterSpeak = calls.filter((c) =>
-      c.url.endsWith("/v1/audio/speech"),
-    ).length;
-    // No new fetch — the double-buffer slot was consumed
-    expect(speechCallsAfterSpeak).toBe(1);
-    // The slot element (all[0]) was swapped in as primary — it was played
-    const slotEl = audioRef.all[0];
-    expect(slotEl).not.toBeNull();
-    expect(slotEl.playCalls).toBeGreaterThanOrEqual(1);
-  });
-
-  it("onended on current chunk plays next chunk with no awaited fetch round-trip", async () => {
-    const { fetchImpl, calls } = makeFetch();
-    const audioRef: { ref: FakeAudio | null; all: FakeAudio[] } = { ref: null, all: [] };
-    const backend = makeBackend(fetchImpl, audioRef);
-
-    // Simulate TtsPlayer: speak chunk 1 (creates primary = all[0] = ref),
-    // prefetch chunk 2 (creates slot = all[1]), then on chunk 1 end speak chunk 2
-    const ends: string[] = [];
-    backend.speak("Chunk one.", { rate: 1, voiceURI: null }, () => {
-      ends.push("one");
+  // Regression guard for #103: the double-buffer rewrite preloaded each next
+  // chunk into a FRESH HTMLAudioElement and played on it. Browser autoplay
+  // policy binds permission per-element to the one unlocked inside the user
+  // gesture (see unlock()), so playing on a fresh element is blocked and
+  // playback dies after the first chunk. Every chunk MUST play on the single
+  // unlocked element. Do not "optimize" this back into per-chunk elements.
+  it("regression #103: plays every chunk on ONE unlocked element (no per-chunk element)", async () => {
+    const { fetchImpl } = makeFetch();
+    let factoryCalls = 0;
+    const elements: FakeAudio[] = [];
+    const backend = new NeuralHttpBackend("http://tts.local:8880", {
+      fetchImpl,
+      audioFactory: () => {
+        factoryCalls += 1;
+        const a = new FakeAudio();
+        elements.push(a);
+        return a as unknown as HTMLAudioElement;
+      },
     });
+    backend.unlock(); // primes the single element inside the user gesture
+    backend.speak("First chunk.", { rate: 1, voiceURI: null }, () => {});
     await flush();
-    // all[0] is primary element
-    const primaryEl = audioRef.ref!;
-    expect(primaryEl).not.toBeNull();
-
-    // Prefetch chunk 2 while chunk 1 plays (as TtsPlayer does) — creates slot = all[1]
-    await backend.prefetch("Chunk two.", { rate: 1, voiceURI: null });
-
-    const callsBeforeEnd = calls.filter((c) => c.url.endsWith("/v1/audio/speech")).length;
-    // 2 calls so far: chunk 1 + chunk 2 prefetch
-    expect(callsBeforeEnd).toBe(2);
-
-    // Simulate chunk 1 ending: fire onended on the primary, then TtsPlayer calls speak(chunk 2)
-    primaryEl.onended?.();
-    backend.speak("Chunk two.", { rate: 1, voiceURI: null }, () => {
-      ends.push("two");
-    });
-    // The slot is ready synchronously — no additional fetch needed
+    await backend.prefetch("Second chunk.", { rate: 1, voiceURI: null });
     await flush();
-
-    const callsAfterEnd = calls.filter((c) => c.url.endsWith("/v1/audio/speech")).length;
-    // Still 2 — chunk 2 speak consumed the slot, no new fetch
-    expect(callsAfterEnd).toBe(callsBeforeEnd);
-    expect(ends[0]).toBe("one");
-    // The slot element (all[1]) is now active and was played
-    const slotEl = audioRef.all[1];
-    expect(slotEl.playCalls).toBeGreaterThanOrEqual(1);
-  });
-
-  it("cancel() then speak() still works correctly (no stale slot)", async () => {
-    const { fetchImpl, calls } = makeFetch();
-    const audioRef: { ref: FakeAudio | null; all: FakeAudio[] } = { ref: null, all: [] };
-    const backend = makeBackend(fetchImpl, audioRef);
-
-    // Prefetch something, then cancel (skip) before it's consumed
-    await backend.prefetch("Abandoned chunk.", { rate: 1, voiceURI: null });
-    backend.cancel();
-
-    // speak an entirely different chunk — must fetch fresh (slot was cleared)
-    backend.speak("Fresh chunk.", { rate: 1, voiceURI: null }, () => {});
+    backend.speak("Second chunk.", { rate: 1, voiceURI: null }, () => {});
     await flush();
-
-    // Fresh chunk needed a new fetch (not the abandoned preload)
-    const speechCalls = calls.filter((c) => c.url.endsWith("/v1/audio/speech"));
-    const freshFetch = speechCalls.find((c) => {
-      const body = JSON.parse(String(c.init?.body));
-      return body.input === "Fresh chunk.";
-    });
-    expect(freshFetch).toBeTruthy();
-    // play() was called for fresh chunk — on whichever element is current primary
-    const totalPlays = audioRef.all.reduce((sum, el) => sum + el.playCalls, 0);
-    expect(totalPlays).toBeGreaterThanOrEqual(1);
-  });
-
-  it("speak() with a mismatched text (skip case) falls back to fetch-then-play", async () => {
-    const { fetchImpl, calls } = makeFetch();
-    const audioRef: { ref: FakeAudio | null; all: FakeAudio[] } = { ref: null, all: [] };
-    const backend = makeBackend(fetchImpl, audioRef);
-
-    // Prefetch chunk A
-    await backend.prefetch("Prefetched chunk A.", { rate: 1, voiceURI: null });
-    const callsAfterPrefetch = calls.filter((c) => c.url.endsWith("/v1/audio/speech")).length;
-
-    // But then we speak chunk B (user skipped) — not in slot, must fetch
-    backend.speak("Completely different chunk B.", { rate: 1, voiceURI: null }, () => {});
-    await flush();
-
-    // B was not prefetched — it required a fetch
-    const callsAfterB = calls.filter((c) => c.url.endsWith("/v1/audio/speech")).length;
-    expect(callsAfterB).toBeGreaterThan(callsAfterPrefetch);
-    // play() was called on some element
-    const totalPlays = audioRef.all.reduce((sum, el) => sum + el.playCalls, 0);
-    expect(totalPlays).toBeGreaterThanOrEqual(1);
+    expect(factoryCalls).toBe(1);
+    expect(elements).toHaveLength(1);
+    expect(elements[0].playCalls).toBeGreaterThanOrEqual(2);
   });
 });
 


### PR DESCRIPTION
## Bug
Pressing play on production (neural TTS active) plays at most the first chunk, then silence; a second press can produce no audio at all.

## Root cause
#103's gapless double-buffering preloaded each next chunk into a **fresh `HTMLAudioElement`** and played on it. Browser autoplay policy binds permission **per-element** to the one element `unlock()` primes inside the user gesture (the code comment documents exactly this). The never-unlocked slot elements are blocked by the browser → `play()` rejects → the player skips to the end. The blocked element also becomes the persistent `audioEl`, so the next press has no unlocked element → total silence.

Confirmed: prod bakes in `VITE_TTS_NEURAL_URL` and the `tts` edge function is up (HTTP 401, JWT-gated), so neural is active and the bug bites. (If the function were down, Web Speech fallback would still play.)

## Fix
- Revert `tts-neural.ts` to the proven **single-element** design (one long-lived unlocked element; `prefetch()` warms the URL cache only).
- **Keep** #103's abbreviation-aware `chunkText` (that part is fine and unrelated to the break).
- Add a regression test asserting every chunk plays on one unlocked element (verified: it fails on the #103 code, passes on this fix).

## Test Evidence
- lint: PASS · build: PASS
- unit: **416 passed** (tts-neural: 46, incl. the new regression guard)
- Regression test confirmed failing on buggy code (`expected 2 to be 1`), passing on the fix.

## Tradeoff / follow-up
This restores working audio but brings back the original inter-chunk gap (#103's target). Gapless can be re-done correctly with a fixed pool of **pre-unlocked** elements (unlock both inside the gesture, ping-pong). Tracking that as follow-up.