### PR TITLE
docs: Perplexity usage/cost and the heavy/light local-LLM split

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -58,8 +58,8 @@ work:
 - 🧠 **GAIA** — *the agent framework.* A GAIA `Agent` reasons over a topic, calls
   `@tool` scrapers, reads what comes back, and decides when the digest is done.
 - ⚡ **Lemonade** — *the inference runtime.* GAIA talks to Lemonade Server over a
-  standard OpenAI-compatible API on `localhost`; it serves the model that writes
-  every summary.
+  standard OpenAI-compatible API on `localhost`; it serves the models that write
+  every digest and power source curation.
 - 🔴 **Strix Halo** — *the silicon.* 128 GB unified memory lets a heavy model stay
   resident across runs — no reload, no cloud.
 
@@ -90,6 +90,23 @@ the result from your phone.
 > host — belongs here once captured from a real run.
 > *(placeholder: run `python -m news_digest "…"` and record the actual numbers
 > rather than estimating.)*
+
+### Two model tiers, three jobs
+
+Lemonade serves two locally-resident model tiers, picked per task. Everything
+below runs on the Strix Halo GPU — no LLM call leaves the box.
+
+| Activity | Model tier | Config key | Where |
+|---|---|---|---|
+| **Generate the digest** — the reasoning loop *is* the summarizer (invariant #1) | heavy | `lemonade_heavy_model` | [agent.py](../src/news_digest/agent.py) |
+| **Curator: craft the web-search query** — turns a failing source + topic into a Perplexity query | light | `lemonade_light_model` | [`craft_query`](../src/news_digest/curator.py) |
+| **Curator: judge candidate relevance** — scores a discovered source against the topic (drives auto-adopt / queue / reject) | light | `lemonade_light_model` | [`judge_relevance`](../src/news_digest/curator.py) |
+
+The **heavy** model does the daily work — generating digests. The two **light**
+model calls fire only when the source curator is repairing a persistently-failing
+source, and fall back to the heavy model if no light model is configured
+([curator.py](../src/news_digest/curator.py)). Article deduplication
+(`deduplicate_articles`) is a pure function — **no model involved**.
 
 ---
 
@@ -324,7 +341,7 @@ maintenance jobs at configurable UTC hours (`config.py` defaults shown):
 | Job | When (UTC) | What it does |
 |---|---|---|
 | 🔁 **Digest cycle** | every 15 min, 24/7 | tick → due-check → run each due topic |
-| 🔎 **Source curator** | `04:00` daily *(default)* | discovers new sources (optional, Perplexity) |
+| 🔎 **Source curator** | `04:00` daily *(default)* | repairs failing sources: light-model query craft + relevance judging, plus optional Perplexity web search |
 | 🧹 **Retention purge** | `05:00` daily *(default)* | drops digests older than the retention window |
 
 Timing facts worth showing, all from [scheduler.py](../src/news_digest/scheduler.py):
@@ -377,8 +394,10 @@ The boundary is the whole point: **inference and source text never leave the
 host.** Two systemd units share the box — the agent and an always-on Lemonade
 with the heavy model resident, talking over `localhost`. Only finished digests
 and logs cross to Supabase; the phone reads those through an anon key under RLS.
-(The one external API call beyond storage is the optional Perplexity
-source-curator — discovery, not inference.)
+(The only external call beyond storage is the source-curator's optional
+Perplexity web search — that's *external discovery*. The curator's own
+reasoning — crafting the query and judging relevance — is local inference on
+the light model, same box as the digest.)
 
 ---
 

--- a/docs/perplexity-cost.md
+++ b/docs/perplexity-cost.md
@@ -1,0 +1,93 @@
+# Perplexity API — Usage & Cost
+
+Perplexity is **not** part of the digest pipeline. It is only called by the
+**source curator** ([`src/news_digest/curator.py`](../src/news_digest/curator.py))
+to discover replacement feeds when a configured source has been persistently
+failing. See [architecture.md](architecture.md) for where it sits.
+
+## Bottom line
+
+- **Total spend to date: ~$0.01 (about one cent).** Two API calls, both on a
+  single dev/test run on 2026-06-12.
+- **Recurring production cost today: $0/month.** The scheduled 04:00 curator job
+  runs daily but skips Perplexity entirely because `PERPLEXITY_API_KEY` is not
+  set in production — every run logs `PERPLEXITY_API_KEY not set — source
+  curation skipped`.
+- **If enabled, worst-case is ~$1.65/month**, and realistically near-zero most
+  days (see [Projection](#projection-if-enabled)).
+
+## Measured usage
+
+Each Perplexity call is preceded by a `system_logs` row with
+`metadata->>'action' = 'search'`, so call count is directly auditable.
+
+| Metric | Value | Source |
+|---|---|---|
+| Real API calls, all-time | **2** | `system_logs`, measured |
+| Dates with calls | 2026-06-12 only | measured |
+| Model used | `sonar` | config default ([config.py](../src/news_digest/config.py)) |
+| Search context size | `low` | hardcoded ([search.py](../src/news_digest/search.py), `web_search_options`) |
+| Output token cap | 512 | hardcoded (`max_tokens`, [search.py](../src/news_digest/search.py)) |
+| Scheduled prod runs since | skipped (key unset) | measured (`no_op` logs) |
+
+Both calls were for topic `ai_updates`, searching for alternates to
+`https://www.amd.com/en/blogs.html`.
+
+## Pricing reference
+
+From the official Perplexity pricing docs (<https://docs.perplexity.ai/guides/pricing>),
+**as of 2026-06-19**. Re-verify before relying on these — Perplexity changes pricing.
+
+> Total cost per query = token costs + a per-request fee that varies by
+> `search_context_size`.
+
+| Model | Input ($/1M tok) | Output ($/1M tok) | Request fee — low / med / high (per 1k req) |
+|---|---|---|---|
+| `sonar` (what we use) | $1 | $1 | $5 / $8 / $12 |
+| `sonar-pro` | $3 | $15 | $6 / $10 / $14 |
+
+## Cost model for one curator search
+
+With our config (`sonar`, `search_context_size: low`, `max_tokens: 512`):
+
+| Component | Amount | Cost |
+|---|---|---|
+| Request fee (low context) | 1 request | **$0.0050** (exact — fee is fixed per request) |
+| Input tokens | ~25 tok (short system + query prompt) | ~$0.00003 (estimated) |
+| Output tokens | ≤512 tok cap | ≤$0.00051 (estimated) |
+| **Per call** | | **≈ $0.0055** |
+
+The request fee dominates; token cost is rounding error at $1/1M. Two calls ≈
+**$0.011**.
+
+> Classification: call count is *measured* (from logs); the request fee is
+> *deterministic* (fixed per request at our context size); token costs are
+> *estimated* — token counts are not currently logged.
+
+## Projection if enabled
+
+Per daily curator run, searches are bounded by the churn caps in
+[`curator.py`](../src/news_digest/curator.py):
+
+- `MAX_SOURCES_PER_RUN = 10` → at most ~10 searches/day → **~$0.055/day ≈
+  $1.65/month** absolute worst case (every cap maxed, every day).
+- Realistic cost is far lower: a search only fires for a *persistently* failing
+  source (≥3 attempts in 7d AND <50% success or no success in 72h), there is a
+  7-day per-URL cooldown, and `MAX_AUTO_ADDS_PER_RUN = 3`. On a healthy source
+  list most runs make **zero** calls.
+
+## How to re-measure
+
+```sql
+-- Real Perplexity calls (each 'search' action == one API call)
+SELECT count(*)            AS calls,
+       min(timestamp)      AS first_call,
+       max(timestamp)      AS last_call,
+       count(DISTINCT date_trunc('day', timestamp)) AS days_with_calls
+FROM system_logs
+WHERE category = 'curator'
+  AND metadata->>'action' = 'search';
+```
+
+For authoritative billed spend (including exact token counts, which we do not
+log), check the Perplexity account dashboard at <https://www.perplexity.ai/settings/api>.


### PR DESCRIPTION
Documents how Perplexity and the local LLMs are actually used, so the cost and the model split are clear and re-verifiable.

## What changed
- **New `docs/perplexity-cost.md`** — measured curator usage (2 API calls ever, both on a 2026-06-12 dev run; production makes zero because `PERPLEXITY_API_KEY` is unset) vs. current published Sonar pricing, with a per-call cost model and a re-measure SQL query.
- **`docs/architecture.md`** — adds a "Two model tiers, three jobs" subsection (heavy = digest generation; light = curator query-craft + relevance-judging), updates the §1.5 stack bullet and the scheduler table, and fixes the misleading "discovery, not inference" note (the curator *does* run local inference).

## Proof
Docs-only change. Claims were verified against source and live data:

<details>
<summary>Evidence</summary>

- Local-LLM roles traced to code: digest → heavy model (`agent.py`), curator `craft_query` + `judge_relevance` → light model (`curator.py`); dedup is a pure function (no model).
- Usage measured from Supabase `system_logs`: 2 rows with `metadata->>'action' = 'search'` (2026-06-12); scheduled runs since log `PERPLEXITY_API_KEY not set — source curation skipped`.
- Pricing taken from https://docs.perplexity.ai/guides/pricing (as-of date recorded in the doc).
</details>
