### PR TITLE
feat(topics): add Formula 1 digest topic with Haas + Cadillac focus

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -189,6 +189,7 @@ ruff format src tests
 | 3 | AI company/product updates         | 24h     | `ai_updates`      |
 | 4 | Pittsburgh Penguins (non-scores)   | 7-day   | `penguins`        |
 | 5 | US/Poland world news + sentiment   | TBD     | `world_news`      |
+| 6 | Formula 1 (general + Haas/Cadillac) | 24h     | `f1`              |
 
 **Build order:** Topic 1 first (end-to-end validation), then replicate to others.
 

--- a/supabase/migrations/0017_seed_f1_topic.sql
+++ b/supabase/migrations/0017_seed_f1_topic.sql
@@ -1,0 +1,45 @@
+-- 0017_seed_f1_topic.sql — Formula 1 digest topic (general F1 with mandatory
+-- Haas + Cadillac team focus).
+--
+-- Sources chosen (all RSS, HTTP 200 verified 2026-06-27):
+--   BBC Sport F1        — https://feeds.bbci.co.uk/sport/formula1/rss.xml
+--   Motorsport.com F1   — https://www.motorsport.com/rss/f1/news/
+--   The Race            — https://www.the-race.com/feed/
+--   RaceFans            — https://www.racefans.net/feed/
+--   Autosport F1        — https://www.autosport.com/rss/f1/news/
+--
+-- PlanetF1 (https://www.planetf1.com/feed) returned 404 during verification and
+-- was omitted; the five feeds above cover both general F1 and team-specific news.
+--
+-- Single topic by design (not three): general Formula 1 coverage, with the
+-- prompt_hint steering mandatory explicit attention to two teams — Haas and the
+-- new GM/Cadillac entry — woven into the one digest. Team items are flagged via
+-- the generic items[].tags array ("haas" / "cadillac"); no new schema or web
+-- renderer change is required.
+--
+-- Idempotent: on conflict (slug) do nothing, matching the other seed migrations.
+
+insert into digest_topics (name, slug, cadence, sources, prompt_hint, enabled)
+values (
+  'Formula 1',
+  'f1',
+  '24h',
+  '[
+    {"type": "rss", "url": "https://feeds.bbci.co.uk/sport/formula1/rss.xml"},
+    {"type": "rss", "url": "https://www.motorsport.com/rss/f1/news/"},
+    {"type": "rss", "url": "https://www.the-race.com/feed/"},
+    {"type": "rss", "url": "https://www.racefans.net/feed/"},
+    {"type": "rss", "url": "https://www.autosport.com/rss/f1/news/"}
+  ]'::jsonb,
+  'Summarise the most significant Formula 1 stories from the last 24 hours: race weekends and results with their championship implications, driver and team line-up moves, car and technical-regulation developments, and major business or political developments in the sport.
+
+Source window: when calling fetch_rss, pass since_hours=24 for each source to collect the last day''s article pool.
+
+Deduplication: before composing the digest, call get_recent_digests with slug "f1" and limit=2 to retrieve the two most recent f1 digests. Do not repeat stories already covered there.
+
+Mandatory team focus — Haas and Cadillac: in addition to general F1 coverage, always give explicit attention to two teams — the Haas F1 Team (MoneyGram Haas) and the Cadillac F1 Team (the new General Motors / Cadillac entry joining the grid). Whenever the gathered sources contain any news touching either team — results, driver line-up, sponsorship, leadership, car or power-unit development, or regulatory and entry news — surface it as its own ranked item and add the tag "haas" or "cadillac" (lowercase) to that item''s tags array. If the window contains no material news for a team, do not invent any and do not pad with generic background; simply omit it.
+
+Editorial focus: prioritise concrete developments over speculation and rumour. Live lap-by-lap timing minutiae are not needed — focus on outcomes and why they matter.',
+  true
+)
+on conflict (slug) do nothing;

--- a/web/src/pages/logs.ts
+++ b/web/src/pages/logs.ts
@@ -40,6 +40,7 @@ export const LOG_CATEGORIES = [
 export const FALLBACK_TOPIC_SLUGS = [
   "ai_models",
   "ai_updates",
+  "f1",
   "local_news",
   "penguins",
   "world_news",

--- a/web/tests/unit/logs.test.ts
+++ b/web/tests/unit/logs.test.ts
@@ -314,10 +314,11 @@ describe("LOG_CATEGORIES", () => {
 });
 
 describe("FALLBACK_TOPIC_SLUGS", () => {
-  it("covers the five known digest topics", () => {
+  it("covers the six known digest topics", () => {
     expect([...FALLBACK_TOPIC_SLUGS].sort()).toEqual([
       "ai_models",
       "ai_updates",
+      "f1",
       "local_news",
       "penguins",
       "world_news",


### PR DESCRIPTION
Adds a single **Formula 1** digest topic (`f1`, 24h cadence) covering general F1 news, with the prompt steering mandatory explicit attention to the **Haas** and **Cadillac** teams (their items are tagged `haas` / `cadillac`). Rides the existing topic machinery — no new code paths; the scheduler picks it up by cadence and the web app reads it live via `fetchTopics`.

### Changes
- `supabase/migrations/0017_seed_f1_topic.sql` — seeds the `f1` topic. Sources (all HTTP 200 verified 2026-06-27): BBC Sport F1, Motorsport.com, The Race, RaceFans, Autosport. PlanetF1 dropped (404).
- `web/src/pages/logs.ts` + test — add `f1` to `FALLBACK_TOPIC_SLUGS` (network-failure fallback for the logs filter).
- `CLAUDE.md` — F1 added to the Digest Topics table.

### Proof it works
**Migration applied to prod** (`apply_migration`) and verified:
```
id=7  name=Formula 1  slug=f1  cadence=24h  enabled=true  n_sources=5
```

**Real run on the host (Strix Halo, Qwen3.5-35B heavy model)** — the F1 pipeline runs end-to-end: loads the `f1` config, scrapes all feeds, dedups, reaches LLM completion. From `system_logs`:
```
list_topics: 6 enabled topics
fetch_topic_config: loaded 'f1'
get_recent_digests: 'f1' -> 0 digest(s)
fetch_rss: returned 27 entries from https://www.motorsport.com/rss/f1/news/
fetch_rss: returned 11 entries from https://www.autosport.com/rss/f1/news/
generate_and_publish: LLM run complete
```

**Web unit tests:** `tests/unit/logs.test.ts` — 51 passed.

> [!WARNING]
> **Pre-existing, unrelated blocker (not introduced here):** the heavy model is currently emitting unparseable final-answer JSON for **every** topic right now — `ai_models` failed with the identical `JSONDecodeError` three times (the scheduler's own retry loop) at 15:42–15:43, minutes *before* the F1 run. Earlier topics published fine overnight (~04:00), so this is a model-output regression that surfaced later in the day, not an F1 config issue. The F1 digest will publish on schedule once that clears. Flagging separately — out of scope for this PR.
