### PR TITLE
Harden digest parsing against the heavy model's malformed JSON

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,6 +27,10 @@ dependencies = [
     "supabase>=2.0,<3.0",
     "tenacity>=8.2.3",
     "praw>=7.7,<8.0",
+    # Repairs malformed JSON the heavy local model intermittently emits
+    # (unquoted keys/values) in GAIA's tool-call / final-answer protocol;
+    # see agent._repair_json_text and NewsDigestAgent._parse_llm_response.
+    "json-repair>=0.61,<1.0",
 ]
 
 [project.optional-dependencies]

--- a/src/news_digest/agent.py
+++ b/src/news_digest/agent.py
@@ -12,13 +12,14 @@ local SQLite state (run log / article cache); Supabase remains the primary store
 import json
 from typing import Any
 
+import json_repair
 from gaia.agents.base.agent import Agent
 from gaia.database import DatabaseMixin
 from gaia.llm.lemonade_client import LemonadeClient
 
 from news_digest.config import get_settings
 from news_digest.logging import drain_fallback, log
-from news_digest.prompts import SYSTEM_PROMPT
+from news_digest.prompts import COMPOSE_SYSTEM_PROMPT, SYSTEM_PROMPT
 
 # Importing the tool modules registers their @tool functions into GAIA's global
 # tool registry at import time; the agent then advertises them to the model.
@@ -110,6 +111,47 @@ def _is_llm_error_response(text: str) -> bool:
     )
 
 
+def _repair_json_text(text: str) -> dict[str, Any] | None:
+    """Best-effort recovery of a JSON object from malformed model output.
+
+    The heavy local model (Qwen3.5-35B) intermittently emits JSON with unquoted
+    keys and/or unquoted string values — e.g. ``{"thought": I gathered ...,
+    goal: ..., tool: fetch_topic_config, tool_args: {slug: f1}}``. This is a
+    non-deterministic sampling artifact (it varies run-to-run even at
+    temperature 0, from llama-server batching numerics), so it cannot be steered
+    away with the prompt alone. ``json.loads`` rejects it; ``json_repair`` quotes
+    the dangling keys/values and parses it.
+
+    Returns the repaired dict, or ``None`` when repair yields anything other than
+    a JSON object (so callers can fall back to their existing handling).
+    """
+    try:
+        obj = json_repair.loads(text)
+    except Exception:  # noqa: BLE001 - repair must never raise into the caller
+        return None
+    return obj if isinstance(obj, dict) else None
+
+
+def _is_actionable_response(parsed: dict[str, Any]) -> bool:
+    """Whether a repaired response dict is worth substituting for the raw text.
+
+    A repaired dict is only substituted back into GAIA's loop when it carries a
+    real instruction: a (truthy) ``tool`` call, an ``answer``, a non-empty
+    ``plan``, or a bare digest (``summary`` + ``items``). A repaired
+    ``{"thought": ..., "tool": null}`` is deliberately NOT actionable — feeding
+    a null tool back to GAIA makes it append consecutive assistant turns and
+    loop until llama-server rejects the message list ("2+ assistant messages"),
+    which is worse than letting GAIA's own fallback finalize the turn.
+    """
+    if parsed.get("tool"):
+        return True
+    if parsed.get("answer"):
+        return True
+    if isinstance(parsed.get("plan"), list) and parsed["plan"]:
+        return True
+    return bool(parsed.get("summary") and parsed.get("items"))
+
+
 def _strip_code_fences(text: str) -> str:
     """Strip leading/trailing markdown code fences from a model answer.
 
@@ -144,6 +186,56 @@ def _topic_slug_from_conversation(conversation: list[dict] | None) -> str | None
             if slug:
                 return slug
     return None
+
+
+# Caps for the corrective compose pass (_compose_and_publish). Sized for the
+# 32K-token context: ~24K chars of gathered material plus the prompt still
+# leaves ample room for the heavy model to emit a multi-item digest.
+_COMPOSE_MAX_PER_TOOL = 6000
+_COMPOSE_MAX_TOTAL = 24000
+
+
+def _extract_gathered_materials(conversation: list[dict] | None) -> str:
+    """Concatenate the tool results (scraped feeds/articles) from a run.
+
+    The corrective compose pass re-summarizes from what the agent already
+    fetched, so this pulls every ``role="tool"`` entry's content out of the
+    process_query conversation, capped per-tool and overall to stay within the
+    model's context window. Returns an empty string when nothing was gathered
+    (e.g. the run failed before any source was fetched).
+    """
+    chunks: list[str] = []
+    total = 0
+    for msg in conversation or []:
+        if msg.get("role") != "tool":
+            continue
+        text = json.dumps(msg.get("content"), default=str)[:_COMPOSE_MAX_PER_TOOL]
+        piece = f"### {msg.get('name')}\n{text}"
+        if total + len(piece) > _COMPOSE_MAX_TOTAL:
+            break
+        chunks.append(piece)
+        total += len(piece)
+    return "\n\n".join(chunks)
+
+
+def _parse_digest_text(text: str) -> dict[str, Any] | None:
+    """Parse a compose-pass response into a digest dict, repairing if needed.
+
+    Strips any fences, tries strict JSON, then ``_repair_json_text``, and
+    unwraps a nested ``answer`` object. Returns ``None`` when no JSON object can
+    be recovered.
+    """
+    if not isinstance(text, str):
+        return None
+    stripped = _strip_code_fences(text)
+    try:
+        parsed = json.loads(stripped)
+    except (ValueError, TypeError):
+        parsed = _repair_json_text(stripped)
+    if not isinstance(parsed, dict):
+        return None
+    answer = parsed.get("answer")
+    return answer if isinstance(answer, dict) else parsed
 
 
 def _publish_from_result(result: dict[str, Any]) -> dict[str, Any]:
@@ -187,14 +279,18 @@ def _publish_from_result(result: dict[str, Any]) -> dict[str, Any]:
     try:
         parsed = json.loads(stripped)
     except (ValueError, TypeError) as exc:
-        log(
-            "error",
-            "publish",
-            f"generate_and_publish: could not parse final answer: "
-            f"{exc.__class__.__name__}",
-            metadata={"error": str(exc), "raw": raw[:500]},
-        )
-        return {"success": False, "error": "parse_error"}
+        # The heavy model often emits unquoted keys/values; recover before
+        # giving up (see _repair_json_text).
+        parsed = _repair_json_text(stripped)
+        if parsed is None:
+            log(
+                "error",
+                "publish",
+                f"generate_and_publish: could not parse final answer: "
+                f"{exc.__class__.__name__}",
+                metadata={"error": str(exc), "raw": raw[:500]},
+            )
+            return {"success": False, "error": "parse_error"}
 
     if not isinstance(parsed, dict):
         log(
@@ -212,10 +308,11 @@ def _publish_from_result(result: dict[str, Any]) -> dict[str, Any]:
     if isinstance(answer, dict):
         digest = answer
     elif isinstance(answer, str):
+        inner_text = _strip_code_fences(answer)
         try:
-            inner = json.loads(_strip_code_fences(answer))
+            inner = json.loads(inner_text)
         except (ValueError, TypeError):
-            inner = None
+            inner = _repair_json_text(inner_text)
         digest = inner if isinstance(inner, dict) else parsed
     else:
         digest = parsed
@@ -414,7 +511,126 @@ class NewsDigestAgent(Agent, DatabaseMixin):
             },
         )
 
-        return _publish_from_result(result)
+        publish_result = _publish_from_result(result)
+        if publish_result.get("success"):
+            return publish_result
+
+        # The agent loop ended without a usable digest — the heavy model emitted
+        # a planning thought or a degenerate/empty answer instead of composing
+        # (a non-deterministic failure, see _repair_json_text). Try one
+        # corrective compose pass from the material already gathered before
+        # giving up; on success it lands the row, otherwise the original failure
+        # stands.
+        fallback = self._compose_and_publish(query, result, topic_slug)
+        return fallback if fallback is not None else publish_result
+
+    def _compose_and_publish(
+        self, query: str, result: dict[str, Any], topic_slug: str | None
+    ) -> dict[str, Any] | None:
+        """Re-summarize the gathered material with one tightly scoped call.
+
+        The agent loop occasionally fails to compose a digest even though every
+        source was fetched successfully. Rather than lose the run, this re-asks
+        the model for just the digest — no tools, no agent protocol — over the
+        material it already gathered, which it produces far more reliably (see
+        COMPOSE_SYSTEM_PROMPT). Returns the push_to_supabase result on success,
+        or ``None`` when no digest could be recovered (caller then keeps the
+        original failure). Never raises.
+
+        Args:
+            query: The original natural-language request.
+            result: The process_query result (its conversation holds the
+                gathered tool outputs).
+            topic_slug: The slug resolved from the run, if any.
+
+        Returns:
+            The push_to_supabase result dict, or ``None``.
+        """
+        conversation = result.get("conversation")
+        slug = topic_slug or _topic_slug_from_conversation(conversation)
+        materials = _extract_gathered_materials(conversation)
+        if not slug or not materials:
+            return None
+
+        user_message = (
+            f"Topic slug: {slug}\nOriginal request: {query}\n\n"
+            f"Gathered material:\n{materials}\n\n"
+            "Now output ONLY the digest JSON object described in the system "
+            "prompt."
+        )
+        try:
+            response = self.chat.send_messages(
+                [{"role": "user", "content": user_message}],
+                system_prompt=COMPOSE_SYSTEM_PROMPT,
+            )
+        except Exception as exc:  # noqa: BLE001 - fallback must never raise
+            log(
+                "error",
+                "publish",
+                f"corrective compose call failed: {exc!r}",
+                topic_slug=slug,
+            )
+            return None
+
+        digest = _parse_digest_text(getattr(response, "text", response))
+        summary = digest.get("summary") if isinstance(digest, dict) else None
+        items = digest.get("items") if isinstance(digest, dict) else None
+        if not (summary and items):
+            log(
+                "error",
+                "publish",
+                "corrective compose pass produced no usable digest",
+                topic_slug=slug,
+            )
+            return None
+
+        log(
+            "info",
+            "publish",
+            "recovered digest via corrective compose pass",
+            topic_slug=slug,
+        )
+        # token_count should reflect the whole topic effort: the primary run's
+        # output tokens plus this compose call's (get_stats reports the last
+        # call). Best-effort — a stats hiccup must not block the publish.
+        compose_tokens = 0
+        try:
+            compose_tokens = int(
+                (self.chat.get_stats() or {}).get("output_tokens", 0) or 0
+            )
+        except Exception:  # noqa: BLE001 - stats are advisory, never fatal
+            compose_tokens = 0
+        return push_to_supabase(
+            slug,
+            summary=summary,
+            items=items,
+            sources_used=(digest.get("sources_used") or []),
+            token_count=result.get("output_tokens", 0) + compose_tokens,
+        )
+
+    def _parse_llm_response(self, response: str) -> dict[str, Any]:
+        """Repair malformed JSON before GAIA's parser sees it.
+
+        GAIA drives tools and final answers through a JSON-in-content protocol.
+        The heavy local model intermittently emits JSON with unquoted keys or
+        unquoted string values (a non-deterministic sampling artifact — see
+        _repair_json_text); GAIA's own repair only handles trailing commas and
+        control characters, so such a turn is misread as a plain-text answer and
+        the run dies as a parse_error. Here we detect a malformed JSON object,
+        repair it, and — only when the repair is actionable (a real tool call,
+        answer, plan, or digest) — hand the cleaned JSON to the base parser. A
+        repaired null-tool response is left to GAIA's own fallback to avoid the
+        assistant-message loop (see _is_actionable_response).
+        """
+        stripped = (response or "").strip()
+        if stripped.startswith("{"):
+            try:
+                json.loads(stripped)
+            except (ValueError, TypeError):
+                repaired = _repair_json_text(stripped)
+                if repaired is not None and _is_actionable_response(repaired):
+                    response = json.dumps(repaired)
+        return super()._parse_llm_response(response)
 
     def _get_system_prompt(self) -> str:
         return SYSTEM_PROMPT

--- a/src/news_digest/prompts.py
+++ b/src/news_digest/prompts.py
@@ -76,6 +76,27 @@ the others."""
 PROMPT_VERSION = "sp-" + hashlib.sha256(SYSTEM_PROMPT.encode()).hexdigest()[:12]
 
 
+# Corrective compose pass (agent._compose_and_publish). When the agent loop ends
+# without a usable digest — the heavy model emits a planning thought or a
+# degenerate answer instead of composing (a non-deterministic failure) — we
+# re-summarize from the already-gathered material with this single, tightly
+# scoped completion (no tools, no agent loop), which the model handles far more
+# reliably. The item shape mirrors step 4 of SYSTEM_PROMPT.
+COMPOSE_SYSTEM_PROMPT = """You are a news digest writer. You are given material \
+already gathered from sources. Output ONLY a single JSON object — no prose, no \
+markdown fences, nothing before { or after } — with exactly these keys:
+- "topic_slug": the provided slug (string).
+- "summary": a one to two sentence overview of the most important theme (string).
+- "items": a ranked array of items, most significant first. Each item is an \
+object with "headline" (string), "blurb" (one or two sentences), "detail" (a \
+fuller paragraph with specifics and numbers), and "metadata" (an object with a \
+"sources" array of {"title", "url"} objects).
+- "sources_used": an array of the source URL strings you used.
+Aim for roughly three to seven items. Stay factual and grounded in the gathered \
+material; never invent facts that were not present. Every key and every string \
+value MUST be wrapped in double quotes."""
+
+
 def count_words(text: str) -> int:
     """Count whitespace-separated words in text."""
     return len(text.split())

--- a/tests/test_generate_and_publish.py
+++ b/tests/test_generate_and_publish.py
@@ -389,3 +389,324 @@ def test_non_matching_malformed_json_still_returns_parse_error(
         "parse_error path must still log 'could not parse final answer'"
     )
     assert not any("LLM returned an error response" in m for m in logged_messages)
+
+
+# ---------------------------------------------------------------------------
+# json_repair hardening — malformed JSON the heavy model emits (unquoted
+# keys/values), recovered before giving up. See agent._repair_json_text.
+# ---------------------------------------------------------------------------
+
+
+def test_repair_json_text_recovers_unquoted_keys_and_values():
+    """A tool call with unquoted keys/values (real Qwen shape) is recovered."""
+    from news_digest.agent import _repair_json_text
+
+    malformed = (
+        '{"thought": found the f1 topic, goal: Fetch config, '
+        "tool: fetch_topic_config, tool_args: {slug: f1}}"
+    )
+    out = _repair_json_text(malformed)
+    assert out["tool"] == "fetch_topic_config"
+    assert out["tool_args"] == {"slug": "f1"}
+
+
+def test_repair_json_text_returns_none_for_non_dict():
+    """Pure garbage / arrays must not be coerced into a dict (stay parse_error)."""
+    from news_digest.agent import _repair_json_text
+
+    assert _repair_json_text("not json {{{") is None
+    assert _repair_json_text("{bad json") is None
+    assert _repair_json_text("[1, 2, 3]") is None
+
+
+def test_is_actionable_response():
+    from news_digest.agent import _is_actionable_response
+
+    assert _is_actionable_response({"tool": "fetch_rss", "tool_args": {}})
+    assert _is_actionable_response({"answer": "the digest"})
+    assert _is_actionable_response({"plan": [{"tool": "x", "tool_args": {}}]})
+    assert _is_actionable_response({"summary": "s", "items": _ITEMS})
+    # A null-tool response is NOT actionable — feeding it back to GAIA loops.
+    assert not _is_actionable_response({"thought": "t", "tool": None, "tool_args": {}})
+    assert not _is_actionable_response({})
+    # An empty/null answer is NOT actionable either (truthy check, not presence).
+    assert not _is_actionable_response({"answer": ""})
+    assert not _is_actionable_response({"answer": None})
+
+
+def test_publish_repairs_unquoted_top_level_digest(_capture_push):
+    """result['result'] is a digest with an unquoted value → repaired & published."""
+    raw = (
+        '{"topic_slug": "ai_models", "summary": Top AI news today, "items": '
+        + json.dumps(_ITEMS)
+        + ', "sources_used": ["https://example.com"]}'
+    )
+    result = {"status": "success", "result": raw, "output_tokens": 3}
+    out = _publish_from_result(result)
+
+    assert out["success"] is True
+    assert _capture_push[0]["topic_slug"] == "ai_models"
+    assert _capture_push[0]["summary"] == "Top AI news today"
+
+
+def test_publish_repairs_malformed_nested_answer(_capture_push):
+    """A malformed (unquoted slug) digest nested under 'answer' is recovered."""
+    inner = (
+        '{topic_slug: ai_models, "summary": "S", "items": '
+        + json.dumps(_ITEMS)
+        + ', "sources_used": []}'
+    )
+    raw = json.dumps({"thought": "done", "answer": inner})
+    result = {
+        "status": "success",
+        "result": raw,
+        "conversation": [],
+        "output_tokens": 1,
+    }
+    out = _publish_from_result(result)
+
+    assert out["success"] is True
+    assert _capture_push[0]["topic_slug"] == "ai_models"
+
+
+# ---------------------------------------------------------------------------
+# _parse_llm_response override — repair before GAIA's parser sees the response
+# ---------------------------------------------------------------------------
+
+
+def _bare_agent():
+    """Construct a NewsDigestAgent without running __init__ (no Lemonade/DB)."""
+    from news_digest.agent import NewsDigestAgent
+
+    return NewsDigestAgent.__new__(NewsDigestAgent)
+
+
+def test_parse_llm_response_repairs_malformed_tool_call(monkeypatch):
+    """A malformed tool call is repaired to valid JSON before the base parser."""
+    from gaia.agents.base.agent import Agent
+
+    seen = {}
+    monkeypatch.setattr(
+        Agent,
+        "_parse_llm_response",
+        lambda self, response: seen.setdefault("response", response) or {},
+    )
+    malformed = (
+        '{"thought": found it, goal: do, tool: fetch_topic_config, '
+        "tool_args: {slug: f1}}"
+    )
+    _bare_agent()._parse_llm_response(malformed)
+    parsed = json.loads(seen["response"])  # must now be valid JSON
+    assert parsed["tool"] == "fetch_topic_config"
+    assert parsed["tool_args"] == {"slug": "f1"}
+
+
+def test_parse_llm_response_leaves_null_tool_to_base(monkeypatch):
+    """A repaired null-tool response is NOT substituted (avoids the loop)."""
+    from gaia.agents.base.agent import Agent
+
+    seen = {}
+    monkeypatch.setattr(
+        Agent,
+        "_parse_llm_response",
+        lambda self, response: seen.setdefault("response", response) or {},
+    )
+    malformed = '{"thought": I am done now, goal: x, tool: null, tool_args: {}}'
+    _bare_agent()._parse_llm_response(malformed)
+    assert seen["response"] == malformed  # passed through unchanged
+
+
+def test_parse_llm_response_passes_valid_json_unchanged(monkeypatch):
+    """Valid JSON takes the fast path untouched (no needless re-serialization)."""
+    from gaia.agents.base.agent import Agent
+
+    seen = {}
+    monkeypatch.setattr(
+        Agent,
+        "_parse_llm_response",
+        lambda self, response: seen.setdefault("response", response) or {},
+    )
+    valid = '{"thought": "t", "tool": "fetch_rss", "tool_args": {}}'
+    _bare_agent()._parse_llm_response(valid)
+    assert seen["response"] == valid
+
+
+# ---------------------------------------------------------------------------
+# Corrective compose pass — re-summarize gathered material when the agent loop
+# fails to produce a usable digest. See agent._compose_and_publish.
+# ---------------------------------------------------------------------------
+
+
+class _FakeResp:
+    def __init__(self, text):
+        self.text = text
+
+
+class _FakeChat:
+    """Stub for agent.chat — records calls, returns a fixed response text."""
+
+    def __init__(self, text, output_tokens=0):
+        self._text = text
+        self._output_tokens = output_tokens
+        self.calls = []
+
+    def send_messages(self, messages, system_prompt=None, **kwargs):
+        self.calls.append((messages, system_prompt))
+        return _FakeResp(self._text)
+
+    def get_stats(self):
+        return {"output_tokens": self._output_tokens}
+
+
+def test_extract_gathered_materials_pulls_tool_results():
+    from news_digest.agent import _extract_gathered_materials
+
+    conv = [
+        {"role": "user", "content": "q"},
+        {"role": "tool", "name": "fetch_rss", "content": {"items": [1, 2]}},
+        {"role": "assistant", "content": {"thought": "t"}},
+        {"role": "tool", "name": "parse_article", "content": "body text here"},
+    ]
+    out = _extract_gathered_materials(conv)
+    assert "fetch_rss" in out
+    assert "parse_article" in out
+    assert "body text here" in out
+
+
+def test_extract_gathered_materials_empty_when_no_tools():
+    from news_digest.agent import _extract_gathered_materials
+
+    assert _extract_gathered_materials([{"role": "assistant", "content": {}}]) == ""
+    assert _extract_gathered_materials(None) == ""
+
+
+def test_parse_digest_text_variants():
+    from news_digest.agent import _parse_digest_text
+
+    clean = json.dumps({"summary": "s", "items": [1]})
+    assert _parse_digest_text(clean)["summary"] == "s"
+    assert _parse_digest_text(f"```json\n{clean}\n```")["items"] == [1]
+    # malformed (unquoted value) is repaired
+    assert (
+        _parse_digest_text('{"summary": Hi there, "items": [1]}')["summary"]
+        == "Hi there"
+    )
+    # nested under answer
+    nested = json.dumps({"answer": {"summary": "s", "items": [1]}})
+    assert _parse_digest_text(nested)["summary"] == "s"
+    # unrecoverable / non-string
+    assert _parse_digest_text("not json {{{") is None
+    assert _parse_digest_text(123) is None
+
+
+def test_compose_and_publish_recovers_from_gathered_materials(_capture_push):
+    from news_digest.agent import NewsDigestAgent
+
+    agent = NewsDigestAgent.__new__(NewsDigestAgent)
+    agent.chat = _FakeChat(json.dumps(_answer_payload()))
+    conversation = [
+        {
+            "role": "tool",
+            "name": "fetch_topic_config",
+            "tool_args": {"slug": "ai_models"},
+        },
+        {"role": "tool", "name": "fetch_rss", "content": {"items": [{"t": "x"}]}},
+    ]
+    result = {"conversation": conversation, "output_tokens": 9}
+
+    out = agent._compose_and_publish("q", result, "ai_models")
+
+    assert out["success"] is True
+    assert _capture_push[0]["topic_slug"] == "ai_models"
+    # The compose call was handed the gathered material and the compose prompt.
+    sent_messages, system_prompt = agent.chat.calls[0]
+    assert "fetch_rss" in sent_messages[0]["content"]
+    assert "digest" in system_prompt.lower()
+
+
+def test_compose_and_publish_token_count_sums_primary_and_compose(_capture_push):
+    """token_count reflects the whole effort: primary run + compose call."""
+    from news_digest.agent import NewsDigestAgent
+
+    agent = NewsDigestAgent.__new__(NewsDigestAgent)
+    agent.chat = _FakeChat(json.dumps(_answer_payload()), output_tokens=200)
+    conversation = [{"role": "tool", "name": "fetch_rss", "content": {"x": 1}}]
+    result = {"conversation": conversation, "output_tokens": 50}
+
+    out = agent._compose_and_publish("q", result, "ai_models")
+
+    assert out["success"] is True
+    assert _capture_push[0]["token_count"] == 250  # 50 primary + 200 compose
+
+
+def test_compose_and_publish_repairs_malformed_compose_output(_capture_push):
+    from news_digest.agent import NewsDigestAgent
+
+    agent = NewsDigestAgent.__new__(NewsDigestAgent)
+    malformed = (
+        '{topic_slug: ai_models, "summary": Big news today, "items": '
+        + json.dumps(_ITEMS)
+        + "}"
+    )
+    agent.chat = _FakeChat(malformed)
+    conversation = [{"role": "tool", "name": "fetch_rss", "content": {"x": 1}}]
+
+    out = agent._compose_and_publish("q", {"conversation": conversation}, "ai_models")
+
+    assert out["success"] is True
+    assert _capture_push[0]["summary"] == "Big news today"
+
+
+def test_compose_and_publish_none_without_materials(_capture_push):
+    from news_digest.agent import NewsDigestAgent
+
+    agent = NewsDigestAgent.__new__(NewsDigestAgent)
+    agent.chat = _FakeChat("{}")  # must never be called
+
+    out = agent._compose_and_publish("q", {"conversation": []}, "ai_models")
+
+    assert out is None
+    assert agent.chat.calls == [], "model must not be called when nothing was gathered"
+    assert _capture_push == []
+
+
+def test_compose_and_publish_none_when_compose_has_no_digest(_capture_push):
+    from news_digest.agent import NewsDigestAgent
+
+    agent = NewsDigestAgent.__new__(NewsDigestAgent)
+    agent.chat = _FakeChat('{"thought": "I am done", "tool": null}')
+    conversation = [{"role": "tool", "name": "fetch_rss", "content": {"x": 1}}]
+
+    out = agent._compose_and_publish("q", {"conversation": conversation}, "ai_models")
+
+    assert out is None
+    assert _capture_push == []
+
+
+def test_generate_and_publish_falls_back_to_compose(monkeypatch, _capture_push):
+    """Primary publish fails (no-digest answer) but compose recovers & publishes."""
+    from news_digest.agent import NewsDigestAgent
+
+    conversation = [
+        {
+            "role": "tool",
+            "name": "fetch_topic_config",
+            "tool_args": {"slug": "ai_models"},
+        },
+        {"role": "tool", "name": "fetch_rss", "content": {"items": [{"t": "x"}]}},
+    ]
+    # final answer parses but carries no digest -> missing_fields on primary path
+    fake_result = {
+        "status": "success",
+        "result": json.dumps({"thought": "planning", "answer": "{}"}),
+        "conversation": conversation,
+        "output_tokens": 5,
+    }
+    agent = NewsDigestAgent.__new__(NewsDigestAgent)
+    monkeypatch.setattr(NewsDigestAgent, "process_query", lambda self, q: fake_result)
+    agent.chat = _FakeChat(json.dumps(_answer_payload()))
+
+    out = agent.generate_and_publish("Generate the AI digest")
+
+    assert out["success"] is True
+    assert _capture_push[0]["topic_slug"] == "ai_models"


### PR DESCRIPTION
Fixes the production scheduler failing to publish **any** digest: the heavy local model (Qwen3.5-35B) intermittently emits malformed JSON in GAIA's tool-call/final-answer protocol, so every publish died with `JSONDecodeError`. This adds two complementary layers of robustness so digests publish reliably.

Closes #117

## What changed

- **JSON repair at the parse seam** — `_parse_llm_response` repairs malformed JSON (unquoted keys/values) via `json-repair` before GAIA's parser sees it, substituting only *actionable* repairs so a repaired `tool:null` is left to GAIA's own fallback (avoids the "2+ assistant messages" loop). Plus repair fallbacks in `_publish_from_result`.
- **Corrective compose pass** — when the agent loop yields *no* digest (a planning thought or degenerate answer that repair can't conjure content from), `_compose_and_publish` re-summarizes the already-gathered material with one focused completion.

## Real-world testing evidence

Ran manual digests on the Strix Halo host (prod venv + prod Supabase) against the patched code. Both topics that were failing every attempt landed rows for 2026-06-27:

```
digests (2026-06-27):
  ai_models  16:13:41  tok=1031
  f1         16:16:58  tok=1929
```

The ai_models run exercises the full recovery chain — the primary loop hit the exact prod failure, then the compose pass recovered and published:

```
17:04:30  error  -          generate_and_publish: LLM returned an error response, not a digest
17:04:55  info   ai_models  recovered digest via corrective compose pass
17:04:55  info   ai_models  push_to_supabase: upserted digest for 'ai_models'
```

<details>
<summary>Root cause &amp; before-state</summary>

The model emits malformed JSON (unquoted keys/values) **non-deterministically even at temperature 0** — llama-server continuous-batching FP non-associativity under concurrent load — which is why it presented as a daytime regression (prod scheduler + manual runs hitting Lemonade together) while overnight low-load runs succeeded. Before the fix, 2026-06-27 15:13–16:00 logged `could not parse final answer: JSONDecodeError` for every ai_models/f1 attempt with raw answers like `{\` and `{"thought": I gathered..., tool: null}`; only overnight ai_updates/world_news had rows.

Unit coverage: `tests/test_generate_and_publish.py` adds repair-path, `_parse_llm_response`-override, and compose-pass tests (incl. the real Qwen malformed shapes). Full suite green; ruff clean.
</details>
