### PR TITLE
feat(ai_updates): broaden hardware + AI-company sources

### DIFF
--- a/supabase/migrations/0018_ai_updates_hardware_sources.sql
+++ b/supabase/migrations/0018_ai_updates_hardware_sources.sql
@@ -1,0 +1,45 @@
+-- 0018_ai_updates_hardware_sources.sql — broaden ai_updates hardware + AI-company coverage.
+--
+-- The ai_updates topic's `sources` jsonb is the live source of truth and is
+-- edited directly in Supabase (CLAUDE.md). The original seed (0006) shipped a
+-- dead AMD URL (www.amd.com, Akamai bot-blocked) that was removed live, and the
+-- topic lacked dedicated silicon/accelerator feeds. This migration records the
+-- finalized list so a fresh DB rebuild ends in the correct state (it runs after
+-- 0006 and overwrites it) and never serves the dead AMD URL.
+--
+-- Every added feed was validated through the project's real scraping tools
+-- (`python -m news_digest.tools.scraping <url> {24,168}`) on host t-nx-strx-halo
+-- on 2026-06-27 — each returns real, on-topic content in the 168h window.
+-- Dropped on re-validation: newsroom.intel.com/feed (0 items at both 24h and
+-- 168h — Intel posts ~biweekly and had nothing in window).
+--
+-- The prompt_hint gains an explicit hardware/semiconductor clause: the prior
+-- hint de-emphasised "benchmarks and architectural novelty", which suppressed
+-- chip news; the new clause makes silicon news explicitly wanted while keeping
+-- the dedup-against-ai_models clause.
+--
+-- Deterministic final state: both `sources` and `prompt_hint` are set to their
+-- final merged values, so re-running this migration is a no-op (idempotent,
+-- re-run safety contract per supabase/README.md).
+
+update digest_topics
+set sources = '[
+  {"url": "https://techcrunch.com/feed/", "type": "rss"},
+  {"url": "https://www.theverge.com/rss/index.xml", "type": "rss"},
+  {"url": "https://openai.com/news/rss.xml", "type": "rss"},
+  {"url": "https://www.anthropic.com/news", "type": "html"},
+  {"url": "https://blog.google/technology/ai/rss/", "type": "rss"},
+  {"url": "https://ai.meta.com/blog/", "type": "html"},
+  {"url": "https://mistral.ai/news/", "type": "html"},
+  {"url": "https://rocm.blogs.amd.com/blog/atom.xml", "type": "rss"},
+  {"url": "https://developer.nvidia.com/blog/feed/", "type": "rss"},
+  {"url": "https://www.nextplatform.com/feed/", "type": "rss"},
+  {"url": "https://newsletter.semianalysis.com/feed", "type": "rss"},
+  {"url": "https://azure.microsoft.com/en-us/blog/feed/?tags=azure-ai-services", "type": "rss"},
+  {"url": "https://deepmind.google/blog/rss.xml", "type": "rss"},
+  {"url": "https://machinelearning.apple.com/rss.xml", "type": "rss"},
+  {"url": "https://news.google.com/rss/search?q=%22qualcomm.com%22+ai+OR+snapdragon+OR+hexagon&hl=en-US&gl=US&ceid=US:en", "type": "rss"}
+]'::jsonb,
+    prompt_hint = 'Focus on product launches, GA releases, partnerships, funding rounds, pricing changes, and availability announcements from AI companies. Cover business and strategic moves — acquisitions, leadership changes, enterprise deals. De-emphasise pure opinion, speculation, and research-only papers. De-emphasise benchmarks and architectural novelty unless they accompany a released product. Also actively cover AI hardware and semiconductor news — especially AMD (Instinct, ROCm, Ryzen AI), and also NVIDIA, Intel, Apple Silicon, Qualcomm, Google TPU, and AI-accelerator companies: new GPUs, accelerators, and AI chips; data-center and AI-server platforms; inference/training performance and software stacks (ROCm, CUDA); foundry, packaging, and major supply or partnership deals (e.g. large hyperscaler or model-lab chip purchases); and earnings only where they signal AI demand or capacity. Treat a new chip, accelerator, or inference stack as a released product. Avoid raw spec-sheet number dumps — explain why a hardware development matters. Deduplicate against the most recent ai_models digest — do not repeat items already covered there.'
+where slug = 'ai_updates'
+  and sources::text not like '%developer.nvidia.com%';


### PR DESCRIPTION
Broadens the `ai_updates` digest topic with 7 hardware/AI-company feeds (NVIDIA dev, The Next Platform, SemiAnalysis, Azure AI, Google DeepMind, Apple ML, Qualcomm) and adds an explicit silicon/semiconductor clause to its `prompt_hint` so chip news is actively wanted instead of suppressed. Brings the source list from 8 → 15. Migration `0018` records the finalized live state so a fresh DB rebuild ends correctly and never serves the old dead AMD URL.

Every added feed was validated through the project's **real scraping tools** (`python -m news_digest.tools.scraping`) on host `t-nx-strx-halo` on 2026-06-27 — not a curl 200. Counts are items returned in the 24h / 168h windows.

### Added sources (validation evidence)

| Source | Type | 24h | 168h | Sample title |
|---|---|---|---|---|
| developer.nvidia.com/blog/feed/ | rss | 1 | 13 | "Deploy a Production-Ready NVIDIA AI-Q Blueprint on Oracle Cloud…" |
| www.nextplatform.com/feed/ | rss | 2 | 6 | "A Deep Dive On China's 'LineShine' All-CPU, Exaflops-Class Supercomputer" |
| newsletter.semianalysis.com/feed | rss | 0 | 2 | "China's CXMT Is Set to Challenge DRAM Incumbents" |
| azure.microsoft.com/.../feed/?tags=azure-ai-services | rss | 0 | 2 | "From insight to action: the next phase of agentic cloud operations" |
| deepmind.google/blog/rss.xml | rss | 0 | 1 | "Introducing computer use in Gemini 3.5 Flash" |
| machinelearning.apple.com/rss.xml | rss | 0 | 2 | "Nine Judges, Two Effective Votes: Correlated Errors Undermine LLM Evaluation" |
| news.google.com/rss/search?q="qualcomm.com"+ai… | rss | 0 | 17 | "Qualcomm Unveils Comprehensive Data Center Roadmap for the Agentic AI Era" |

Low-cadence feeds (semianalysis, azure-ai, deepmind, apple-ml) return 0 in a 24h window but real on-topic content at 168h — they contribute on their publish days. The agent fetches a 24h window daily, so this is expected, not a failure.

### Dropped on re-validation

| Candidate | Reason |
|---|---|
| newsroom.intel.com/feed/ | **0 items at both 24h and 168h.** Intel posts ~biweekly and had nothing in window. Cross-vendor feeds (The Next Platform, SemiAnalysis) carry Intel news day-to-day. |

<details>
<summary>The 8 existing live sources were also re-validated — all healthy</summary>

| Source | Type | 24h | 168h |
|---|---|---|---|
| techcrunch.com/feed/ | rss | 8 | 20 |
| theverge.com/rss/index.xml | rss | 10 | 10 |
| openai.com/news/rss.xml | rss | 0 | 10 (near-daily, healthy) |
| anthropic.com/news | html | content (100 links) | — |
| blog.google/technology/ai/rss/ | rss | 0 | 1 (low cadence, alive) |
| ai.meta.com/blog/ | html | content (38 links) | — |
| mistral.ai/news/ | html | content (139 links) | — |
| rocm.blogs.amd.com/blog/atom.xml | rss | 0 | 4 |

</details>

### prompt_hint change

Adds a hardware/semiconductor clause (AMD-first: Instinct/ROCm/Ryzen AI, plus NVIDIA/Intel/Apple Silicon/Qualcomm/Google TPU/accelerator startups) and "treat a new chip/accelerator/inference stack as a released product" — counteracting the prior "de-emphasise benchmarks and architectural novelty" wording that was suppressing chip news. The dedup-against-`ai_models` clause is retained.

Migration applied to the live project and verified: `sources` length = 15, hardware + dedup clauses both present.
