### PR TITLE
chore(release): bump version to 0.2.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "news-digest-agent"
-version = "0.1.0"
+version = "0.2.0"
 description = "A GAIA-based agent that produces personalized news digests from curated sources using local LLM inference."
 readme = "README.md"
 license = "MIT"


### PR DESCRIPTION
Version bump 0.1.0 → 0.2.0 for the v0.2.0 release (first tagged release of news-digest-agent). Headline change: broadened `ai_updates` hardware + AI-company sources (#119).