### PR TITLE
Source Health: scope matview to configured sources + cadence-aware staleness

### DIFF
--- a/supabase/migrations/0019_source_health_configured_only_cadence.sql
+++ b/supabase/migrations/0019_source_health_configured_only_cadence.sql
@@ -1,0 +1,114 @@
+-- 0019_source_health_configured_only_cadence.sql
+--
+-- Extends mv_source_health with two improvements:
+--
+--   1. Configured-only filter: only URLs present in digest_topics.sources appear
+--      in the matview. One-off article fetches, test artifacts, and removed sources
+--      are excluded automatically (they simply have no matching configured URL).
+--
+--   2. cadence_hours column: carries the most lenient cadence across all topics
+--      that reference a given URL (24 for '24h', 168 for '7d', NULL for unknown).
+--      The frontend uses this to compute the staleness threshold per-source.
+--
+-- URL normalization: trailing slashes are stripped before joining so that
+-- "https://example.com/feed/" and "https://example.com/feed" match.
+--
+-- Per-source enabled flag: sources with enabled=false (added in 0016_source_curation)
+-- are excluded — they are configured but intentionally not fetched.
+--
+-- Grants: authenticated SELECT only (mirrors 0013 + 0015; anon was never granted).
+--
+-- Idempotent: DROP IF EXISTS before recreating, UNIQUE INDEX IF NOT EXISTS.
+-- The hourly pg_cron job 'news_digest_refresh_source_health' (0013) references
+-- mv_source_health by name and continues to work unchanged.
+-- Rollback: re-apply 0015_source_health_scope_to_sources.sql (idempotent).
+
+-- ── mv_source_health ──────────────────────────────────────────────────────────
+-- Must DROP + recreate because the column set changes (cadence_hours added).
+-- The UNIQUE index and grants are re-created below.
+
+drop materialized view if exists mv_source_health;
+
+create materialized view mv_source_health as
+with cfg as (
+  -- One row per distinct configured source URL (trailing-slash-normalized).
+  -- cadence_hours: most lenient across all topics that reference this URL;
+  --   24h → 24, 7d → 168, anything else → NULL (surfaces as unknown, not mis-bucketed).
+  -- enabled filter: skip sources explicitly disabled via the per-source enabled flag.
+  select
+    rtrim(s->>'url', '/')                                      as url,
+    max(
+      case dt.cadence
+        when '24h' then 24
+        when '7d'  then 168
+        else            null
+      end
+    )                                                          as cadence_hours
+  from digest_topics dt,
+       lateral jsonb_array_elements(dt.sources) s
+  where coalesce((s->>'enabled')::boolean, true)
+  group by rtrim(s->>'url', '/')
+),
+scrape as (
+  select
+    timestamp,
+    message,
+    metadata ->> 'url'                                         as source_url,
+    (level = 'info' and metadata ? 'duration_ms')             as is_success,
+    (
+      level = 'warn'
+      and not metadata ? 'bozo_exception'
+      and not metadata ? 'truncated_chars'
+    )                                                          as is_failure
+  from system_logs
+  where
+    category = 'scrape'
+    and metadata ->> 'url' is not null
+    and (message like 'fetch_rss:%' or message like 'fetch_html:%')
+    and timestamp >= now() - interval '7 days'
+)
+select
+  s.source_url,
+  count(*) filter (where s.is_success)                        as success_7d,
+  count(*) filter (where s.is_failure)                        as failure_7d,
+  count(*) filter (where s.is_success or s.is_failure)        as total_7d,
+  round(
+    count(*) filter (where s.is_success)::numeric
+    / nullif(count(*) filter (where s.is_success or s.is_failure), 0) * 100,
+    1
+  )                                                            as success_pct_7d,
+  max(s.timestamp) filter (where s.is_success)                as last_success_at,
+  max(s.timestamp) filter (where s.is_failure)                as last_error_at,
+  max(s.timestamp)                                             as last_fetch_at,
+  (
+    select s2.message
+    from scrape s2
+    where s2.source_url = s.source_url and s2.is_failure
+    order by s2.timestamp desc
+    limit 1
+  )                                                            as last_error,
+  cfg.cadence_hours
+from scrape s
+join cfg on cfg.url = rtrim(s.source_url, '/')
+group by s.source_url, cfg.cadence_hours
+with data;
+
+-- Unique index required for REFRESH MATERIALIZED VIEW CONCURRENTLY (hourly cron).
+create unique index if not exists mv_source_health_url_idx
+  on mv_source_health (source_url);
+
+grant select on mv_source_health to authenticated;
+
+-- ── Guard: assert the unique index exists ─────────────────────────────────────
+-- A missing index makes REFRESH … CONCURRENTLY silently fail forever.
+do $$ begin
+  if not exists (
+    select 1 from pg_indexes
+    where tablename  = 'mv_source_health'
+      and indexname  = 'mv_source_health_url_idx'
+      and indexdef   ilike '%unique%'
+  ) then
+    raise exception
+      'mv_source_health_url_idx (UNIQUE) missing — CONCURRENTLY refresh would fail';
+  end if;
+end $$;

--- a/web/src/lib/staleness.ts
+++ b/web/src/lib/staleness.ts
@@ -1,0 +1,65 @@
+// Shared, cadence-aware source-staleness rule (issue #123).
+//
+// A single source of truth used by BOTH the Source Health page
+// (`pages/source-health.ts`) and the Logs "Aggregations" tab
+// (`pages/logs.ts`), so the two surfaces can never disagree.
+//
+// A source is STALE when ANY of:
+//   1. success_pct_7d is known and below 50% (more failures than successes), OR
+//   2. it has never had a successful fetch (last_success_at is null), OR
+//   3. its last success is older than the cadence-aware deadline:
+//        effHours + STALE_SUCCESS_GRACE_HOURS
+//      where effHours is the source's configured cadence (cadence_hours) when
+//      known and positive, else the 24h default. The grace window keeps a feed
+//      from flapping to "stale" the moment it's one cycle late.
+//
+// Examples (grace = 48h):
+//   24h cadence → deadline 72h  (preserves the pre-#123 behavior)
+//    7d cadence → deadline 216h (a healthy weekly feed isn't falsely flagged)
+//   unknown     → deadline 72h  (falls back to the 24h default)
+
+import type { SourceHealth } from "./types";
+
+/** Below this 7-day success percentage, a source is stale. */
+export const STALE_SUCCESS_PCT_THRESHOLD = 50;
+
+/** Hours of grace added on top of a source's cadence before it's "stale". */
+export const STALE_SUCCESS_GRACE_HOURS = 48;
+
+/** Default cadence (hours) when a source has no known cadence_hours. */
+const DEFAULT_CADENCE_HOURS = 24;
+
+/**
+ * Last-success deadline (hours) for a 24h-cadence / unknown-cadence source.
+ * Equals DEFAULT_CADENCE_HOURS + STALE_SUCCESS_GRACE_HOURS = 72, matching the
+ * pre-#123 fixed threshold. Kept as a named export for tests and callers.
+ */
+export const STALE_LAST_SUCCESS_HOURS =
+  DEFAULT_CADENCE_HOURS + STALE_SUCCESS_GRACE_HOURS;
+
+/**
+ * Cadence-aware last-success deadline (hours) for one source.
+ * Uses the configured cadence when known and positive, else the 24h default,
+ * plus the shared grace window.
+ */
+export function staleAfterHours(cadenceHours: number | null | undefined): number {
+  const effHours =
+    typeof cadenceHours === "number" && cadenceHours > 0
+      ? cadenceHours
+      : DEFAULT_CADENCE_HOURS;
+  return effHours + STALE_SUCCESS_GRACE_HOURS;
+}
+
+/** Return true when a source is considered stale per the cadence-aware rules. */
+export function isSourceStale(row: SourceHealth): boolean {
+  const lowRate =
+    row.success_pct_7d !== null &&
+    row.success_pct_7d < STALE_SUCCESS_PCT_THRESHOLD;
+  if (lowRate) return true;
+
+  if (row.last_success_at === null) return true;
+
+  const ageHours =
+    (Date.now() - new Date(row.last_success_at).getTime()) / 3_600_000;
+  return ageHours > staleAfterHours(row.cadence_hours);
+}

--- a/web/src/lib/supabase.ts
+++ b/web/src/lib/supabase.ts
@@ -173,7 +173,7 @@ export async function fetchSourceHealth(
   const { data, error } = await client
     .from("mv_source_health")
     .select(
-      "source_url, success_7d, failure_7d, total_7d, success_pct_7d, last_success_at, last_error_at, last_fetch_at, last_error",
+      "source_url, success_7d, failure_7d, total_7d, success_pct_7d, last_success_at, last_error_at, last_fetch_at, last_error, cadence_hours",
     )
     .order("source_url", { ascending: true });
   if (error) throw error;

--- a/web/src/lib/types.ts
+++ b/web/src/lib/types.ts
@@ -120,7 +120,7 @@ export interface SourceCandidate {
   decided_at: string | null;
 }
 
-/** One row from v_source_success_rate or mv_source_health. */
+/** One row from mv_source_health (also covers v_source_success_rate's subset). */
 export interface SourceHealth {
   source_url: string;
   success_7d: number;
@@ -131,6 +131,9 @@ export interface SourceHealth {
   last_error_at: string | null;
   last_fetch_at: string | null;
   last_error: string | null;
+  /** Most lenient configured cadence in hours (24 or 168); null if unknown.
+   *  Drives the cadence-aware staleness rule (see lib/staleness.ts). */
+  cadence_hours: number | null;
 }
 
 /** One row from v_run_duration. */

--- a/web/src/pages/logs.ts
+++ b/web/src/pages/logs.ts
@@ -9,6 +9,7 @@ import {
   fetchTopics,
 } from "../lib/supabase";
 import type { ErrorsPerDay, RunDuration, SourceHealth, SystemLog, Topic } from "../lib/types";
+import { isSourceStale } from "../lib/staleness";
 import { renderAuthGate } from "../views/auth-gate";
 
 // Issue #27 — Log view UI at `#/logs`.
@@ -119,16 +120,6 @@ export function prettyMetadata(metadata: unknown): string {
   } catch {
     return String(metadata);
   }
-}
-
-/** Source health staleness: true when <50% success rate OR >72h since last success. */
-export function isSourceStale(row: SourceHealth): boolean {
-  const lowSuccessRate =
-    row.success_pct_7d !== null && row.success_pct_7d < 50;
-  const staleLastSuccess =
-    row.last_success_at === null ||
-    Date.now() - new Date(row.last_success_at).getTime() > 72 * 3_600_000;
-  return lowSuccessRate || staleLastSuccess;
 }
 
 /** Format a success rate percentage, or "N/A" when null. */

--- a/web/src/pages/source-health.ts
+++ b/web/src/pages/source-health.ts
@@ -7,28 +7,15 @@ import {
   rejectSourceCandidate,
 } from "../lib/supabase";
 import type { SourceCandidate, SourceHealth } from "../lib/types";
+import { isSourceStale } from "../lib/staleness";
 import { renderAuthGate } from "../views/auth-gate";
 
 // Issue #20 — Source health page at `#/source-health`.
 // Reads from mv_source_health (materialized view, refreshed hourly via pg_cron).
-// Stale = <50% success over 7 days OR >72h since last successful fetch → red.
+// Stale = <50% success over 7 days OR no success within the source's cadence
+// (cadence_hours) plus a grace window — see lib/staleness.ts (issue #123).
 
 // --- Pure, DOM-free helpers (unit-tested) ------------------------------------
-
-/** Staleness thresholds (mirrors the migration's design intent). */
-export const STALE_SUCCESS_PCT_THRESHOLD = 50;   // percent — below this = stale
-export const STALE_LAST_SUCCESS_HOURS = 72;       // hours since last success = stale
-
-/** Return true when a source is considered stale per the staleness rules. */
-export function isSourceStale(row: SourceHealth): boolean {
-  const lowRate =
-    row.success_pct_7d !== null && row.success_pct_7d < STALE_SUCCESS_PCT_THRESHOLD;
-  const noRecentSuccess =
-    row.last_success_at === null ||
-    Date.now() - new Date(row.last_success_at).getTime() >
-      STALE_LAST_SUCCESS_HOURS * 3_600_000;
-  return lowRate || noRecentSuccess;
-}
 
 /** Format a nullable success-rate percentage. */
 export function formatPct(pct: number | null): string {
@@ -343,7 +330,7 @@ export async function renderSourceHealthPage(
     const staleNote = document.createElement("p");
     staleNote.className = "agg-note";
     staleNote.textContent =
-      "Stale = <50% success rate in the last 7 days, OR >72 hours since last successful fetch.";
+      "Stale = <50% success rate in the last 7 days, OR no successful fetch within the source's cadence plus a 48-hour grace (≈72h for daily feeds, ≈9 days for weekly feeds).";
     staleSection.appendChild(staleNote);
 
     if (stale.length > 0) {

--- a/web/tests/unit/observability.test.ts
+++ b/web/tests/unit/observability.test.ts
@@ -2,11 +2,11 @@ import { describe, expect, it } from "vitest";
 import {
   formatAvgDuration,
   formatSuccessPct,
-  isSourceStale,
   parseLogsState,
   serializeLogsState,
   type LogsState,
 } from "../../src/pages/logs";
+import { isSourceStale } from "../../src/lib/staleness";
 import {
   defaultLogsFilterExtended,
   escapeIlike,
@@ -15,7 +15,9 @@ import {
 } from "../../src/lib/query";
 import type { SourceHealth } from "../../src/lib/types";
 
-function makeHealthRow(overrides: Partial<SourceHealth> = {}): SourceHealth {
+function makeHealthRow(
+  overrides: Partial<SourceHealth & { cadence_hours: number | null }> = {},
+): SourceHealth & { cadence_hours: number | null } {
   return {
     source_url: "https://example.com/feed",
     success_7d: 10,
@@ -26,6 +28,7 @@ function makeHealthRow(overrides: Partial<SourceHealth> = {}): SourceHealth {
     last_error_at: null,
     last_fetch_at: new Date().toISOString(),
     last_error: null,
+    cadence_hours: null,
     ...overrides,
   };
 }

--- a/web/tests/unit/source-health.test.ts
+++ b/web/tests/unit/source-health.test.ts
@@ -4,14 +4,18 @@ import {
   formatPct,
   formatRelativeTime,
   formatRelevance,
-  isSourceStale,
   partitionByHealth,
+} from "../../src/pages/source-health";
+import {
+  isSourceStale,
   STALE_LAST_SUCCESS_HOURS,
   STALE_SUCCESS_PCT_THRESHOLD,
-} from "../../src/pages/source-health";
+} from "../../src/lib/staleness";
 import type { SourceCandidate, SourceHealth } from "../../src/lib/types";
 
-function makeRow(overrides: Partial<SourceHealth> = {}): SourceHealth {
+function makeRow(
+  overrides: Partial<SourceHealth & { cadence_hours: number | null }> = {},
+): SourceHealth & { cadence_hours: number | null } {
   return {
     source_url: "https://example.com/feed",
     success_7d: 10,
@@ -22,6 +26,7 @@ function makeRow(overrides: Partial<SourceHealth> = {}): SourceHealth {
     last_error_at: null,
     last_fetch_at: new Date().toISOString(),
     last_error: null,
+    cadence_hours: null,
     ...overrides,
   };
 }
@@ -33,59 +38,75 @@ describe("isSourceStale", () => {
     expect(isSourceStale(makeRow())).toBe(false);
   });
 
-  it("returns true when success_pct_7d is below threshold", () => {
-    const row = makeRow({ success_pct_7d: STALE_SUCCESS_PCT_THRESHOLD - 1 });
-    expect(isSourceStale(row)).toBe(true);
-  });
-
-  it("returns false at exactly the threshold", () => {
-    const row = makeRow({ success_pct_7d: STALE_SUCCESS_PCT_THRESHOLD });
-    // threshold is strictly < 50, so 50 is NOT stale (assuming recent success)
+  // cadence_hours:168 (7d feed) @ 80h → NOT stale (80 < 168+48=216)
+  it("7d-cadence source with last success 80h ago is NOT stale", () => {
+    const row = makeRow({
+      cadence_hours: 168,
+      last_success_at: new Date(Date.now() - 80 * 3_600_000).toISOString(),
+    });
     expect(isSourceStale(row)).toBe(false);
   });
 
+  // cadence_hours:24 (24h feed) @ 80h → stale (80 > 24+48=72)
+  it("24h-cadence source with last success 80h ago IS stale", () => {
+    const row = makeRow({
+      cadence_hours: 24,
+      last_success_at: new Date(Date.now() - 80 * 3_600_000).toISOString(),
+    });
+    expect(isSourceStale(row)).toBe(true);
+  });
+
+  // 24h-cadence @ 70h → NOT stale (70 < 72) — preserves the 72h boundary
+  it("24h-cadence source with last success 70h ago is NOT stale", () => {
+    const row = makeRow({
+      cadence_hours: 24,
+      last_success_at: new Date(Date.now() - 70 * 3_600_000).toISOString(),
+    });
+    expect(isSourceStale(row)).toBe(false);
+  });
+
+  // success_pct_7d:49 → stale regardless of cadence
+  it("returns true when success_pct_7d is below 50 (regardless of cadence)", () => {
+    const row = makeRow({ cadence_hours: 168, success_pct_7d: 49 });
+    expect(isSourceStale(row)).toBe(true);
+  });
+
+  // last_success_at:null → stale
   it("returns true when last_success_at is null", () => {
     const row = makeRow({ last_success_at: null });
     expect(isSourceStale(row)).toBe(true);
   });
 
-  it("returns true when last_success_at is older than 72h", () => {
-    const oldDate = new Date(
-      Date.now() - (STALE_LAST_SUCCESS_HOURS + 1) * 3_600_000,
-    ).toISOString();
-    const row = makeRow({ last_success_at: oldDate });
+  // cadence_hours:null @ 80h → stale (falls back to 24h → 72h boundary; 80 > 72)
+  it("cadence_hours:null with last success 80h ago IS stale (falls back to 24h/72h)", () => {
+    const row = makeRow({
+      cadence_hours: null,
+      last_success_at: new Date(Date.now() - 80 * 3_600_000).toISOString(),
+    });
     expect(isSourceStale(row)).toBe(true);
   });
 
-  it("returns false when last_success_at is within 72h", () => {
-    const recentDate = new Date(
-      Date.now() - (STALE_LAST_SUCCESS_HOURS - 1) * 3_600_000,
-    ).toISOString();
-    const row = makeRow({ last_success_at: recentDate });
+  // cadence_hours:null @ 70h → NOT stale (falls back to 72h)
+  it("cadence_hours:null with last success 70h ago is NOT stale (fallback 72h)", () => {
+    const row = makeRow({
+      cadence_hours: null,
+      last_success_at: new Date(Date.now() - 70 * 3_600_000).toISOString(),
+    });
     expect(isSourceStale(row)).toBe(false);
   });
 
-  it("returns true when success_pct is null (treated as stale)", () => {
-    // null success_pct_7d does not trigger lowRate, but a null last_success_at
-    // triggers noRecentSuccess — test both together
-    const row = makeRow({ success_pct_7d: null, last_success_at: null });
-    expect(isSourceStale(row)).toBe(true);
+  // merge-safety: different cadence_hours → different results at same 80h age
+  it("MERGE-SAFETY: 168h-cadence and 24h-cadence return different staleness at 80h age", () => {
+    const t80 = new Date(Date.now() - 80 * 3_600_000).toISOString();
+    const row7d = makeRow({ cadence_hours: 168, last_success_at: t80 });
+    const row24h = makeRow({ cadence_hours: 24, last_success_at: t80 });
+    expect(isSourceStale(row7d)).toBe(false);
+    expect(isSourceStale(row24h)).toBe(true);
   });
 
-  it("is stale if either condition holds", () => {
-    // Low rate but recent success
-    const lowRate = makeRow({
-      success_pct_7d: 10,
-      last_success_at: new Date().toISOString(),
-    });
-    expect(isSourceStale(lowRate)).toBe(true);
-
-    // Good rate but old success
-    const oldSuccess = makeRow({
-      success_pct_7d: 100,
-      last_success_at: new Date(Date.now() - 100 * 3_600_000).toISOString(),
-    });
-    expect(isSourceStale(oldSuccess)).toBe(true);
+  it("returns true when success_pct_7d is null and last_success_at is null", () => {
+    const row = makeRow({ success_pct_7d: null, last_success_at: null });
+    expect(isSourceStale(row)).toBe(true);
   });
 });
 
@@ -163,7 +184,7 @@ describe("staleness thresholds", () => {
     expect(STALE_SUCCESS_PCT_THRESHOLD).toBe(50);
   });
 
-  it("STALE_LAST_SUCCESS_HOURS is 72", () => {
+  it("STALE_LAST_SUCCESS_HOURS is 72 (24h cadence baseline)", () => {
     expect(STALE_LAST_SUCCESS_HOURS).toBe(72);
   });
 });


### PR DESCRIPTION
Closes #123

## Summary
Source Health listed junk and false-positives because the `mv_source_health` materialized view counted **every** scraped URL, and staleness used a fixed 72h rule with no cadence awareness. This change:
- **Scopes the matview to configured sources** — migration `0019` inner-joins scrape rows to `digest_topics.sources` on a trailing-slash-normalized URL (and drops sources with `enabled=false`). One-off article fetches, the `--help` test artifact, and removed sources simply have no configured match and disappear. **No data deletion needed.**
- **Adds `cadence_hours`** to the matview (24h→24, 7d→168, unknown→null; most-lenient `max` across topics) and a single shared **cadence-aware** `isSourceStale` in `web/src/lib/staleness.ts` used by both the Source Health page and the Logs Aggregations tab (so they can't disagree). A source is stale at `<50%` 7d success, or never-succeeded, or last-success older than `cadence + 48h` grace → 72h for daily feeds (unchanged), ~9 days for weekly feeds.

The migration mirrors `0015` (DROP+recreate, unique index `mv_source_health_url_idx` for `REFRESH … CONCURRENTLY`, `authenticated` grant), and ends with a guard that fails loudly if the unique index is missing. Rollback: re-apply the idempotent `0015`.

## Evidence
**Real-world — migration applied to production, then validated:**

| Check | Result |
|---|---|
| Total rows in `mv_source_health` | **38** (= configured source count) |
| Junk still present (`--help`, `amd.com/blogs.html`, article URLs, `?tags=azure-ai`) | **0** ✓ |
| Configured URLs with scrape history silently dropped | **0** ✓ (rtrim normalization — no trailing-slash casualties) |
| `pittsburghhockeynow.com/feed/` (7d cadence) | `cadence_hours=168`, last success 4d ago → **healthy** (was falsely "stale") ✓ |
| Unique index present / hourly cron job present | 1 / 1 ✓ |
| Distinct cadence values | `{24, 168}` (no nulls) |

**Source Health page (authenticated, prod data):** header now reads **"Stale sources — none"** with the cadence-aware caption; **Healthy sources (38)** with no junk rows; penguins feed shown healthy. Screenshot captured during validation (before: 8 stale entries incl. `--help`, removed sources, article URLs, and the false-positive penguins feed).

**Unit (vitest):** `418 passed` incl. all cadence boundary cases (24h@70h not stale, 24h@80h stale, 7d@80h not stale, null fallbacks) and a merge-safety test asserting 168-vs-24 divergence at 80h. `build` + `lint` clean.

## Tests
- Unit: 418/418 ✓
- Real-world (prod migration + SQL validation + browser): all checks green ✓

## Notes
- Resolves the operational "clean up stale sources" need without deleting `system_logs` rows — the view filter excludes them and they age out of the 7-day window.
- Rollback: re-apply `0015_source_health_scope_to_sources.sql`.
