### PR TITLE
Shared nav component: keep all tabs visible with an active-state highlight

### DIFF
--- a/web/src/pages/history.ts
+++ b/web/src/pages/history.ts
@@ -269,9 +269,21 @@ function renderList(
       section.appendChild(topicHeading);
 
       for (const digest of topicBucket.digests) {
-        const card = renderDigestCard(digest);
-        card.appendChild(metaLine(digestMeta(digest, topics)));
-        section.appendChild(card);
+        // Defense in depth (issue #121): a single structurally broken digest
+        // (e.g. garbled metadata.sources from the heavy model) must never blank
+        // the whole list. Wrap each card so a render failure degrades to a small
+        // inline note and the rest of the list still renders.
+        try {
+          const card = renderDigestCard(digest);
+          card.appendChild(metaLine(digestMeta(digest, topics)));
+          section.appendChild(card);
+        } catch {
+          const fallback = document.createElement("p");
+          fallback.className = "digest-error";
+          fallback.setAttribute("data-digest-id", digest.id);
+          fallback.textContent = "This digest could not be displayed.";
+          section.appendChild(fallback);
+        }
       }
     }
     container.appendChild(section);

--- a/web/src/pages/history.ts
+++ b/web/src/pages/history.ts
@@ -1,9 +1,10 @@
 import type { SupabaseClient } from "@supabase/supabase-js";
-import { isAuthenticatedAtRequiredLevel, signOut } from "../lib/auth";
+import { isAuthenticatedAtRequiredLevel } from "../lib/auth";
 import { appToday } from "../lib/dates";
 import { groupDigestsByDateAndTopic } from "../lib/group";
 import { fetchAllDigests, fetchTopics } from "../lib/supabase";
 import type { Digest, Topic } from "../lib/types";
+import { buildAppNav } from "../views/app-nav";
 import { renderAuthGate } from "../views/auth-gate";
 import { renderDigestCard } from "../views/digest-card";
 import { formatDate } from "../views/digest-list";
@@ -363,37 +364,7 @@ export async function renderHistory(root: HTMLElement, client: SupabaseClient): 
   title.textContent = "History";
   header.appendChild(title);
 
-  const nav = document.createElement("nav");
-  nav.className = "app-nav";
-  const homeLink = document.createElement("a");
-  homeLink.href = "#/";
-  homeLink.textContent = "Today";
-  nav.appendChild(homeLink);
-  const logsLink = document.createElement("a");
-  logsLink.href = "#/logs";
-  logsLink.textContent = "Logs";
-  nav.appendChild(logsLink);
-  const sourceHealthLink = document.createElement("a");
-  sourceHealthLink.href = "#/source-health";
-  sourceHealthLink.textContent = "Source Health";
-  nav.appendChild(sourceHealthLink);
-  const tokenUsageLink = document.createElement("a");
-  tokenUsageLink.href = "#/token-usage";
-  tokenUsageLink.textContent = "Token Usage";
-  nav.appendChild(tokenUsageLink);
-  const out = document.createElement("button");
-  out.type = "button";
-  out.className = "sign-out";
-  out.textContent = "Sign out";
-  out.addEventListener("click", () => {
-    void (async () => {
-      await signOut(client);
-      window.location.hash = "#/";
-      window.location.reload();
-    })();
-  });
-  nav.appendChild(out);
-  header.appendChild(nav);
+  header.appendChild(buildAppNav(client, "#/history"));
   root.appendChild(header);
 
   const main = document.createElement("main");

--- a/web/src/pages/home.ts
+++ b/web/src/pages/home.ts
@@ -2,12 +2,12 @@ import type { SupabaseClient } from "@supabase/supabase-js";
 import {
   changePassword,
   isAuthenticatedAtRequiredLevel,
-  signOut,
   validatePassword,
 } from "../lib/auth";
 import { isToday } from "../lib/dates";
 import { fetchDigests, fetchMissedDigests, fetchTopics } from "../lib/supabase";
 import type { Digest, MissedDigest } from "../lib/types";
+import { buildAppNav } from "../views/app-nav";
 import { renderAuthGate } from "../views/auth-gate";
 import { renderDigestList } from "../views/digest-list";
 
@@ -126,38 +126,7 @@ export async function renderHome(root: HTMLElement, client: SupabaseClient): Pro
   title.textContent = "News Digest";
   header.appendChild(title);
 
-  const nav = document.createElement("nav");
-  nav.className = "app-nav";
-  const historyLink = document.createElement("a");
-  historyLink.href = "#/history";
-  historyLink.textContent = "History";
-  nav.appendChild(historyLink);
-  const logsLink = document.createElement("a");
-  logsLink.href = "#/logs";
-  logsLink.textContent = "Logs";
-  nav.appendChild(logsLink);
-  const sourceHealthLink = document.createElement("a");
-  sourceHealthLink.href = "#/source-health";
-  sourceHealthLink.textContent = "Source Health";
-  nav.appendChild(sourceHealthLink);
-  const tokenUsageLink = document.createElement("a");
-  tokenUsageLink.href = "#/token-usage";
-  tokenUsageLink.textContent = "Token Usage";
-  nav.appendChild(tokenUsageLink);
-
-  const out = document.createElement("button");
-  out.type = "button";
-  out.className = "sign-out";
-  out.textContent = "Sign out";
-  out.addEventListener("click", () => {
-    void (async () => {
-      await signOut(client);
-      window.location.hash = "#/";
-      window.location.reload();
-    })();
-  });
-  nav.appendChild(out);
-  header.appendChild(nav);
+  header.appendChild(buildAppNav(client, "#/"));
   root.appendChild(header);
 
   const main = document.createElement("main");

--- a/web/src/pages/logs.ts
+++ b/web/src/pages/logs.ts
@@ -1,5 +1,5 @@
 import type { SupabaseClient } from "@supabase/supabase-js";
-import { isAuthenticatedAtRequiredLevel, signOut } from "../lib/auth";
+import { isAuthenticatedAtRequiredLevel } from "../lib/auth";
 import { defaultLogsFilter, LOG_PAGE_SIZE, type LogLevel } from "../lib/query";
 import {
   fetchErrorsPerDay,
@@ -9,6 +9,7 @@ import {
   fetchTopics,
 } from "../lib/supabase";
 import type { ErrorsPerDay, RunDuration, SourceHealth, SystemLog, Topic } from "../lib/types";
+import { buildAppNav } from "../views/app-nav";
 import { renderAuthGate } from "../views/auth-gate";
 
 // Issue #27 — Log view UI at `#/logs`.
@@ -671,37 +672,7 @@ export async function renderLogs(root: HTMLElement, client: SupabaseClient): Pro
   title.textContent = "Logs";
   header.appendChild(title);
 
-  const nav = document.createElement("nav");
-  nav.className = "app-nav";
-  const homeLink = document.createElement("a");
-  homeLink.href = "#/";
-  homeLink.textContent = "Today";
-  nav.appendChild(homeLink);
-  const historyLink = document.createElement("a");
-  historyLink.href = "#/history";
-  historyLink.textContent = "History";
-  nav.appendChild(historyLink);
-  const sourceHealthLink = document.createElement("a");
-  sourceHealthLink.href = "#/source-health";
-  sourceHealthLink.textContent = "Source Health";
-  nav.appendChild(sourceHealthLink);
-  const tokenUsageLink = document.createElement("a");
-  tokenUsageLink.href = "#/token-usage";
-  tokenUsageLink.textContent = "Token Usage";
-  nav.appendChild(tokenUsageLink);
-  const out = document.createElement("button");
-  out.type = "button";
-  out.className = "sign-out";
-  out.textContent = "Sign out";
-  out.addEventListener("click", () => {
-    void (async () => {
-      await signOut(client);
-      window.location.hash = "#/";
-      window.location.reload();
-    })();
-  });
-  nav.appendChild(out);
-  header.appendChild(nav);
+  header.appendChild(buildAppNav(client, "#/logs"));
   root.appendChild(header);
 
   const main = document.createElement("main");

--- a/web/src/pages/source-health.ts
+++ b/web/src/pages/source-health.ts
@@ -1,5 +1,5 @@
 import type { SupabaseClient } from "@supabase/supabase-js";
-import { isAuthenticatedAtRequiredLevel, signOut } from "../lib/auth";
+import { isAuthenticatedAtRequiredLevel } from "../lib/auth";
 import {
   approveSourceCandidate,
   fetchSourceCandidates,
@@ -7,6 +7,7 @@ import {
   rejectSourceCandidate,
 } from "../lib/supabase";
 import type { SourceCandidate, SourceHealth } from "../lib/types";
+import { buildAppNav } from "../views/app-nav";
 import { renderAuthGate } from "../views/auth-gate";
 
 // Issue #20 — Source health page at `#/source-health`.
@@ -253,38 +254,6 @@ function renderCandidatesTable(
   return wrap;
 }
 
-function buildNav(client: SupabaseClient): HTMLElement {
-  const nav = document.createElement("nav");
-  nav.className = "app-nav";
-
-  const links: Array<[string, string]> = [
-    ["#/", "Today"],
-    ["#/history", "History"],
-    ["#/logs", "Logs"],
-    ["#/token-usage", "Token Usage"],
-  ];
-  for (const [href, text] of links) {
-    const a = document.createElement("a");
-    a.href = href;
-    a.textContent = text;
-    nav.appendChild(a);
-  }
-
-  const out = document.createElement("button");
-  out.type = "button";
-  out.className = "sign-out";
-  out.textContent = "Sign out";
-  out.addEventListener("click", () => {
-    void (async () => {
-      await signOut(client);
-      window.location.hash = "#/";
-      window.location.reload();
-    })();
-  });
-  nav.appendChild(out);
-  return nav;
-}
-
 export async function renderSourceHealthPage(
   root: HTMLElement,
   client: SupabaseClient,
@@ -301,7 +270,7 @@ export async function renderSourceHealthPage(
   const title = document.createElement("h1");
   title.textContent = "Source Health";
   header.appendChild(title);
-  header.appendChild(buildNav(client));
+  header.appendChild(buildAppNav(client, "#/source-health"));
   root.appendChild(header);
 
   const main = document.createElement("main");

--- a/web/src/pages/token-usage.ts
+++ b/web/src/pages/token-usage.ts
@@ -1,7 +1,8 @@
 import type { SupabaseClient } from "@supabase/supabase-js";
-import { isAuthenticatedAtRequiredLevel, signOut } from "../lib/auth";
+import { isAuthenticatedAtRequiredLevel } from "../lib/auth";
 import { fetchTokenUsage } from "../lib/supabase";
 import type { TokenUsageDay } from "../lib/types";
+import { buildAppNav } from "../views/app-nav";
 import { renderAuthGate } from "../views/auth-gate";
 
 // Issue #20 — Token usage dashboard at `#/token-usage`.
@@ -74,38 +75,6 @@ export function primaryMetricLabel(useTokens: boolean): string {
 }
 
 // --- DOM rendering -----------------------------------------------------------
-
-function buildNav(client: SupabaseClient): HTMLElement {
-  const nav = document.createElement("nav");
-  nav.className = "app-nav";
-
-  const links: Array<[string, string]> = [
-    ["#/", "Today"],
-    ["#/history", "History"],
-    ["#/logs", "Logs"],
-    ["#/source-health", "Source Health"],
-  ];
-  for (const [href, text] of links) {
-    const a = document.createElement("a");
-    a.href = href;
-    a.textContent = text;
-    nav.appendChild(a);
-  }
-
-  const out = document.createElement("button");
-  out.type = "button";
-  out.className = "sign-out";
-  out.textContent = "Sign out";
-  out.addEventListener("click", () => {
-    void (async () => {
-      await signOut(client);
-      window.location.hash = "#/";
-      window.location.reload();
-    })();
-  });
-  nav.appendChild(out);
-  return nav;
-}
 
 /** Render a single day group as a card with per-row bars. */
 function renderDayCard(group: DayGroup, maxMetric: number, useTokens: boolean): HTMLElement {
@@ -185,7 +154,7 @@ export async function renderTokenUsagePage(
   const title = document.createElement("h1");
   title.textContent = "Token Usage";
   header.appendChild(title);
-  header.appendChild(buildNav(client));
+  header.appendChild(buildAppNav(client, "#/token-usage"));
   root.appendChild(header);
 
   const main = document.createElement("main");

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -144,6 +144,13 @@ h1 {
   border-bottom-color: var(--accent);
 }
 
+.app-nav a[aria-current="page"],
+.app-nav a.nav-active {
+  border-bottom-color: var(--accent);
+  font-weight: 700;
+  color: var(--fg);
+}
+
 /* ── Buttons ──────────────────────────────────────────────────────────────── */
 
 button {

--- a/web/src/views/app-nav.ts
+++ b/web/src/views/app-nav.ts
@@ -1,0 +1,50 @@
+import type { SupabaseClient } from "@supabase/supabase-js";
+import { signOut } from "../lib/auth";
+
+/** Canonical nav destinations in display order. */
+const NAV_TABS: ReadonlyArray<readonly [string, string]> = [
+  ["#/", "Today"],
+  ["#/history", "History"],
+  ["#/logs", "Logs"],
+  ["#/source-health", "Source Health"],
+  ["#/token-usage", "Token Usage"],
+];
+
+/**
+ * Build the shared application nav.
+ *
+ * @param client   - Supabase client (used for sign-out).
+ * @param activeHref - The exact href of the current page (e.g. `#/`, `#/history`).
+ *                    The matching link receives `aria-current="page"` and the
+ *                    `nav-active` class; it is NOT removed from the DOM.
+ */
+export function buildAppNav(client: SupabaseClient, activeHref: string): HTMLElement {
+  const nav = document.createElement("nav");
+  nav.className = "app-nav";
+
+  for (const [href, label] of NAV_TABS) {
+    const a = document.createElement("a");
+    a.href = href;
+    a.textContent = label;
+    if (href === activeHref) {
+      a.setAttribute("aria-current", "page");
+      a.classList.add("nav-active");
+    }
+    nav.appendChild(a);
+  }
+
+  const out = document.createElement("button");
+  out.type = "button";
+  out.className = "sign-out";
+  out.textContent = "Sign out";
+  out.addEventListener("click", () => {
+    void (async () => {
+      await signOut(client);
+      window.location.hash = "#/";
+      window.location.reload();
+    })();
+  });
+  nav.appendChild(out);
+
+  return nav;
+}

--- a/web/src/views/digest-card.ts
+++ b/web/src/views/digest-card.ts
@@ -45,8 +45,16 @@ export function registerItemFlagMounter(fn: MountItemFlags): void {
  * Returns the URL string unchanged when it starts with http:// or https://.
  * Returns null for javascript:, data:, or any other scheme — these must never
  * appear as an href value (LLM-generated source URLs could carry injected schemes).
+ *
+ * Also returns null for non-string input (null/undefined) and empty strings:
+ * malformed digests (e.g. garbled JSON from the heavy model) can yield a source
+ * whose `url` is missing, and a bad source must never throw — issue #121. The
+ * http(s) scheme allow-list above is unchanged; this only adds a type guard.
  */
-function safeHref(url: string): string | null {
+export function safeHref(url: string | null | undefined): string | null {
+  if (typeof url !== "string" || url === "") {
+    return null;
+  }
   if (url.startsWith("https://") || url.startsWith("http://")) {
     return url;
   }
@@ -146,12 +154,20 @@ function renderItem(item: DigestItem): HTMLElement {
   }
 
   // Source links — only http(s) URLs are emitted as anchors.
-  const sources = item.metadata?.sources ?? [];
+  // Malformed digests (issue #121) can yield a source that is not a well-formed
+  // { url, title } object: a non-object entry, or a missing/non-string url.
+  // Such entries are skipped rather than throwing — one bad source must never
+  // blank the item (or the whole list above it).
+  const sources = Array.isArray(item.metadata?.sources) ? item.metadata.sources : [];
   if (sources.length > 0) {
     const sourcesList = document.createElement("ul");
     sourcesList.className = "item-sources";
     for (const src of sources) {
+      if (src === null || typeof src !== "object") {
+        continue; // non-object source entry — nothing to render
+      }
       const href = safeHref(src.url);
+      const title = typeof src.title === "string" ? src.title : null;
       const li = document.createElement("li");
       if (href !== null) {
         const a = document.createElement("a");
@@ -159,11 +175,14 @@ function renderItem(item: DigestItem): HTMLElement {
         a.href = href;
         a.target = "_blank";
         a.rel = "noopener noreferrer";
-        a.textContent = src.title;
+        a.textContent = title ?? href;
         li.appendChild(a);
+      } else if (title !== null) {
+        // Non-http(s) URL but a usable title: render as plain text to avoid
+        // dropping the source name. A url-less/title-less entry is skipped.
+        li.textContent = title;
       } else {
-        // Non-http(s) URL: render as plain text to avoid dropping the source name.
-        li.textContent = src.title;
+        continue; // no usable href and no title — skip entirely
       }
       sourcesList.appendChild(li);
     }

--- a/web/tests/unit/app-nav.test.ts
+++ b/web/tests/unit/app-nav.test.ts
@@ -1,0 +1,88 @@
+// @vitest-environment jsdom
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import type { SupabaseClient } from "@supabase/supabase-js";
+import { buildAppNav } from "../../src/views/app-nav";
+
+const stubClient = { auth: { signOut: async () => ({}) } } as unknown as SupabaseClient;
+
+const ALL_HREFS = ["#/", "#/history", "#/logs", "#/source-health", "#/token-usage"] as const;
+
+beforeEach(() => {
+  document.body.innerHTML = "";
+});
+
+afterEach(() => {
+  document.body.innerHTML = "";
+});
+
+// ---------------------------------------------------------------------------
+// Structure
+// ---------------------------------------------------------------------------
+
+describe("buildAppNav — structure", () => {
+  it("renders exactly 5 <a> links in the nav", () => {
+    const nav = buildAppNav(stubClient, "#/");
+    document.body.appendChild(nav);
+    const links = nav.querySelectorAll("a");
+    expect(links.length).toBe(5);
+  });
+
+  it("renders links in canonical order: #/, #/history, #/logs, #/source-health, #/token-usage", () => {
+    const nav = buildAppNav(stubClient, "#/");
+    document.body.appendChild(nav);
+    const hrefs = Array.from(nav.querySelectorAll<HTMLAnchorElement>("a")).map(
+      (a) => a.getAttribute("href"),
+    );
+    expect(hrefs).toEqual([...ALL_HREFS]);
+  });
+
+  it("contains a sign-out button with class sign-out", () => {
+    const nav = buildAppNav(stubClient, "#/");
+    document.body.appendChild(nav);
+    const btn = nav.querySelector(".sign-out");
+    expect(btn).not.toBeNull();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// aria-current per active route — regression: active link must appear in DOM
+// ---------------------------------------------------------------------------
+
+describe.each(ALL_HREFS.map((href) => ({ activeHref: href })))(
+  "buildAppNav — active route $activeHref",
+  ({ activeHref }) => {
+    it("exactly one <a> has aria-current='page'", () => {
+      const nav = buildAppNav(stubClient, activeHref);
+      document.body.appendChild(nav);
+      const active = nav.querySelectorAll<HTMLAnchorElement>("a[aria-current='page']");
+      expect(active.length).toBe(1);
+    });
+
+    it("the active <a> href matches activeHref", () => {
+      const nav = buildAppNav(stubClient, activeHref);
+      document.body.appendChild(nav);
+      const active = nav.querySelector<HTMLAnchorElement>("a[aria-current='page']");
+      expect(active).not.toBeNull();
+      expect(active!.getAttribute("href")).toBe(activeHref);
+    });
+
+    it("the active link IS present in the DOM (regression: old code omitted it)", () => {
+      const nav = buildAppNav(stubClient, activeHref);
+      document.body.appendChild(nav);
+      const link = nav.querySelector<HTMLAnchorElement>(`a[href="${activeHref}"]`);
+      expect(link).not.toBeNull();
+    });
+
+    it("all other 4 links have no aria-current attribute", () => {
+      const nav = buildAppNav(stubClient, activeHref);
+      document.body.appendChild(nav);
+      const others = Array.from(
+        nav.querySelectorAll<HTMLAnchorElement>("a"),
+      ).filter((a) => a.getAttribute("href") !== activeHref);
+      expect(others.length).toBe(4);
+      for (const a of others) {
+        expect(a.hasAttribute("aria-current")).toBe(false);
+      }
+    });
+  },
+);

--- a/web/tests/unit/digest-card.test.ts
+++ b/web/tests/unit/digest-card.test.ts
@@ -374,6 +374,73 @@ describe("renderDigestCard — sentiment badge (issue #19)", () => {
 });
 
 // ---------------------------------------------------------------------------
+// Issue #121 — renderItem resilience: malformed sources must not throw (AC3)
+// ---------------------------------------------------------------------------
+
+describe("renderDigestCard — malformed-source resilience (AC3)", () => {
+  it("does not throw when a source entry has no url property", () => {
+    const itemMissingUrl: DigestItem = {
+      headline: "Article with broken source",
+      blurb: "Something interesting happened.",
+      detail: "Full details here.",
+      metadata: {
+        sources: [
+          { title: "Good Source", url: "https://example.com/good" },
+          // url is intentionally missing — cast to exercise the runtime path
+          { title: "Broken Source" } as unknown as { title: string; url: string },
+        ],
+      },
+    };
+    const digest = makeDigest({ summary: "S.", items: [itemMissingUrl] });
+    expect(() => renderDigestCard(digest)).not.toThrow();
+  });
+
+  it("still renders the <details class=digest-item> element when a source url is missing", () => {
+    const itemMissingUrl: DigestItem = {
+      headline: "Article with broken source",
+      blurb: "Blurb text.",
+      detail: "Detail text.",
+      metadata: {
+        sources: [{ title: "No URL" } as unknown as { title: string; url: string }],
+      },
+    };
+    const digest = makeDigest({ summary: "S.", items: [itemMissingUrl] });
+    const card = renderDigestCard(digest);
+    document.body.appendChild(card);
+    expect(card.querySelector("details.digest-item")).not.toBeNull();
+  });
+
+  it("does not produce an <a class=source-link> anchor when source url is undefined", () => {
+    const itemUndefinedUrl: DigestItem = {
+      headline: "Article with undefined url source",
+      blurb: "Blurb.",
+      detail: "Detail.",
+      metadata: {
+        sources: [{ title: "No URL" } as unknown as { title: string; url: string }],
+      },
+    };
+    const digest = makeDigest({ summary: "S.", items: [itemUndefinedUrl] });
+    const card = renderDigestCard(digest);
+    document.body.appendChild(card);
+    const links = card.querySelectorAll("a.source-link");
+    expect(links.length).toBe(0);
+  });
+
+  it("does not throw when a source entry is null (non-object)", () => {
+    const itemNullSource: DigestItem = {
+      headline: "Article with null source",
+      blurb: "Blurb.",
+      detail: "Detail.",
+      metadata: {
+        sources: [null as unknown as { title: string; url: string }],
+      },
+    };
+    const digest = makeDigest({ summary: "S.", items: [itemNullSource] });
+    expect(() => renderDigestCard(digest)).not.toThrow();
+  });
+});
+
+// ---------------------------------------------------------------------------
 // TTS playback slot preserved in both modes (issue #11 contract)
 // ---------------------------------------------------------------------------
 

--- a/web/tests/unit/history.test.ts
+++ b/web/tests/unit/history.test.ts
@@ -10,7 +10,8 @@ import {
   withinLastDays,
   wordCount,
 } from "../../src/pages/history";
-import type { Digest, Topic } from "../../src/lib/types";
+import { renderDigestCard } from "../../src/views/digest-card";
+import type { Digest, DigestItem, Topic } from "../../src/lib/types";
 
 function digest(
   partial: Partial<Digest> & { topic_slug: string; digest_date: string },
@@ -220,5 +221,79 @@ describe("generateFixtureDigests", () => {
     expect(dates.size).toBe(30);
     // every row has searchable content and a sources array
     expect(a.every((d) => d.content.length > 0 && Array.isArray(d.sources_used))).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Issue #121 — renderList resilience: a broken card must not abort the list (AC4)
+//
+// renderList is private. The fix wraps each renderDigestCard call in try/catch
+// so one bad digest can't blank the whole list. We test the same behaviour here
+// by running the try/catch loop ourselves and asserting that the two valid cards
+// are still collected even when the third (malformed) card would have thrown
+// before the fix.
+// ---------------------------------------------------------------------------
+
+describe("renderList resilience — bad digest must not abort per-card loop (AC4)", () => {
+  function makeDigestWithItems(
+    id: string,
+    items: DigestItem[] | null,
+  ): Digest {
+    return {
+      id,
+      topic_slug: "ai_models",
+      content: "Fallback content.",
+      cadence: "24h",
+      digest_date: "2026-06-29",
+      sources_used: [],
+      token_count: 100,
+      prompt_version: "v",
+      created_at: "2026-06-29T12:00:00Z",
+      summary: "Summary text.",
+      items,
+    };
+  }
+
+  it("collects at least 2 cards when one of three digests has a malformed source", () => {
+    const goodItems: DigestItem[] = [
+      {
+        headline: "Good article",
+        blurb: "All good.",
+        detail: "No issues.",
+        metadata: { sources: [{ title: "Src", url: "https://example.com" }] },
+      },
+    ];
+
+    const badItems: DigestItem[] = [
+      {
+        headline: "Bad source article",
+        blurb: "Has broken source.",
+        detail: "Source entry missing url.",
+        metadata: {
+          sources: [{ title: "Broken" } as unknown as { title: string; url: string }],
+        },
+      },
+    ];
+
+    const digests: Digest[] = [
+      makeDigestWithItems("valid-1", goodItems),
+      makeDigestWithItems("bad-1", badItems),
+      makeDigestWithItems("valid-2", goodItems),
+    ];
+
+    // Mimics what the fixed renderList does internally: per-card try/catch so
+    // one broken card doesn't abort the loop.
+    const cards: HTMLElement[] = [];
+    for (const d of digests) {
+      try {
+        cards.push(renderDigestCard(d));
+      } catch {
+        // swallow — bad card must not stop the rest
+      }
+    }
+
+    // Both valid digests must have rendered; the bad one either renders (after
+    // the fix) or throws and is caught (before the fix). Either way >= 2.
+    expect(cards.length).toBeGreaterThanOrEqual(2);
   });
 });

--- a/web/tests/unit/history.test.ts
+++ b/web/tests/unit/history.test.ts
@@ -1,3 +1,4 @@
+// @vitest-environment jsdom
 import { describe, expect, it } from "vitest";
 import {
   digestMeta,

--- a/web/tests/unit/safe-href.test.ts
+++ b/web/tests/unit/safe-href.test.ts
@@ -1,0 +1,44 @@
+// @vitest-environment jsdom
+import { describe, expect, it } from "vitest";
+// safeHref will be exported after the fix; import fails until then (tests are intentionally red)
+import { safeHref } from "../../src/views/digest-card";
+
+// ---------------------------------------------------------------------------
+// AC1: null / undefined / empty inputs → null
+// ---------------------------------------------------------------------------
+
+describe("safeHref — null and nullish inputs (AC1)", () => {
+  it("returns null for undefined", () => {
+    expect(safeHref(undefined)).toBeNull();
+  });
+
+  it("returns null for null", () => {
+    expect(safeHref(null)).toBeNull();
+  });
+
+  it("returns null for an empty string", () => {
+    expect(safeHref("")).toBeNull();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// AC2: scheme allow-list — XSS-dangerous schemes → null; http/https → URL
+// ---------------------------------------------------------------------------
+
+describe("safeHref — scheme allow-list (AC2)", () => {
+  it("returns null for javascript: scheme (XSS guard)", () => {
+    expect(safeHref("javascript:alert(1)")).toBeNull();
+  });
+
+  it("returns null for data: scheme (XSS guard)", () => {
+    expect(safeHref("data:text/html,<h1>hi</h1>")).toBeNull();
+  });
+
+  it("returns the URL unchanged for https scheme", () => {
+    expect(safeHref("https://example.com")).toBe("https://example.com");
+  });
+
+  it("returns the URL unchanged for http scheme", () => {
+    expect(safeHref("http://example.com")).toBe("http://example.com");
+  });
+});


### PR DESCRIPTION
Closes #122

> Stacked on #121 (`fix/121-history-blank`) — this PR's base will be retargeted to `main` once #121 merges.

## Summary
Clicking a nav tab made that tab disappear, because each page hand-rolled its own `<nav>` that omitted a link to itself (and there was no active-state). This extracts a single shared `buildAppNav(client, activeHref)` (`web/src/views/app-nav.ts`) used by all 5 pages: it always renders the full, canonical 5-tab set and marks the current page with `aria-current="page"` + a `nav-active` style instead of removing it. The five duplicated, drifting nav builders are deleted (net −151 nav lines; JS bundle shrank slightly from the dedup).

## Evidence
**Real-world — local Vite preview, authenticated:** on `#/source-health` (the page whose tab was missing in the bug report) the nav now renders all 5 links with the active one present and highlighted:
```
Today | History | Logs | [Source Health ← aria-current=page] | Token Usage   (+ Sign out)
```
DOM check: `nav.app-nav` has 5 `<a>`; exactly one (`#/source-health`) has `aria-current="page"`. Before: the active page's link was absent from its own nav. Screenshot (Source Health tab bold+underlined) captured during validation.

**Unit (vitest):** `451 passed (20 files)` incl. 23 new `app-nav` contract tests — for each of the 5 routes: 5 links in canonical order, exactly one `aria-current` matching the href, the active link is **present** (the regression), others unmarked, sign-out present. `build` + `lint` clean.

**Scope:** diff touches only nav-construction regions + imports — verified no changes to `isSourceStale`/`mv_source_health` (#123) or `safeHref`/`renderList`/`renderDigestCard` (#121). Sign-out behavior is byte-identical to the originals.

## Tests
- Unit: 451/451 ✓ (23 new)
- Real-world (local preview): all 5 tabs present + active highlighted on Source Health ✓
